### PR TITLE
docs: fix broken MkDocs links to files outside docs directory

### DIFF
--- a/docs/operator-public-documentation/preview/advanced-configuration/README.md
+++ b/docs/operator-public-documentation/preview/advanced-configuration/README.md
@@ -36,8 +36,8 @@ The operator supports three TLS modes for secure gateway connections, each suite
 
 For comprehensive TLS setup and testing documentation, see:
 
-- **[Complete TLS Setup Guide](../../../../documentdb-playground/tls/README.md)** — Quick start with automated scripts, detailed configuration for each TLS mode, troubleshooting, and best practices
-- **[E2E Testing Guide](../../../../documentdb-playground/tls/E2E-TESTING.md)** — Automated and manual testing, validation procedures, and CI/CD integration examples
+- **[Complete TLS Setup Guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/documentdb-playground/tls/README.md)** — Quick start with automated scripts, detailed configuration for each TLS mode, troubleshooting, and best practices
+- **[E2E Testing Guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/documentdb-playground/tls/E2E-TESTING.md)** — Automated and manual testing, validation procedures, and CI/CD integration examples
 
 ### Quick TLS Setup
 
@@ -169,7 +169,7 @@ kubectl get secret -n <namespace> <tls-secret-name> -o jsonpath='{.data.tls\.crt
 
 ### Troubleshooting TLS
 
-For comprehensive troubleshooting, see the [E2E Testing Guide](../../../../documentdb-playground/tls/E2E-TESTING.md#troubleshooting).
+For comprehensive troubleshooting, see the [E2E Testing Guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/documentdb-playground/tls/E2E-TESTING.md#troubleshooting).
 
 Common issues:
 
@@ -457,6 +457,6 @@ For production, consider using:
 ## Additional Resources
 
 - [Public Documentation](https://documentdb.io/documentdb-kubernetes-operator/preview/)
-- [TLS Setup Guide](../../../../documentdb-playground/tls/README.md)
-- [E2E Testing Guide](../../../../documentdb-playground/tls/E2E-TESTING.md)
+- [TLS Setup Guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/documentdb-playground/tls/README.md)
+- [E2E Testing Guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/documentdb-playground/tls/E2E-TESTING.md)
 - [GitHub Repository](https://github.com/documentdb/documentdb-kubernetes-operator)

--- a/docs/operator-public-documentation/preview/faq.md
+++ b/docs/operator-public-documentation/preview/faq.md
@@ -45,4 +45,4 @@ Set `spec.instancesPerNode` to 3 to deploy one primary and two replicas. The ope
 
 ### Can I deploy across multiple clouds?
 
-Yes. The operator supports multi-cloud deployment with cross-cluster replication. See the [Multi-Cloud Deployment Guide](../../../documentdb-playground/multi-cloud-deployment/README.md) for setup instructions.
+Yes. The operator supports multi-cloud deployment with cross-cluster replication. See the [Multi-Cloud Deployment Guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/documentdb-playground/multi-cloud-deployment/README.md) for setup instructions.

--- a/docs/operator-public-documentation/preview/index.md
+++ b/docs/operator-public-documentation/preview/index.md
@@ -370,7 +370,7 @@ switched to db sample_mflix
 
 The operator uses a sidecar injector plugin to automatically inject the DocumentDB Gateway container into PostgreSQL pods. You can customize the gateway image, pod labels, and annotations.
 
-For details, see [Sidecar Injector Plugin Configuration](../../developer-guides/sidecar-injector-plugin-configuration.md).
+For details, see [Sidecar Injector Plugin Configuration](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/docs/developer-guides/sidecar-injector-plugin-configuration.md).
 
 ### Local high-availability (HA)
 
@@ -404,14 +404,14 @@ This configuration creates:
 
 ### Multi-cloud deployment
 
-The operator supports deployment across multiple cloud environments and Kubernetes distributions. For guidance, see the [Multi-Cloud Deployment Guide](../../../documentdb-playground/multi-cloud-deployment/README.md).
+The operator supports deployment across multiple cloud environments and Kubernetes distributions. For guidance, see the [Multi-Cloud Deployment Guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/documentdb-playground/multi-cloud-deployment/README.md).
 
 ### TLS setup
 
 For advanced TLS configuration and testing:
 
-- [TLS Setup Guide](../../../documentdb-playground/tls/README.md) — Complete TLS configuration guide
-- [E2E Testing](../../../documentdb-playground/tls/E2E-TESTING.md) — Comprehensive testing procedures
+- [TLS Setup Guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/documentdb-playground/tls/README.md) — Complete TLS configuration guide
+- [E2E Testing](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/documentdb-playground/tls/E2E-TESTING.md) — Comprehensive testing procedures
 
 
 ## Clean up


### PR DESCRIPTION
## Summary

Documentation files under `docs/operator-public-documentation/preview/` contain relative links to files that live outside the MkDocs `docs_dir` (e.g., `documentdb-playground/tls/README.md`, `docs/developer-guides/sidecar-injector-plugin-configuration.md`). These relative paths resolve correctly when browsing on GitHub, but cause warnings and broken links when MkDocs builds the site with `--strict`. This PR converts all such links to absolute GitHub URLs so they work in both contexts.

## Changes

- **`docs/operator-public-documentation/preview/index.md`**  Fix 4 broken links (sidecar injector config, multi-cloud deployment, TLS setup guide, E2E testing)
- **`docs/operator-public-documentation/preview/faq.md`**  Fix 1 broken link (multi-cloud deployment)
- **`docs/operator-public-documentation/preview/advanced-configuration/README.md`**  Fix 5 broken links (TLS setup guide 2, E2E testing 2, E2E testing troubleshooting anchor)

All relative paths pointing outside `docs_dir` are replaced with absolute URLs of the form:
`https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/...`

## Testing

- [x] `mkdocs build --strict` passes with zero warnings
- [x] All replaced links manually verified to resolve correctly on GitHub

## Checklist

- [x] Code follows project conventions
- [x] No unintended debug code or TODOs left in
