### PR TITLE
Bump DocumentDB Operator and Helm version to 0.1.1

### DIFF
--- a/docs/v1/index.md
+++ b/docs/v1/index.md
@@ -162,7 +162,7 @@ metadata:
 spec:
   nodeCount: 1
   instancesPerNode: 1
-  documentDBImage: ghcr.io/microsoft/documentdb/documentdb-local:16
+  documentDbCredentialSecret: documentdb-credentials
   resource:
     storage:
       pvcSize: 10Gi

--- a/documentdb-chart/Chart.yaml
+++ b/documentdb-chart/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: documentdb-operator
-version: 0.1.0
+version: 0.1.1
 description: A Helm chart for deploying the DocumentDB operator
 # appVersion represents the default DocumentDB version for this chart release
-appVersion: "0.1.0"
+appVersion: "0.1.1"
 dependencies:
   - name: cloudnative-pg
     version: "0.23.2"

--- a/internal/utils/util.go
+++ b/internal/utils/util.go
@@ -318,15 +318,16 @@ func GetGatewayImageForDocumentDB(documentdb *dbpreview.DocumentDB) string {
 		return documentdb.Spec.GatewayImage
 	}
 
-	// Use spec-level documentDBVersion if set
-	if documentdb.Spec.DocumentDBVersion != "" {
-		return fmt.Sprintf("%s:%s", DOCUMENTDB_IMAGE_REPOSITORY, documentdb.Spec.DocumentDBVersion)
-	}
+	// TODO: Uncomment when we publish custom gateway images
+	// // Use spec-level documentDBVersion if set
+	// if documentdb.Spec.DocumentDBVersion != "" {
+	// 	return fmt.Sprintf("%s:%s", DOCUMENTDB_IMAGE_REPOSITORY, documentdb.Spec.DocumentDBVersion)
+	// }
 
-	// Use global documentDbVersion if set
-	if version := os.Getenv(DOCUMENTDB_VERSION_ENV); version != "" {
-		return fmt.Sprintf("%s:%s", DOCUMENTDB_IMAGE_REPOSITORY, version)
-	}
+	// // Use global documentDbVersion if set
+	// if version := os.Getenv(DOCUMENTDB_VERSION_ENV); version != "" {
+	// 	return fmt.Sprintf("%s:%s", DOCUMENTDB_IMAGE_REPOSITORY, version)
+	// }
 
 	// Fall back to default
 	return DEFAULT_GATEWAY_IMAGE
@@ -339,15 +340,16 @@ func GetDocumentDBImageForInstance(documentdb *dbpreview.DocumentDB) string {
 		return documentdb.Spec.DocumentDBImage
 	}
 
-	// Use spec-level documentDBVersion if set
-	if documentdb.Spec.DocumentDBVersion != "" {
-		return fmt.Sprintf("%s:%s", DOCUMENTDB_IMAGE_REPOSITORY, documentdb.Spec.DocumentDBVersion)
-	}
+	// TODO: Uncomment when we publish custom documentdb images
+	// // Use spec-level documentDBVersion if set
+	// if documentdb.Spec.DocumentDBVersion != "" {
+	// 	return fmt.Sprintf("%s:%s", DOCUMENTDB_IMAGE_REPOSITORY, documentdb.Spec.DocumentDBVersion)
+	// }
 
-	// Use global documentDbVersion if set
-	if version := os.Getenv(DOCUMENTDB_VERSION_ENV); version != "" {
-		return fmt.Sprintf("%s:%s", DOCUMENTDB_IMAGE_REPOSITORY, version)
-	}
+	// // Use global documentDbVersion if set
+	// if version := os.Getenv(DOCUMENTDB_VERSION_ENV); version != "" {
+	// 	return fmt.Sprintf("%s:%s", DOCUMENTDB_IMAGE_REPOSITORY, version)
+	// }
 
 	// Fall back to default
 	return DEFAULT_DOCUMENTDB_IMAGE


### PR DESCRIPTION
This PR bump our Document DB Operator + Helm Chart and Sidecar injector image versions from 0.1.0 to 0.1.1.

Currently we are not publishing custom tagged images for Document DB gateway and Postgres. That's why commenting out document DB version-based image tag for future usage.



