### PR TITLE
docs: Add high availability documentation for local HA configuration

### DIFF
--- a/docs/operator-public-documentation/preview/high-availability/local-ha.md
+++ b/docs/operator-public-documentation/preview/high-availability/local-ha.md
@@ -9,11 +9,18 @@ tags:
 
 # Local High Availability
 
-Local high availability (HA) deploys multiple DocumentDB instances within a single Kubernetes cluster, providing automatic failover and zero data loss during instance failures.
+Local high availability (HA) deploys multiple DocumentDB instances within a single Kubernetes cluster, providing automatic failover and minimal data loss during instance failures.
+
+!!! info "Built on CloudNative-PG"
+    DocumentDB uses [CloudNative-PG's](https://cloudnative-pg.io/) default high availability configuration for local HA. For detailed information about the underlying HA mechanisms, see:
+    
+    - [CloudNative-PG Architecture](https://cloudnative-pg.io/documentation/current/architecture/)
+    - [CloudNative-PG Replication](https://cloudnative-pg.io/documentation/current/replication/)
+    - [CloudNative-PG Failover](https://cloudnative-pg.io/documentation/current/failover/)
 
 ## Overview
 
-Local HA uses synchronous replication between a primary instance and one or two replicas. When the primary fails, a replica is automatically promoted to primary.
+Local HA uses streaming replication between a primary instance and one or two replicas. When the primary fails, a replica is automatically promoted to primary.
 
 ```mermaid
 flowchart LR
@@ -28,8 +35,8 @@ flowchart LR
     end
     
     App([Application]) --> P
-    P -->|Sync Replication| R1
-    P -->|Sync Replication| R2
+    P -->|Streaming Replication| R1
+    P -->|Streaming Replication| R2
 ```
 
 ## Instance Configuration
@@ -43,10 +50,12 @@ metadata:
   name: my-documentdb
   namespace: documentdb
 spec:
+  nodeCount: 1
   instancesPerNode: 3  # (1)!
-  storage:
-    size: 10Gi
-    storageClassName: managed-csi
+  resource:
+    storage:
+      pvcSize: 10Gi
+      storageClass: managed-csi
 ```
 
 1. Valid values: `1` (no HA), `2` (primary + 1 replica), `3` (primary + 2 replicas, recommended for production)
@@ -60,7 +69,7 @@ spec:
 | `3` | Primary + 2 replicas | **Recommended** for production |
 
 !!! tip "Why 3 instances?"
-    Three instances provide quorum-based failover. With 2 instances, the system cannot distinguish between a network partition and a failed primary. With 3 instances, the system can achieve consensus and safely promote a replica.
+    Three instances provide better fault tolerance: if the primary fails, you still have two replicas, ensuring one can be promoted while retaining a standby. With only 2 instances, after a failover you have no replicas until the former primary recovers. Three instances also allow rolling updates and maintenance without reducing redundancy.
 
 ## Pod Anti-Affinity
 
@@ -77,7 +86,12 @@ metadata:
   name: my-documentdb
   namespace: documentdb
 spec:
+  nodeCount: 1
   instancesPerNode: 3
+  resource:
+    storage:
+      pvcSize: 10Gi
+      storageClass: managed-csi
   affinity:
     enablePodAntiAffinity: true
     topologyKey: topology.kubernetes.io/zone  # (1)!
@@ -96,7 +110,12 @@ metadata:
   name: my-documentdb
   namespace: documentdb
 spec:
+  nodeCount: 1
   instancesPerNode: 3
+  resource:
+    storage:
+      pvcSize: 10Gi
+      storageClass: managed-csi
   affinity:
     enablePodAntiAffinity: true
     topologyKey: kubernetes.io/hostname  # (1)!
@@ -134,7 +153,7 @@ sequenceDiagram
     Op->>Op: Wait failoverDelay (default: 0s)
     Op->>P: Mark TargetPrimary pending
     P->>P: Fast shutdown (up to 30s)
-    Op->>R: Leader election
+    Op->>R: Select most up-to-date replica
     R->>R: Promote to primary
     Op->>App: Update service endpoint
     App->>R: Reconnect to new primary
@@ -168,24 +187,65 @@ The failover process occurs in two phases:
 
 **Phase 2: Promotion**
 
-1. Leader election selects the most up-to-date replica
+1. Operator selects the most up-to-date replica based on WAL position
 2. Selected replica promotes to primary and begins accepting writes
 3. Kubernetes service endpoints update to point to new primary
 4. Former primary restarts as a replica when recovered
 
-!!! note "Zero Data Loss"
-    Because replication is synchronous, a committed write exists on at least one replica before acknowledgment. Failover promotes a replica with all committed data.
+!!! note "Replication and Data Durability"
+    DocumentDB relies on [CloudNative-PG's streaming replication](https://cloudnative-pg.io/documentation/current/replication/), which uses asynchronous replication by default. Replicas typically lag only milliseconds behind the primary under normal conditions. During failover, the most up-to-date replica is promoted, minimizing potential data loss to recent uncommitted transactions.
 
 ### RTO and RPO Impact
 
 | Scenario | RTO Impact | RPO Impact |
 |----------|------------|------------|
-| Fast shutdown succeeds | Seconds to tens of seconds | Zero data loss |
-| Fast shutdown times out | Up to `stopDelay` (30s default) | Possible data loss |
-| Network partition | Depends on quorum | Zero if quorum maintained |
+| Fast shutdown succeeds | Seconds to tens of seconds | Minimal (replication lag) |
+| Fast shutdown times out | Up to `stopDelay` (30s default) | Potential data loss |
+| Network partition | Varies by scenario | Depends on replica sync state |
 
 !!! tip "Tuning for RTO vs RPO"
     Lower `stopDelay` values favor faster recovery (RTO) but may increase data loss risk (RPO). Higher values prioritize data safety but may delay recovery.
+
+## Monitoring and Failover Detection
+
+Understanding when a failover has occurred is essential for operations.
+
+### Checking Current Primary
+
+Identify which instance is currently the primary:
+
+```bash
+# Check CNPG cluster status for current primary
+kubectl get cluster my-documentdb -n documentdb -o jsonpath='{.status.currentPrimary}'
+
+# List all pods with their instance roles
+kubectl get pods -n documentdb -l cnpg.io/cluster=my-documentdb \
+  -o custom-columns=NAME:.metadata.name,ROLE:.metadata.labels.cnpg\\.io/instanceRole
+```
+
+### Monitoring Cluster Events
+
+Watch for cluster state changes:
+
+```bash
+# Watch all events for the cluster
+kubectl get events -n documentdb --sort-by='.lastTimestamp' --watch
+
+# Check CNPG cluster conditions
+kubectl get cluster my-documentdb -n documentdb -o jsonpath='{.status.conditions}' | jq
+```
+
+### Monitoring Replication Lag
+
+Track replication health using PostgreSQL system views:
+
+```bash
+# View streaming replication status (run on primary)
+kubectl exec -n documentdb my-documentdb-1 -- psql -U postgres -c "SELECT client_addr, state, sent_lsn, write_lsn, flush_lsn, replay_lsn FROM pg_stat_replication;"
+```
+
+!!! tip "Alerting and Observability"
+    For production monitoring, see the [CloudNative-PG Monitoring documentation](https://cloudnative-pg.io/documentation/current/monitoring/) which covers Prometheus metrics, Grafana dashboards, and alerting rules for failover detection.
 
 ## Testing High Availability
 
@@ -195,7 +255,7 @@ Verify your HA configuration works correctly.
 
 ```bash
 # Check pod distribution across zones/nodes
-kubectl get pods -n documentdb -l documentdb.io/cluster=my-documentdb \
+kubectl get pods -n documentdb -l cnpg.io/cluster=my-documentdb \
   -o custom-columns=NAME:.metadata.name,NODE:.spec.nodeName,ZONE:.metadata.labels.topology\\.kubernetes\\.io/zone
 ```
 
@@ -220,7 +280,7 @@ kubectl delete pod my-documentdb-1 -n documentdb
 kubectl get pods -n documentdb -w
 
 # Check pod status after failover
-kubectl get pods -n documentdb -l documentdb.io/cluster=my-documentdb
+kubectl get pods -n documentdb -l cnpg.io/cluster=my-documentdb
 ```
 
 ### Test 3: Application Connectivity
@@ -263,7 +323,7 @@ kubectl get nodes -L topology.kubernetes.io/zone
 **Solution**:
 ```bash
 # Check operator logs
-kubectl logs -n documentdb-operator -l app.kubernetes.io/name=documentdb-operator --tail=100
+kubectl logs deployment/documentdb-operator -n documentdb-operator --tail=100
 
 # Check events
 kubectl get events -n documentdb --sort-by='.lastTimestamp' | tail -20
@@ -286,4 +346,3 @@ kubectl top pod my-documentdb-2 -n documentdb
 # Check pod logs for replication issues
 kubectl logs my-documentdb-2 -n documentdb --tail=50
 ```
-

--- a/docs/operator-public-documentation/preview/high-availability/overview.md
+++ b/docs/operator-public-documentation/preview/high-availability/overview.md
@@ -18,7 +18,7 @@ High availability (HA) ensures your DocumentDB deployment remains accessible and
 High availability in DocumentDB means:
 
 - **Automatic failover**: When a primary instance fails, a replica is automatically promoted
-- **Data durability**: Data is replicated across multiple instances before acknowledging writes  
+- **Data durability**: Data is replicated across multiple instances
 - **Minimal downtime**: Recovery happens automatically without manual intervention
 - **Continuous operation**: Applications experience brief interruption rather than extended outages
 
@@ -72,7 +72,7 @@ Local HA runs multiple DocumentDB instances within a single Kubernetes cluster, 
 | **Scope** | Single Kubernetes cluster |
 | **Instances** | 1-3 instances (primary + replicas) |
 | **Failover** | Automatic, typically < 30 seconds |
-| **Data Loss** | Zero (synchronous replication) |
+| **Data Loss** | Minimal (async streaming replication) |
 | **Use Case** | Standard production deployments |
 
 **Best for:** Most production workloads requiring high availability without geographic distribution.
@@ -127,7 +127,7 @@ When planning for high availability, understand these key metrics:
 
 | HA Type | Typical RPO |
 |---------|-------------|
-| Local HA | 0 (synchronous) |
+| Local HA | Near-zero (milliseconds of replication lag) |
 | Multi-Region | Seconds (replication lag) |
 | Multi-Cloud | Seconds (replication lag) |
 
@@ -149,8 +149,8 @@ flowchart TD
     
     E --> I[Configure instancesPerNode: 3]
     F --> J[Configure instancesPerNode: 1]
-    G --> K[See Multi-Cloud Guide]
-    H --> L[See Multi-Region Guide]
+    G --> K[Multi-Cloud Guide<br/>Coming soon]
+    H --> L[Multi-Region Guide<br/>Coming soon]
 ```
 
 ## Trade-offs Summary
@@ -160,7 +160,7 @@ flowchart TD
 | **Complexity** | Low | Medium | High |
 | **Cost** | $ | $$ | $$$ |
 | **RTO** | Seconds | Minutes | Minutes |
-| **RPO** | Zero | Replication lag | Replication lag |
+| **RPO** | Near-zero | Replication lag | Replication lag |
 | **Blast radius** | Zone outage | Region outage | Cloud outage |
 | **Network latency** | Minimal | Regional | Variable |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,8 +26,8 @@ extra:
     provider: mike
     default: latest
 
-extra_javascript:
-  - https://unpkg.com/mermaid@10/dist/mermaid.min.js
+# Mermaid is configured via pymdownx.superfences custom_fences below.
+# The Material theme handles mermaid rendering without external CDN dependencies.
 
 nav:
   - Preview:


### PR DESCRIPTION
## Summary

Adds comprehensive high availability documentation covering local HA concepts, configuration, and automatic failover behavior.

## Changes

### New Files
- `docs/operator-public-documentation/preview/high-availability/overview.md` - HA concepts overview
- `docs/operator-public-documentation/preview/high-availability/local-ha.md` - Local HA configuration guide

### Updated Files
- `mkdocs.yml` - Added High Availability navigation section and enabled Mermaid diagram support

## Documentation Highlights

**HA Overview:**
- Explains three HA types: Local HA, Multi-Region, Multi-Cloud
- RTO/RPO concepts and trade-offs
- Decision tree for selecting appropriate HA strategy
- Architecture diagrams using Mermaid

**Local HA Guide:**
- Instance configuration (`instancesPerNode: 1-3`)
- Pod anti-affinity setup (zone-level and node-level distribution)
- Automatic failover process with CNPG timing parameters
- Documents configurable vs default parameters (`stopDelay` is currently the only configurable timeout)
- Testing procedures and troubleshooting

## Notes

- Failover timing parameters are inherited from CloudNative-PG
- Manual failover for local HA is not currently supported via kubectl plugin (plugin is for multi-cluster promotion only)
- Connection string can be retrieved from `kubectl get documentdb <name> -o jsonpath='{.status.connectionString}'`