### PR TITLE
Make DocumentDB Credentials k8s secret name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you prefer to use port forwarding, you can connect as follows:
 kubectl port-forward pod/documentdb-preview-1 10260:10260 -n documentdb-preview-ns
 ```
 
-Connect using [mongosh](https://www.mongodb.com/docs/mongodb-shell/install/). Use the username and password from the `documentdb-credentials` secret you created earlier:
+Connect using [mongosh](https://www.mongodb.com/docs/mongodb-shell/install/). Use the username and password from the credentials secret (defaults to `documentdb-credentials`, or the value you set in `spec.documentDbCredentialSecret`):
 
 ```sh
 mongosh 127.0.0.1:10260 -u k8s_secret_user -p K8sSecret100 --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates

--- a/api/preview/documentdb_types.go
+++ b/api/preview/documentdb_types.go
@@ -29,6 +29,11 @@ type DocumentDBSpec struct {
 	// If not specified, defaults to a version that matches the DocumentDB operator version.
 	GatewayImage string `json:"gatewayImage,omitempty"`
 
+	// DocumentDbCredentialSecret is the name of the Kubernetes Secret containing credentials
+	// for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
+	// a default secret name `documentdb-credentials` is used.
+	DocumentDbCredentialSecret string `json:"documentDbCredentialSecret,omitempty"`
+
 	// ClusterReplication configures cross-cluster replication for DocumentDB.
 	ClusterReplication *ClusterReplication `json:"clusterReplication,omitempty"`
 

--- a/config/crd/bases/db.microsoft.com_documentdbs.yaml
+++ b/config/crd/bases/db.microsoft.com_documentdbs.yaml
@@ -72,6 +72,12 @@ spec:
               documentDBImage:
                 description: DocumentDBImage is the container image to use for DocumentDB.
                 type: string
+              documentDbCredentialSecret:
+                description: |-
+                  DocumentDbCredentialSecret is the name of the Kubernetes Secret containing credentials
+                  for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
+                  a default secret name `documentdb-credentials` is used.
+                type: string
               exposeViaService:
                 description: |-
                   ExposeViaService configures how to expose DocumentDB via a Kubernetes service.

--- a/docs/v1/index.md
+++ b/docs/v1/index.md
@@ -140,7 +140,7 @@ NAME                     TYPE     DATA   AGE
 documentdb-credentials   Opaque   2      10s
 ```
 
-> **Note:** The sidecar injector plugin requires the secret to be named `documentdb-credentials` and must contain `username` and `password` keys. The plugin will automatically inject these as `USERNAME` and `PASSWORD` environment variables into the DocumentDB gateway container.
+> **Note:** By default the operator expects a credentials secret named `documentdb-credentials` containing `username` and `password` keys. You can override the secret name by setting `spec.documentDbCredentialSecret` in your `DocumentDB` resource. Whatever name you configure (or the default) will be used by the sidecar injector to project the values as `USERNAME` and `PASSWORD` environment variables into the gateway sidecar container.
 
 
 ### Deploy a DocumentDB cluster

--- a/documentdb-chart/crds/db.microsoft.com_documentdbs.yaml
+++ b/documentdb-chart/crds/db.microsoft.com_documentdbs.yaml
@@ -72,6 +72,12 @@ spec:
               documentDBImage:
                 description: DocumentDBImage is the container image to use for DocumentDB.
                 type: string
+              documentDbCredentialSecret:
+                description: |-
+                  DocumentDbCredentialSecret is the name of the Kubernetes Secret containing credentials
+                  for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
+                  a default secret name `documentdb-credentials` is used.
+                type: string
               exposeViaService:
                 description: |-
                   ExposeViaService configures how to expose DocumentDB via a Kubernetes service.

--- a/internal/cnpg/cnpg_cluster.go
+++ b/internal/cnpg/cnpg_cluster.go
@@ -23,6 +23,11 @@ func GetCnpgClusterSpec(req ctrl.Request, documentdb dbpreview.DocumentDB, docum
 	gatewayImage := util.GetGatewayImageForDocumentDB(&documentdb)
 	log.Info("Creating CNPG cluster with gateway image", "gatewayImage", gatewayImage, "documentdbName", documentdb.Name, "specGatewayImage", documentdb.Spec.GatewayImage)
 
+	credentialSecretName := documentdb.Spec.DocumentDbCredentialSecret
+	if credentialSecretName == "" {
+		credentialSecretName = util.DEFAULT_DOCUMENTDB_CREDENTIALS_SECRET
+	}
+
 	return &cnpgv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.Name,
@@ -41,7 +46,8 @@ func GetCnpgClusterSpec(req ctrl.Request, documentdb dbpreview.DocumentDB, docum
 					{
 						Name: sidecarPluginName,
 						Parameters: map[string]string{
-							"gatewayImage": gatewayImage,
+							"gatewayImage":               gatewayImage,
+							"documentDbCredentialSecret": credentialSecretName,
 						},
 					},
 				},

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -12,8 +12,9 @@ const (
 	DOCUMENTDB_SIDECAR_IMAGE_ENV  = "DOCUMENTDB_SIDECAR_IMAGE"
 	ENABLE_SCALING_CONTROLLER_ENV = "ENABLE_SCALING_CONTROLLER"
 
-	DEFAULT_DOCUMENTDB_IMAGE = "ghcr.io/microsoft/documentdb/documentdb-local:16"
-	DEFAULT_GATEWAY_IMAGE    = "ghcr.io/microsoft/documentdb/documentdb-local:16"
+	DEFAULT_DOCUMENTDB_IMAGE              = "ghcr.io/microsoft/documentdb/documentdb-local:16"
+	DEFAULT_GATEWAY_IMAGE                 = "ghcr.io/microsoft/documentdb/documentdb-local:16"
+	DEFAULT_DOCUMENTDB_CREDENTIALS_SECRET = "documentdb-credentials"
 
 	LABEL_APP                      = "app"
 	LABEL_REPLICA_TYPE             = "replica_type"

--- a/internal/utils/util.go
+++ b/internal/utils/util.go
@@ -251,8 +251,11 @@ func DeleteRoleBinding(ctx context.Context, c client.Client, name, namespace str
 
 // GenerateConnectionString returns a MongoDB connection string for the DocumentDB instance
 func GenerateConnectionString(documentdb *dbpreview.DocumentDB, serviceIp string) string {
-	// TODO: Update the secret name once its configureable through DocumentDB Spec
-	return fmt.Sprintf("mongodb://$(kubectl get secret documentdb-credentials -n %s -o jsonpath='{.data.username}' | base64 -d):$(kubectl get secret documentdb-credentials -n %s -o jsonpath='{.data.password}' | base64 -d)@%s:%d/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&replicaSet=rs0", documentdb.Namespace, documentdb.Namespace, serviceIp, GetPortFor(GATEWAY_PORT))
+	secretName := documentdb.Spec.DocumentDbCredentialSecret
+	if secretName == "" {
+		secretName = DEFAULT_DOCUMENTDB_CREDENTIALS_SECRET
+	}
+	return fmt.Sprintf("mongodb://$(kubectl get secret %s -n %s -o jsonpath='{.data.username}' | base64 -d):$(kubectl get secret %s -n %s -o jsonpath='{.data.password}' | base64 -d)@%s:%d/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&replicaSet=rs0", secretName, documentdb.Namespace, secretName, documentdb.Namespace, serviceIp, GetPortFor(GATEWAY_PORT))
 }
 
 // GetGatewayImageForDocumentDB returns the gateway image for a DocumentDB instance.

--- a/plugins/sidecar-injector/internal/config/config.go
+++ b/plugins/sidecar-injector/internal/config/config.go
@@ -13,16 +13,18 @@ import (
 )
 
 const (
-	labelsParameter       = "labels"
-	annotationParameter   = "annotations"
-	gatewayImageParameter = "gatewayImage"
+	labelsParameter                     = "labels"
+	annotationParameter                 = "annotations"
+	gatewayImageParameter               = "gatewayImage"
+	documentDbCredentialSecretParameter = "documentDbCredentialSecret"
 )
 
 // Configuration represents the plugin configuration parameters
 type Configuration struct {
-	Labels       map[string]string
-	Annotations  map[string]string
-	GatewayImage string
+	Labels                     map[string]string
+	Annotations                map[string]string
+	GatewayImage               string
+	DocumentDbCredentialSecret string
 }
 
 // FromParameters builds a plugin configuration from the configuration parameters
@@ -51,13 +53,15 @@ func FromParameters(
 		}
 	}
 
-	// Parse gateway image parameter
+	// Parse simple string parameters
 	gatewayImage := helper.Parameters[gatewayImageParameter]
+	credentialSecret := helper.Parameters[documentDbCredentialSecretParameter]
 
 	configuration := &Configuration{
-		Labels:       labels,
-		Annotations:  annotations,
-		GatewayImage: gatewayImage,
+		Labels:                     labels,
+		Annotations:                annotations,
+		GatewayImage:               gatewayImage,
+		DocumentDbCredentialSecret: credentialSecret,
 	}
 
 	configuration.applyDefaults()
@@ -95,9 +99,12 @@ func (config *Configuration) applyDefaults() {
 			"plugin-metadata": "default",
 		}
 	}
-	// Set default gateway image if not specified
+	// Set defaults
 	if config.GatewayImage == "" {
 		config.GatewayImage = "ghcr.io/microsoft/documentdb/documentdb-local:16"
+	}
+	if config.DocumentDbCredentialSecret == "" {
+		config.DocumentDbCredentialSecret = "documentdb-credentials"
 	}
 }
 
@@ -115,6 +122,7 @@ func (config *Configuration) ToParameters() (map[string]string, error) {
 	result[labelsParameter] = string(serializedLabels)
 	result[annotationParameter] = string(serializedAnnotations)
 	result[gatewayImageParameter] = config.GatewayImage
+	result[documentDbCredentialSecretParameter] = config.DocumentDbCredentialSecret
 
 	return result, nil
 }

--- a/plugins/sidecar-injector/internal/lifecycle/lifecycle.go
+++ b/plugins/sidecar-injector/internal/lifecycle/lifecycle.go
@@ -137,16 +137,16 @@ func (impl Implementation) reconcileMetadata(
 		},
 	}
 
-	// Add USERNAME and PASSWORD environment variables from secret
-	// TODO: Make this configurable and expose it in the configuration
-	log.Printf("Adding USERNAME and PASSWORD environment variables from secret")
+	// Add USERNAME and PASSWORD environment variables from secret defined in configuration
+	credentialSecretName := configuration.DocumentDbCredentialSecret
+	log.Printf("Adding USERNAME and PASSWORD environment variables from secret '%s'", credentialSecretName)
 	envVars = append(envVars,
 		corev1.EnvVar{
 			Name: "USERNAME",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "documentdb-credentials",
+						Name: credentialSecretName,
 					},
 					Key: "username",
 				},
@@ -157,7 +157,7 @@ func (impl Implementation) reconcileMetadata(
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "documentdb-credentials",
+						Name: credentialSecretName,
 					},
 					Key: "password",
 				},

--- a/scripts/deployment-examples/single-node-documentdb.yaml
+++ b/scripts/deployment-examples/single-node-documentdb.yaml
@@ -14,6 +14,7 @@ spec:
   instancesPerNode: 1
   documentDBImage: ghcr.io/microsoft/documentdb/documentdb-local:16
   gatewayImage: ghcr.io/microsoft/documentdb/documentdb-local:16
+  documentDbCredentialSecret: documentdb-credentials
   resource:
     pvcSize: 10Gi
   exposeViaService:


### PR DESCRIPTION
**Test Output:**

```
rhossain@rayhanmsft:~/wsl_workspace/bromine/documentdb-kubernetes-operator$ kubectl get documentdb documentdb-preview -n documentdb-preview-ns
NAME                 STATUS                     CONNECTION STRING
documentdb-preview   Cluster in healthy state   mongodb://$(kubectl get secret documentdb-credentials-ray -n documentdb-preview-ns -o jsonpath='{.data.username}' | base64 -d):$(kubectl get secret documentdb-credentials-ray -n documentdb-preview-ns -o jsonpath='{.data.password}' | base64 -d)@4.155.140.153:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&replicaSet=rs0
rhossain@rayhanmsft:~/wsl_workspace/bromine/documentdb-kubernetes-operator$ mongosh "mongodb://$(kubectl get secret documentdb-credentials-ray -n documentdb-preview-ns -o jsonpath='{.data.username}' | base64 -d):$(kubectl get secret documentdb-credentials-ray -n documentdb-preview-ns -o jsonpath='{.data.password}' | base64 -d)@4.155.140.153:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&replicaSet=rs0"
Current Mongosh Log ID: 68b9cf7410c4e94ad3d861df
Connecting to:          mongodb://<credentials>@MY_SERVICE_IP:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&replicaSet=rs0&appName=mongosh+2.5.0
Using MongoDB:          7.0.0
Using Mongosh:          2.5.0
mongosh 2.5.7 is available for download: https://www.mongodb.com/try/download/shell

For mongosh info see: https://www.mongodb.com/docs/mongodb-shell/

rs0 [direct: mongos] test>
```