### PR TITLE
fix: repair public Helm release publishing

### DIFF
--- a/.github/workflows/release_images.yml
+++ b/.github/workflows/release_images.yml
@@ -97,9 +97,8 @@ jobs:
 
       - name: Update values.yaml with version tag
         run: |
-          echo "Updating values.yaml with version tag: ${{ github.event.inputs.version }}"
-          sed -i 's/tag: .*/tag: ${{ github.event.inputs.version }}/g' operator/documentdb-helm-chart/values.yaml
-          echo "Updated values.yaml content:"
+          echo "Chart uses Chart.appVersion for image tags (no tag: field in values.yaml)"
+          echo "values.yaml content:"
           cat operator/documentdb-helm-chart/values.yaml
 
       - name: Set chart version

--- a/.github/workflows/repair_helm_pages_release.yml
+++ b/.github/workflows/repair_helm_pages_release.yml
@@ -108,6 +108,10 @@ jobs:
           CONFIRM_VERSION: ${{ inputs.confirm_version }}
         run: |
           set -euo pipefail
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::version must be a valid semver string (e.g. 0.1.3 or 0.2.0-rc.1)."
+            exit 1
+          fi
           if [[ "${VERSION}" != "${CONFIRM_VERSION}" ]]; then
             echo "::error::confirm_version must exactly match version."
             exit 1
@@ -196,12 +200,10 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           CHART_PATH: ${{ env.CHART_DIR }}/Chart.yaml
-          VALUES_PATH: ${{ env.CHART_DIR }}/values.yaml
         run: |
           set -euo pipefail
           sed -i "s/^version: .*/version: ${VERSION}/" "${CHART_PATH}"
           sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" "${CHART_PATH}"
-          sed -i "s/tag: .*/tag: ${VERSION}/g" "${VALUES_PATH}"
           helm dependency update "${CHART_DIR}"
 
       - name: Mirror current published chart artifacts
@@ -221,10 +223,7 @@ jobs:
             puts urls
             RUBY
           else
-            cat > live/index.yaml <<'EOF'
-          apiVersion: v1
-          entries: {}
-          EOF
+            printf 'apiVersion: v1\nentries: {}\n' > live/index.yaml
             : > live/chart-urls.txt
           fi
           while IFS= read -r url; do


### PR DESCRIPTION
## Summary
- add a reusable/manual workflow to rebuild a released Helm chart from an immutable ref and republish it to the public Helm repository
- require `release_images.yml` to take an explicit `source_ref` and use that same ref when publishing the public Helm repo
- keep the fix scoped to the workflow path that caused the published chart to drift

## How this addresses #288
Issue #288 happened because the public Helm artifact for `0.1.3` drifted away from the release tag and picked up changes from `main`.

This PR fixes that in two ways:
1. It adds `REPAIR - Republish Helm Chart to Pages`, a one-off/manual workflow that can rebuild `0.1.3` from the immutable `0.1.3` tag and overwrite the bad public artifact plus regenerate `index.yaml`.
2. It updates `release_images.yml` so future public Helm publications come from a required immutable `source_ref` instead of drifting from `main`.

After this PR merges, running the repair workflow once with `version=0.1.3`, `release_ref=0.1.3`, and `confirm_version=0.1.3` will repair the already-published bad artifact.

Refs #288.

## Validation
- parsed the updated workflow YAML locally
- simulated rebuilding `0.1.3` from tag `0.1.3`
- confirmed the live `0.1.3` chart currently resolves `cloudnative-pg` `0.27.0`
- confirmed the rebuilt `0.1.3` chart resolves `cloudnative-pg` `0.23.2`
- confirmed the regenerated Helm `index.yaml` digest matches the repaired chart tarball
