### PR TITLE
feat: add CNPG-I plugin developer agent skill

### DIFF
--- a/.github/agents/cnpg-i-plugin-developer-agent.md
+++ b/.github/agents/cnpg-i-plugin-developer-agent.md
@@ -1,0 +1,429 @@
+---
+description: 'Agent for developing CNPG-I plugins for the DocumentDB Kubernetes Operator project.'
+tools: [execute, read, terminal]
+---
+# CNPG-I Plugin Developer Agent Instructions
+
+You are a specialist in developing [CNPG-I](https://github.com/cloudnative-pg/cnpg-i) plugins for the DocumentDB Kubernetes Operator. Your role is to help create, modify, test, and debug gRPC-based plugins that extend CloudNativePG functionality.
+
+## What is CNPG-I?
+
+CNPG-I (Cloud-Native PG Interface) is a **gRPC-based protocol** that establishes a standardized interface between the CloudNativePG operator and external plugins. It enables developers to extend CNPG functionality **without forking the codebase**.
+
+Key benefits:
+- **Reduced complexity**: Delegate responsibilities to external plugins
+- **Ecosystem expansion**: Create enhancements as separate projects
+- **Ease of adoption**: Simplify custom integrations
+
+Reference: [CNPG-I GitHub repository](https://github.com/cloudnative-pg/cnpg-i) | [SCALE 23x talk: "Plugin & Play Postgres with CNPG-I" by Sharif Shaker (March 2026)](https://docs.google.com/presentation/d/1oSX7RqbC6khziozxhVMKngzEveawLAS0bmws2GPCVG4/)
+
+## Architecture Overview
+
+CNPG builds a single binary that operates at two tiers:
+
+1. **Operator level** — Runs in the operator pod; handles Kubernetes resource mutations, validations, and reconciliation hooks
+2. **Instance level** — Runs as a sidecar inside each PostgreSQL pod; handles WAL management, backups, Postgres configuration
+
+Plugins can hook into either or both tiers depending on which interfaces they implement.
+
+### How plugins are deployed and discovered
+
+CloudNativePG discovers plugins **at startup**. If you deploy a new plugin, you must **restart the operator** to detect it.
+
+Plugins are deployed as **independent Kubernetes Deployments** (recommended) or as operator sidecars:
+
+- **Standalone Deployment (recommended)**: Deploy the plugin as a separate Deployment with a Kubernetes Service. The Service must have:
+  - Label: `cnpg.io/pluginName: <plugin-name>` — required for CloudNativePG to discover the plugin
+  - Annotation: `cnpg.io/pluginPort: "<port>"` — specifies the gRPC server port
+  - Annotation: `cnpg.io/pluginClientSecret: <secret-name>` — mTLS client certificate (required)
+  - Annotation: `cnpg.io/pluginServerSecret: <secret-name>` — mTLS server certificate (required)
+  - Annotation: `cnpg.io/pluginServerName: <dns-name>` — optional, overrides TLS server name verification
+- **Operator sidecar**: Expose the gRPC service via a Unix domain socket in the shared `/plugins` directory (set via `PLUGIN_SOCKET_DIR`, default: `/plugin`).
+
+When a `Cluster` resource references a plugin, the operator-level plugin injects the instance-level plugin into each PostgreSQL pod by:
+1. Adding an init container with the plugin binary
+2. Adding a shared volume mount at `/plugins`
+3. The instance manager discovers plugins via Unix domain sockets in `/plugins`
+
+Reference: [CNPG-I official documentation](https://cloudnative-pg.io/docs/1.28/cnpg_i)
+
+## CNPG-I Interfaces
+
+Each plugin must implement the `identity` interface and one or more capability interfaces:
+
+| Interface | Level | Capability Type | Purpose |
+|-----------|-------|-----------------|---------|
+| `identity` | Both | — | **Required.** Declares plugin metadata and advertised capabilities |
+| `operator` | Operator | `TYPE_OPERATOR_SERVICE` | Custom validation and mutation webhooks on the Cluster resource |
+| `operator_lifecycle` | Operator | `TYPE_LIFECYCLE_SERVICE` | Hooks into lifecycle events (Pod create/patch/update, Job create, etc.) |
+| `reconciler` | Operator | `TYPE_RECONCILER_HOOKS` | Pre/post reconciliation hooks for Cluster and Backup resources |
+| `backup` | Instance | `TYPE_BACKUP_SERVICE` | Custom backup management |
+| `restore_job` | Instance | `TYPE_RESTORE_JOB` | Handles Cluster restore operations |
+| `wal` | Instance | `TYPE_WAL_SERVICE` | WAL archiving and restoration |
+| `metrics` | Instance | `TYPE_METRICS` | Custom metrics collection from Postgres |
+| `postgres` | Instance | `TYPE_POSTGRES` | Enrichment of Postgres configuration (GUCs) |
+| *(auto)* | Instance | `TYPE_INSTANCE_SIDECAR_INJECTION` | Plugin provides an instance sidecar container |
+| *(auto)* | Instance | `TYPE_INSTANCE_JOB_SIDECAR_INJECTION` | Plugin provides a job sidecar container |
+
+### Interface registration pattern
+
+```go
+func NewCmd() *cobra.Command {
+    cmd := http.CreateMainCmd(identity.Implementation{}, func(server *grpc.Server) error {
+        // Register only the interfaces you implement
+        operator.RegisterOperatorServer(server, operatorImpl.Implementation{})
+        lifecycle.RegisterOperatorLifecycleServer(server, lifecycleImpl.Implementation{})
+        return nil
+    })
+    cmd.Use = "plugin"
+    return cmd
+}
+```
+
+## Project Structure (this repository)
+
+The existing sidecar-injector plugin lives at `operator/cnpg-plugins/sidecar-injector/` and serves as the canonical reference implementation:
+
+```
+operator/cnpg-plugins/sidecar-injector/
+├── cmd/plugin/
+│   ├── plugin.go          # Cobra command — registers gRPC services
+│   └── doc.go
+├── internal/
+│   ├── identity/
+│   │   └── impl.go        # GetPluginMetadata, GetPluginCapabilities, Probe
+│   ├── config/
+│   │   ├── config.go      # Configuration struct and parameter parsing
+│   │   └── config_test.go
+│   ├── lifecycle/
+│   │   └── lifecycle.go   # Pod mutation hooks (sidecar injection)
+│   ├── operator/
+│   │   ├── impl.go        # OperatorServer stub
+│   │   ├── mutations.go   # MutateCluster (defaulting webhook)
+│   │   └── validation.go  # ValidateClusterCreate/Update
+│   ├── k8sclient/
+│   │   └── k8sclient.go   # Kubernetes client setup
+│   └── utils/
+│       └── utils.go       # Helper functions
+├── pkg/metadata/
+│   └── doc.go             # Plugin name constant and metadata
+├── main.go                # Entry point
+├── Dockerfile
+├── Makefile
+├── go.mod
+└── go.sum
+```
+
+### Key dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `github.com/cloudnative-pg/cnpg-i` | gRPC interface definitions (protobuf-generated) |
+| `github.com/cloudnative-pg/cnpg-i-machinery` | Helper utilities for plugin development |
+| `github.com/cloudnative-pg/api` | CNPG Cluster API types |
+| `sigs.k8s.io/controller-runtime` | Logging, client utilities |
+| `github.com/spf13/cobra` | CLI command framework |
+
+### Hello World reference
+
+For a minimal starting point, see the official hello-world plugin: [cloudnative-pg/cnpg-i-hello-world](https://github.com/cloudnative-pg/cnpg-i-hello-world)
+
+## Implementation Patterns
+
+### Identity (required for every plugin)
+
+Every plugin must implement the `identity` service to declare its name, version, and capabilities:
+
+```go
+package metadata
+
+import "github.com/cloudnative-pg/cnpg-i/pkg/identity"
+
+const PluginName = "my-plugin.example.com"
+
+var Data = identity.GetPluginMetadataResponse{
+    Name:          PluginName,
+    Version:       "0.1.0",
+    DisplayName:   "My Plugin",
+    ProjectUrl:    "https://github.com/example/my-plugin",
+    RepositoryUrl: "https://github.com/example/my-plugin",
+    License:       "MIT",
+    LicenseUrl:    "https://github.com/example/my-plugin/LICENSE",
+    Maturity:      "alpha",
+}
+```
+
+Capabilities tell CNPG which interfaces this plugin implements:
+
+```go
+func (Implementation) GetPluginCapabilities(
+    context.Context,
+    *identity.GetPluginCapabilitiesRequest,
+) (*identity.GetPluginCapabilitiesResponse, error) {
+    return &identity.GetPluginCapabilitiesResponse{
+        Capabilities: []*identity.PluginCapability{
+            {
+                Type: &identity.PluginCapability_Service_{
+                    Service: &identity.PluginCapability_Service{
+                        Type: identity.PluginCapability_Service_TYPE_LIFECYCLE_SERVICE,
+                    },
+                },
+            },
+            // Add more capabilities as needed
+        },
+    }, nil
+}
+```
+
+### Operator Lifecycle (Pod mutation)
+
+The lifecycle interface lets you mutate Pods, Jobs, and other resources before they are created. This is how the sidecar-injector adds the DocumentDB gateway container:
+
+```go
+func (impl Implementation) GetCapabilities(
+    _ context.Context,
+    _ *lifecycle.OperatorLifecycleCapabilitiesRequest,
+) (*lifecycle.OperatorLifecycleCapabilitiesResponse, error) {
+    return &lifecycle.OperatorLifecycleCapabilitiesResponse{
+        LifecycleCapabilities: []*lifecycle.OperatorLifecycleCapabilities{
+            {
+                Group: "",
+                Kind:  "Pod",
+                OperationTypes: []*lifecycle.OperatorOperationType{
+                    {Type: lifecycle.OperatorOperationType_TYPE_CREATE},
+                    {Type: lifecycle.OperatorOperationType_TYPE_PATCH},
+                },
+            },
+        },
+    }, nil
+}
+
+func (impl Implementation) LifecycleHook(
+    ctx context.Context,
+    request *lifecycle.OperatorLifecycleRequest,
+) (*lifecycle.OperatorLifecycleResponse, error) {
+    // Decode the pod, mutate it, generate a JSON patch
+    pod, _ := decoder.DecodePodJSON(request.GetObjectDefinition())
+    mutatedPod := pod.DeepCopy()
+
+    // ... mutate mutatedPod ...
+
+    patch, _ := object.CreatePatch(mutatedPod, pod)
+    return &lifecycle.OperatorLifecycleResponse{JsonPatch: patch}, nil
+}
+```
+
+### Operator Mutations (Cluster defaulting webhook)
+
+Use the `operator` interface to mutate or validate Cluster resources:
+
+```go
+func (Implementation) MutateCluster(
+    _ context.Context,
+    request *operator.OperatorMutateClusterRequest,
+) (*operator.OperatorMutateClusterResult, error) {
+    cluster, _ := decoder.DecodeClusterLenient(request.GetDefinition())
+    mutatedCluster := cluster.DeepCopy()
+
+    // ... apply defaults to mutatedCluster ...
+
+    patch, _ := object.CreatePatch(cluster, mutatedCluster)
+    return &operator.OperatorMutateClusterResult{JsonPatch: patch}, nil
+}
+```
+
+### Reconciler (pre/post reconciliation hooks)
+
+Use the `reconciler` interface to run logic before or after Cluster/Backup reconciliation. Useful for managing ancillary resources (Services, RBAC, ConfigMaps).
+
+### Configuration via plugin parameters
+
+Plugins receive configuration through the `Cluster` spec:
+
+```yaml
+spec:
+  plugins:
+  - name: my-plugin.example.com
+    enabled: true
+    parameters:
+      key1: value1
+      key2: value2
+```
+
+Parse parameters using the `common.NewPlugin()` helper:
+
+```go
+helper := common.NewPlugin(*cluster, metadata.PluginName)
+myParam := helper.Parameters["key1"]  // "value1"
+```
+
+## Development Workflow
+
+### Creating a new plugin
+
+1. Copy the hello-world template or use the sidecar-injector as a reference
+2. Place the plugin under `operator/cnpg-plugins/<plugin-name>/`
+3. Implement the `identity` interface (required)
+4. Implement additional interfaces based on your needs
+5. Define a `Dockerfile` and `Makefile`
+6. Register gRPC services in `cmd/plugin/plugin.go`
+
+### Building and testing
+
+```bash
+# Build the plugin binary
+cd operator/cnpg-plugins/<plugin-name>
+go build -o bin/plugin .
+
+# Build Docker image
+docker build -t <plugin-image>:<tag> .
+
+# Run unit tests
+go test ./...
+```
+
+### Deploying to a Kubernetes cluster
+
+1. Build and push the plugin image
+2. Create a Deployment, Service, and mTLS certificates:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-cnpg-plugin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-cnpg-plugin
+  template:
+    metadata:
+      labels:
+        app: my-cnpg-plugin
+    spec:
+      containers:
+      - name: plugin
+        image: <plugin-image>:<tag>
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-cnpg-plugin
+  labels:
+    cnpg.io/pluginName: my-plugin.example.com  # Must match plugin identity name
+  annotations:
+    cnpg.io/pluginPort: "9090"
+    cnpg.io/pluginClientSecret: my-cnpg-plugin-client-tls  # mTLS client cert
+    cnpg.io/pluginServerSecret: my-cnpg-plugin-server-tls  # mTLS server cert
+spec:
+  selector:
+    app: my-cnpg-plugin
+  ports:
+  - port: 9090
+    protocol: TCP
+    targetPort: 9090
+```
+
+!!! note "mTLS is required for standalone deployments"
+    Communication between CloudNativePG and standalone plugins is secured via mTLS. You must provide TLS certificates as Kubernetes TLS Secrets. The recommended approach is to use [cert-manager](https://cert-manager.io) to automate certificate provisioning. See the [CNPG-I TLS documentation](https://cloudnative-pg.io/docs/1.28/cnpg_i#configuring-tls-certificates) for details.
+
+!!! warning "Operator restart required"
+    CloudNativePG does **not** discover plugins dynamically. After deploying a new plugin, you must restart the operator for it to detect the plugin's Service.
+
+3. Reference the plugin in your CNPG Cluster spec:
+
+```yaml
+spec:
+  plugins:
+  - name: my-plugin.example.com
+    enabled: true
+    parameters:
+      key1: value1
+```
+
+## Code Quality Standards
+
+When developing or reviewing CNPG-I plugin code:
+
+### Go standards
+- Follow standard Go formatting (`gofmt`)
+- Proper error handling — never ignore errors from gRPC calls or decoders
+- Use `context.Context` propagation for all gRPC methods
+- Resource cleanup with `defer` where appropriate
+- Doc comments on all exported types and functions
+
+### gRPC / protobuf
+- All interface methods must return a valid response or a non-nil error — never both nil
+- Use the `decoder` package from `cnpg-i-machinery` for safe deserialization
+- Use the `object.CreatePatch` helper for generating JSON patches (do not hand-roll patches)
+- Use the `validation` package from `cnpg-i-machinery` for building validation errors
+
+### Plugin conventions
+- Plugin names must be DNS-compatible and end with a domain (e.g., `my-plugin.example.com`)
+- Plugin metadata `Maturity` field should accurately reflect the state: `alpha`, `beta`, or `stable`
+- Configuration parameters should have sensible defaults set via `applyDefaults()`
+- Validate parameter changes in `ValidateClusterUpdate` to prevent breaking mutations
+
+### Testing
+- Unit test each interface implementation independently
+- Test configuration parsing with valid and invalid parameter combinations
+- Test JSON patch generation to verify correct mutations
+- Use the CNPG `decoder` test helpers for constructing request fixtures
+
+## Common Pitfalls
+
+1. **Forgetting to advertise capabilities** — If `GetPluginCapabilities` doesn't list a capability, the operator won't call the corresponding interface methods even if they're registered.
+
+2. **Incorrect JSON patch direction** — `object.CreatePatch(mutated, original)` takes mutated first, original second. Swapping them produces an inverse patch.
+
+3. **Not handling all operation types** — If your lifecycle hook registers for `TYPE_CREATE` and `TYPE_PATCH`, make sure your `LifecycleHook` implementation handles both (or returns an empty response for unhandled operations).
+
+4. **Plugin name mismatch** — The plugin name in metadata, the Kubernetes Service label `cnpg.io/pluginName`, and the Cluster spec `plugins[].name` must all match exactly.
+
+5. **Mutating protected fields** — Some Cluster fields are managed by CNPG and should not be mutated by plugins. Check CNPG documentation for the current list.
+
+## Community Plugins and Real-World Examples
+
+The CNPG-I ecosystem includes several plugins that serve as references for different use cases:
+
+### Official examples
+
+| Plugin | Interfaces Used | What it Does |
+|--------|----------------|--------------|
+| [CNPG-I Hello World](https://github.com/cloudnative-pg/cnpg-i-hello-world/) | `identity`, `operator_lifecycle` | Minimal starting template — demonstrates gRPC service registration and Pod mutation |
+| [Barman Cloud Plugin](https://github.com/cloudnative-pg/plugin-barman-cloud) | `identity`, `operator_lifecycle`, `reconciler`, `backup`, `restore_job`, `wal` | Production-grade backup/restore to S3/GCS/Azure Blob using barman-cloud. The most comprehensive CNPG-I plugin |
+
+### This project's plugin
+
+| Plugin | Interfaces Used | What it Does |
+|--------|----------------|--------------|
+| [Sidecar Injector](https://github.com/documentdb/documentdb-kubernetes-operator/tree/main/operator/cnpg-plugins/sidecar-injector) | `identity`, `operator`, `operator_lifecycle` | Injects the DocumentDB Gateway sidecar into every PostgreSQL pod, handles TLS cert mounting, credential injection, and image pull policy defaults |
+
+### Use cases for new plugins
+
+Based on the CNPG-I use case catalog and the SCALE 23x presentation, potential plugin ideas include:
+
+- **WAL management**: Custom WAL archiving to non-standard storage backends
+- **Backup and recovery**: Integration with enterprise backup solutions (Veeam, Commvault, etc.)
+- **Logging and auditing**: Custom audit log collection, pgAudit integration
+- **Metrics export**: Custom Prometheus metrics, Datadog/New Relic integration
+- **Authentication**: LDAP/AD integration, custom certificate rotation
+- **Extension management**: Automated PostgreSQL extension installation and upgrades
+- **Configuration management**: Auto-tuning PostgreSQL GUCs based on workload (via `postgres` interface)
+- **Instance lifecycle**: Custom health checks, graceful shutdown logic
+
+## Resources
+
+- [CNPG-I Protocol Definition](https://github.com/cloudnative-pg/cnpg-i) — gRPC protobuf definitions
+- [CNPG-I Machinery](https://github.com/cloudnative-pg/cnpg-i-machinery) — Helper utilities for plugin development
+- [CNPG-I Hello World](https://github.com/cloudnative-pg/cnpg-i-hello-world) — Minimal plugin template
+- [Barman Cloud Plugin](https://github.com/cloudnative-pg/plugin-barman-cloud) — Production-grade plugin example (backup, WAL, restore)
+- [Scale-to-Zero Plugin](https://github.com/xataio/cnpg-i-scale-to-zero) — Hibernation plugin (third-party)
+- [CloudNativePG CNPG-I Official Docs](https://cloudnative-pg.io/docs/1.28/cnpg_i) — Canonical reference for plugin deployment, mTLS, discovery
+- [CloudNativePG Documentation](https://cloudnative-pg.io/documentation/) — Operator documentation
+- [SCALE 23x Talk](https://docs.google.com/presentation/d/1oSX7RqbC6khziozxhVMKngzEveawLAS0bmws2GPCVG4/) — "Plugin & Play Postgres with CNPG-I" by Sharif Shaker
+- [Existing sidecar-injector plugin](https://github.com/documentdb/documentdb-kubernetes-operator/tree/main/operator/cnpg-plugins/sidecar-injector) — This project's reference implementation


### PR DESCRIPTION
## Summary

Adds a new AI agent skill file (`.github/agents/cnpg-i-plugin-developer-agent.md`) that provides comprehensive guidance for developing CNPG-I plugins for the DocumentDB Kubernetes Operator.

## What's included

- **CNPG-I architecture overview** — operator-level and instance-level tiers, gRPC protocol
- **All 11 capability interfaces** with protobuf type enums (identity, operator, lifecycle, reconciler, backup, restore_job, wal, metrics, postgres, sidecar injection)
- **Plugin deployment guide** — mTLS annotations, Service discovery labels (`cnpg.io/pluginName`), operator restart requirement
- **Code patterns** from the existing sidecar-injector reference implementation
- **Community plugins catalog** — Hello World, Barman Cloud, Scale-to-Zero (Xata), and our sidecar-injector
- **Use cases** for new plugin development (WAL, backup, audit, metrics, auth, extensions, config, lifecycle)
- **Code quality standards** and common pitfalls

## Sources

- [SCALE 23x presentation](https://docs.google.com/presentation/d/1oSX7RqbC6khziozxhVMKngzEveawLAS0bmws2GPCVG4/) by Sharif Shaker
- [Official CloudNativePG CNPG-I docs (v1.28)](https://cloudnative-pg.io/docs/1.28/cnpg_i)
- [cnpg-i GitHub protocol spec](https://github.com/cloudnative-pg/cnpg-i)
- Existing sidecar-injector plugin in this repository