### PR TITLE
docs: add operator public documentation rules to documentation-agent

### DIFF
--- a/.github/agents/documentation-agent.md
+++ b/.github/agents/documentation-agent.md
@@ -44,4 +44,56 @@ You are a documentation specialist for the DocumentDB Kubernetes Operator projec
 
 ## MkDocs Site
 
-The project uses MkDocs for documentation publishing. Configuration is in `mkdocs.yml` at the repository root. Ensure any new pages are properly added to the navigation structure.
+The project uses MkDocs with the Material theme for documentation publishing. Configuration is in `mkdocs.yml` at the repository root. Ensure any new pages are properly added to the navigation structure.
+
+### Operator Public Documentation Rules (`docs/operator-public-documentation/`)
+
+These rules apply to all files under the MkDocs `docs_dir` (`docs/operator-public-documentation/`), which is served on GitHub Pages.
+
+#### Link Rules
+
+- **Never use relative links that escape `docs_dir`.** MkDocs only serves files inside `docs_dir`. Relative paths like `../../../../documentdb-playground/...` produce broken 404s on GitHub Pages.
+- For files outside `docs_dir` (e.g., `documentdb-playground/`, `operator/`), use absolute GitHub repository URLs instead:
+  `https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/documentdb-playground/tls/README.md`
+- Internal cross-references between pages within `docs_dir` should use relative `.md` links (e.g., `[Storage](storage.md)`, `[TLS](../configuration/tls.md)`).
+- Always validate links after creating or editing documentation. Check both internal `.md` references and external URLs.
+
+#### Front Matter (YAML Metadata)
+
+Every page should include front matter for search optimization and AI-friendliness:
+
+```yaml
+---
+title: Page Title
+description: A concise description of the page content for search engines and AI.
+tags:
+  - relevant-tag
+  - another-tag
+search:
+  boost: 2  # Optional: boost important pages in search results
+---
+```
+
+#### Material for MkDocs Features
+
+Use these Material features to improve documentation quality:
+
+- **Content tabs** (`=== "Tab Name"`): Use for cloud-provider-specific examples (AKS/EKS/GKE) and alternative configurations (e.g., TLS modes, workload profiles). Avoids long scrolling through repetitive sections.
+- **Code annotations** (`# (1)!`): Add inline explanations to YAML/code examples. Use numbered annotations to explain non-obvious fields.
+- **Code block titles** (`` ```yaml title="filename.yaml" ``): Show the intended filename above code blocks so users know what to name the file.
+- **Card grids** (`<div class="grid cards" markdown>`): Use on index/landing pages to present navigation as visual cards with icons.
+- **Admonitions** (`!!! note`, `!!! warning`, `!!! tip`, `!!! danger`, `!!! important`): Already configured. Use for callouts, warnings, and tips.
+
+#### Content Structure
+
+- Use proper heading hierarchy (H1 for page title, H2 for sections, H3 for subsections).
+- Include field reference tables for CRD/API documentation with columns: Field, Type, Required, Default, Description.
+- Provide complete, copy-pasteable YAML examples — not fragments.
+- When showing cloud-specific configuration, always cover AKS, EKS, and GKE using content tabs.
+
+#### AI-Friendliness
+
+- Use structured front matter (`title`, `description`, `tags`) to provide semantic context for LLMs and RAG pipelines.
+- Write in clean semantic Markdown — avoid raw HTML where possible.
+- Use descriptive link text (not "click here" or "see this").
+- Keep content self-contained per page — minimize requiring users to read multiple pages to understand a topic.


### PR DESCRIPTION
## Summary

Adds comprehensive documentation rules for the `docs/operator-public-documentation/` directory to the documentation-agent configuration. These rules codify conventions for link handling, front matter, Material for MkDocs features, content structure, and AI-friendliness so the documentation agent produces correct, high-quality pages served on GitHub Pages.

## Changes

- **Link rules**: Never escape MkDocs `docs_dir` with relative paths (causes 404s on GitHub Pages); use absolute GitHub URLs for files outside `docs_dir`; use relative `.md` links for internal cross-references.
- **Front matter requirements**: Every page should include `title`, `description`, `tags`, and optional `search.boost` for SEO and AI/RAG discoverability.
- **Material for MkDocs features**: Content tabs for cloud-specific examples (AKS/EKS/GKE), code annotations, code block titles, card grids for index pages, and admonitions.
- **Content structure**: Heading hierarchy, field reference tables for CRD/API docs, complete copy-pasteable YAML examples, and cloud-provider coverage via content tabs.
- **AI-friendliness**: Structured metadata, semantic Markdown, descriptive link text, and self-contained pages.

## Testing

- [x] Reviewed rendered Markdown for correctness
- [x] Verified rules align with existing `mkdocs.yml` configuration and Material theme features

## Checklist

- [x] Code follows project conventions
- [x] No unintended debug code or TODOs left in
