### PR TITLE
feat: add KEDA autoscaling playground for DocumentDB

### DIFF
--- a/documentdb-playground/keda-autoscaling/README.md
+++ b/documentdb-playground/keda-autoscaling/README.md
@@ -128,6 +128,10 @@ Interactive walkthrough that seeds jobs, watches scaling, drains jobs, and watch
 > attempts replica set discovery, which fails with DocumentDB because it doesn't expose a standard
 > MongoDB replica set topology.
 
+> **Note:** Remove the `replicaSet=rs0` parameter from the connection string. KEDA's Go driver
+> fails topology negotiation with DocumentDB when `replicaSet` is specified alongside
+> `directConnection=true`. The setup script strips this parameter automatically.
+
 > **Note:** A `ClusterTriggerAuthentication` is used because the DocumentDB credentials Secret
 > (`documentdb-ns`) and the ScaledObject (`app`) are in different namespaces. If you deploy
 > everything in the same namespace, you can use a namespace-scoped `TriggerAuthentication` instead.

--- a/documentdb-playground/keda-autoscaling/README.md
+++ b/documentdb-playground/keda-autoscaling/README.md
@@ -1,0 +1,151 @@
+# KEDA autoscaling with DocumentDB
+
+This playground demonstrates event-driven autoscaling using [KEDA](https://keda.sh/) with DocumentDB. KEDA's [MongoDB scaler](https://keda.sh/docs/2.19/scalers/mongodb/) polls a DocumentDB collection for pending jobs and automatically scales a worker Deployment from 0 to N pods based on the query result.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph cluster["Kubernetes cluster"]
+        KEDA[KEDA Operator] -->|"polls appdb.jobs<br/>every 5s"| DDB[(DocumentDB<br/>port 10260)]
+        KEDA -->|scales 0 → N| Worker["job-worker<br/>Deployment"]
+        Seed[seed-jobs Job] -->|inserts pending jobs| DDB
+        Drain[drain-jobs Job] -->|marks jobs completed| DDB
+    end
+```
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| [Kind](https://kind.sigs.k8s.io/) | 0.20+ | Local Kubernetes cluster |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | 1.30+ | Kubernetes CLI |
+| [Helm](https://helm.sh/docs/intro/install/) | 3.x | Package manager for Kubernetes |
+| DocumentDB operator | — | Must be running in the Kubernetes cluster |
+
+> **Note:** If you don't have a Kubernetes cluster with the DocumentDB operator, use the
+> [development deploy script](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/operator/src/scripts/development/deploy.sh)
+> to set up Kind with the operator:
+>
+> ```bash
+> cd operator/src
+> DEPLOY=true DEPLOY_CLUSTER=true ./scripts/development/deploy.sh
+> ```
+
+## Quick start
+
+```bash
+# 1. Ensure the DocumentDB operator is running on your Kubernetes cluster
+
+# 2. Deploy KEDA and the demo
+cd documentdb-playground/keda-autoscaling
+./scripts/setup.sh
+
+# 3. Watch pods scale up (10 pending jobs trigger scaling)
+kubectl get pods -n app -w
+
+# 4. Drain jobs to scale back to 0
+kubectl delete job drain-pending-jobs -n app --ignore-not-found
+kubectl apply -f manifests/drain-jobs.yaml
+
+# 5. Clean up
+./scripts/teardown.sh
+```
+
+## How it works
+
+1. **`setup.sh`** installs KEDA and deploys a DocumentDB instance with a worker Deployment.
+2. A `ClusterTriggerAuthentication` stores the DocumentDB connection string (with TLS and auth parameters) in a Secret.
+3. A `ScaledObject` configures KEDA to poll the `appdb.jobs` collection for documents matching `{"status": "pending"}` every 5 seconds.
+4. When the number of pending jobs exceeds 5, KEDA creates an HPA that scales the `job-worker` Deployment from 0 up to 10 pods.
+5. The **seed job** inserts 10 pending documents to trigger scaling.
+6. The **drain job** updates all pending jobs to `"completed"`, causing KEDA to scale the Deployment back to 0 after the 30-second cooldown.
+
+## Connection string configuration
+
+The setup script builds a connection string for DocumentDB and stores it in a Kubernetes Secret:
+
+```text
+mongodb://<user>:<pass>@documentdb-service-keda-demo.documentdb-ns.svc.cluster.local:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true
+```
+
+| Parameter | Value | Why it's needed |
+|-----------|-------|-----------------|
+| Port | `10260` | DocumentDB Gateway port (not MongoDB's default 27017) |
+| `directConnection=true` | Required | DocumentDB doesn't run a real replica set topology |
+| `authMechanism=SCRAM-SHA-256` | Required | DocumentDB's authentication mechanism |
+| `tls=true` | Required | DocumentDB Gateway serves TLS by default |
+| `tlsAllowInvalidCertificates=true` | For self-signed | Skip certificate validation with the default self-signed certificates |
+
+## Script reference
+
+### `setup.sh`
+
+Installs KEDA, deploys a DocumentDB instance, and configures the autoscaling demo.
+
+| Environment variable | Description | Default |
+|---------------------|-------------|---------|
+| `DOCUMENTDB_NAMESPACE` | Namespace for the DocumentDB instance | `documentdb-ns` |
+| `DOCUMENTDB_NAME` | DocumentDB instance name | `keda-demo` |
+| `APP_NAMESPACE` | Namespace for KEDA resources and the worker | `app` |
+| `KEDA_VERSION` | KEDA Helm chart version | `2.17.0` |
+
+### `teardown.sh`
+
+Removes demo resources. By default, KEDA and DocumentDB are preserved.
+
+| Flag | Description |
+|------|-------------|
+| `--uninstall-keda` | Also uninstall the KEDA Helm release |
+| `--delete-documentdb` | Also delete the DocumentDB instance |
+
+### `demo.sh`
+
+Interactive walkthrough that seeds jobs, watches scaling, drains jobs, and watches scale-down. Pauses between steps so you can observe the behavior.
+
+## Manifest reference
+
+| File | Description |
+|------|-------------|
+| `manifests/documentdb-instance.yaml` | DocumentDB CR (1 node, 2Gi storage) for Kind |
+| `manifests/keda-trigger-auth.yaml` | `ClusterTriggerAuthentication` referencing the DocumentDB connection Secret |
+| `manifests/keda-scaled-object.yaml` | `ScaledObject` with MongoDB trigger — polls `appdb.jobs` for pending documents |
+| `manifests/job-worker.yaml` | Worker Deployment that KEDA scales (starts at 0 replicas) |
+| `manifests/seed-jobs.yaml` | Job that inserts 10 pending documents into DocumentDB |
+| `manifests/drain-jobs.yaml` | Job that marks all pending documents as completed |
+
+## Known limitations and gotchas
+
+> **Important:** KEDA's MongoDB scaler uses the Go MongoDB driver internally. The
+> `tlsAllowInvalidCertificates=true` connection string parameter is respected by the driver, but
+> if you encounter TLS errors, consider switching DocumentDB to `CertManager` TLS mode. See the
+> [TLS configuration documentation](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/docs/operator-public-documentation/preview/configuration/tls.md).
+
+> **Note:** The `directConnection=true` parameter is essential. Without it, the Go MongoDB driver
+> attempts replica set discovery, which fails with DocumentDB because it doesn't expose a standard
+> MongoDB replica set topology.
+
+> **Note:** A `ClusterTriggerAuthentication` is used because the DocumentDB credentials Secret
+> (`documentdb-ns`) and the ScaledObject (`app`) are in different namespaces. If you deploy
+> everything in the same namespace, you can use a namespace-scoped `TriggerAuthentication` instead.
+
+> **Note:** The `mongodb/mongodb-community-server:8.0-ubuntu2404` image is used for the seed and
+> drain jobs because it includes `mongosh`. Any image with `mongosh` installed works.
+
+## Cleanup
+
+```bash
+# Remove demo resources only (keep KEDA and DocumentDB)
+./scripts/teardown.sh
+
+# Remove everything including KEDA and DocumentDB
+./scripts/teardown.sh --uninstall-keda --delete-documentdb
+```
+
+## Related resources
+
+- [KEDA MongoDB scaler documentation](https://keda.sh/docs/2.19/scalers/mongodb/)
+- [KEDA ScaledObject specification](https://keda.sh/docs/2.19/concepts/scaling-deployments/)
+- [DocumentDB Kubernetes Operator documentation](https://documentdb.io/documentdb-kubernetes-operator/preview/)
+- [Connecting to DocumentDB](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/docs/operator-public-documentation/preview/getting-started/connecting-to-documentdb.md)
+- [DocumentDB TLS configuration](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/docs/operator-public-documentation/preview/configuration/tls.md)

--- a/documentdb-playground/keda-autoscaling/README.md
+++ b/documentdb-playground/keda-autoscaling/README.md
@@ -66,7 +66,7 @@ kubectl apply -f manifests/drain-jobs.yaml
 The setup script builds a connection string for DocumentDB and stores it in a Kubernetes Secret:
 
 ```text
-mongodb://<user>:<pass>@documentdb-service-keda-demo.documentdb-ns.svc.cluster.local:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true
+mongodb://<user>:<pass>@documentdb-service-keda-demo.documentdb-ns.svc.cluster.local:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true
 ```
 
 | Parameter | Value | Why it's needed |
@@ -75,7 +75,7 @@ mongodb://<user>:<pass>@documentdb-service-keda-demo.documentdb-ns.svc.cluster.l
 | `directConnection=true` | Required | DocumentDB doesn't run a real replica set topology |
 | `authMechanism=SCRAM-SHA-256` | Required | DocumentDB's authentication mechanism |
 | `tls=true` | Required | DocumentDB Gateway serves TLS by default |
-| `tlsAllowInvalidCertificates=true` | For self-signed | Skip certificate validation with the default self-signed certificates |
+| `tlsInsecure=true` | For self-signed | Skip certificate validation with the default self-signed certificates |
 
 ## Script reference
 
@@ -116,9 +116,12 @@ Interactive walkthrough that seeds jobs, watches scaling, drains jobs, and watch
 
 ## Known limitations and gotchas
 
-> **Important:** KEDA's MongoDB scaler uses the Go MongoDB driver internally. The
-> `tlsAllowInvalidCertificates=true` connection string parameter is respected by the driver, but
-> if you encounter TLS errors, consider switching DocumentDB to `CertManager` TLS mode. See the
+> **Important:** KEDA's MongoDB scaler uses the Go MongoDB driver internally. You must use
+> `tlsInsecure=true` (not `tlsAllowInvalidCertificates=true`) in the connection string. The
+> Go driver only respects `tlsInsecure` for skipping both certificate and hostname verification.
+> Using `tlsAllowInvalidCertificates=true` alone causes `x509: certificate is not valid for any
+> names` errors because hostname verification still applies. For production, switch DocumentDB to
+> `CertManager` TLS mode — see the
 > [TLS configuration documentation](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/docs/operator-public-documentation/preview/configuration/tls.md).
 
 > **Note:** The `directConnection=true` parameter is essential. Without it, the Go MongoDB driver

--- a/documentdb-playground/keda-autoscaling/README.md
+++ b/documentdb-playground/keda-autoscaling/README.md
@@ -132,7 +132,7 @@ Interactive walkthrough that seeds jobs, watches scaling, drains jobs, and watch
 > (`documentdb-ns`) and the ScaledObject (`app`) are in different namespaces. If you deploy
 > everything in the same namespace, you can use a namespace-scoped `TriggerAuthentication` instead.
 
-> **Note:** The `mongodb/mongodb-community-server:8.0-ubuntu2404` image is used for the seed and
+> **Note:** The `mongo:8.0` image is used for the seed and
 > drain jobs because it includes `mongosh`. Any image with `mongosh` installed works.
 
 ## Cleanup

--- a/documentdb-playground/keda-autoscaling/manifests/documentdb-instance.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/documentdb-instance.yaml
@@ -12,4 +12,6 @@ spec:
   resource:
     storage:
       pvcSize: 2Gi
+  exposeViaService:
+    serviceType: ClusterIP
   sidecarInjectorPluginName: cnpg-i-sidecar-injector.documentdb.io

--- a/documentdb-playground/keda-autoscaling/manifests/documentdb-instance.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/documentdb-instance.yaml
@@ -1,0 +1,15 @@
+apiVersion: documentdb.io/preview
+kind: DocumentDB
+metadata:
+  name: keda-demo
+  namespace: documentdb-ns
+  labels:
+    app.kubernetes.io/part-of: keda-documentdb-demo
+spec:
+  nodeCount: 1
+  instancesPerNode: 1
+  documentDbCredentialSecret: documentdb-credentials
+  resource:
+    storage:
+      pvcSize: 2Gi
+  sidecarInjectorPluginName: cnpg-i-sidecar-injector.documentdb.io

--- a/documentdb-playground/keda-autoscaling/manifests/documentdb-instance.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/documentdb-instance.yaml
@@ -1,14 +1,13 @@
 apiVersion: documentdb.io/preview
 kind: DocumentDB
 metadata:
-  name: keda-demo
-  namespace: documentdb-ns
+  name: DOCUMENTDB_NAME_PLACEHOLDER
   labels:
     app.kubernetes.io/part-of: keda-documentdb-demo
 spec:
   nodeCount: 1
   instancesPerNode: 1
-  documentDbCredentialSecret: documentdb-credentials
+  documentDbCredentialSecret: DOCUMENTDB_SECRET_PLACEHOLDER
   resource:
     storage:
       pvcSize: 2Gi

--- a/documentdb-playground/keda-autoscaling/manifests/drain-jobs.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/drain-jobs.yaml
@@ -15,18 +15,19 @@ spec:
       restartPolicy: Never
       containers:
         - name: drain
-          image: mongodb/mongodb-community-server:8.0-ubuntu2404
+          image: mongo:8.0
           command:
-            - mongosh
-            - "--eval"
+            - /bin/sh
+            - -c
             - |
-              const db = connect(process.env.MONGODB_URI);
-              const result = db.getSiblingDB("appdb").jobs.updateMany(
-                {status: "pending"},
-                {$set: {status: "completed", completedAt: new Date()}}
-              );
-              print("Marked " + result.modifiedCount + " jobs as completed");
-              print("Remaining pending: " + db.getSiblingDB("appdb").jobs.countDocuments({status: "pending"}));
+              mongosh "$MONGODB_URI" --eval '
+                const result = db.getSiblingDB("appdb").jobs.updateMany(
+                  {status: "pending"},
+                  {$set: {status: "completed", completedAt: new Date()}}
+                );
+                print("Marked " + result.modifiedCount + " jobs as completed");
+                print("Remaining pending: " + db.getSiblingDB("appdb").jobs.countDocuments({status: "pending"}));
+              '
           env:
             - name: MONGODB_URI
               valueFrom:

--- a/documentdb-playground/keda-autoscaling/manifests/drain-jobs.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/drain-jobs.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: drain-pending-jobs
+  namespace: app
+  labels:
+    app.kubernetes.io/part-of: keda-documentdb-demo
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: keda-documentdb-demo
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: drain
+          image: mongodb/mongodb-community-server:8.0-ubuntu2404
+          command:
+            - mongosh
+            - "--eval"
+            - |
+              const db = connect(process.env.MONGODB_URI);
+              const result = db.getSiblingDB("appdb").jobs.updateMany(
+                {status: "pending"},
+                {$set: {status: "completed", completedAt: new Date()}}
+              );
+              print("Marked " + result.modifiedCount + " jobs as completed");
+              print("Remaining pending: " + db.getSiblingDB("appdb").jobs.countDocuments({status: "pending"}));
+          env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: documentdb-keda-connection
+                  key: connectionString

--- a/documentdb-playground/keda-autoscaling/manifests/drain-jobs.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/drain-jobs.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: drain-pending-jobs
-  namespace: app
   labels:
     app.kubernetes.io/part-of: keda-documentdb-demo
 spec:

--- a/documentdb-playground/keda-autoscaling/manifests/job-worker.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/job-worker.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: job-worker
+  namespace: app
+  labels:
+    app: job-worker
+    app.kubernetes.io/part-of: keda-documentdb-demo
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: job-worker
+  template:
+    metadata:
+      labels:
+        app: job-worker
+        app.kubernetes.io/part-of: keda-documentdb-demo
+    spec:
+      containers:
+        - name: worker
+          image: busybox:1.36
+          command: ["sh", "-c", "echo 'Processing job...' && sleep 30"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/documentdb-playground/keda-autoscaling/manifests/job-worker.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/job-worker.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: job-worker
-  namespace: app
   labels:
     app: job-worker
     app.kubernetes.io/part-of: keda-documentdb-demo

--- a/documentdb-playground/keda-autoscaling/manifests/keda-scaled-object.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/keda-scaled-object.yaml
@@ -1,0 +1,25 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: documentdb-worker-scaler
+  namespace: app
+  labels:
+    app.kubernetes.io/part-of: keda-documentdb-demo
+spec:
+  scaleTargetRef:
+    name: job-worker
+  minReplicaCount: 0
+  maxReplicaCount: 10
+  pollingInterval: 5
+  cooldownPeriod: 30
+  triggers:
+    - type: mongodb
+      metadata:
+        dbName: "appdb"
+        collection: "jobs"
+        query: '{"status":"pending"}'
+        queryValue: "5"
+        activationQueryValue: "1"
+      authenticationRef:
+        name: documentdb-trigger-auth
+        kind: ClusterTriggerAuthentication

--- a/documentdb-playground/keda-autoscaling/manifests/keda-scaled-object.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/keda-scaled-object.yaml
@@ -2,7 +2,6 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: documentdb-worker-scaler
-  namespace: app
   labels:
     app.kubernetes.io/part-of: keda-documentdb-demo
 spec:

--- a/documentdb-playground/keda-autoscaling/manifests/keda-trigger-auth.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/keda-trigger-auth.yaml
@@ -8,5 +8,4 @@ spec:
   secretTargetRef:
     - parameter: connectionString
       name: documentdb-keda-connection
-      namespace: keda
       key: connectionString

--- a/documentdb-playground/keda-autoscaling/manifests/keda-trigger-auth.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/keda-trigger-auth.yaml
@@ -1,0 +1,11 @@
+apiVersion: keda.sh/v1alpha1
+kind: ClusterTriggerAuthentication
+metadata:
+  name: documentdb-trigger-auth
+  labels:
+    app.kubernetes.io/part-of: keda-documentdb-demo
+spec:
+  secretTargetRef:
+    - parameter: connectionString
+      name: documentdb-keda-connection
+      key: connectionString

--- a/documentdb-playground/keda-autoscaling/manifests/keda-trigger-auth.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/keda-trigger-auth.yaml
@@ -8,4 +8,5 @@ spec:
   secretTargetRef:
     - parameter: connectionString
       name: documentdb-keda-connection
+      namespace: keda
       key: connectionString

--- a/documentdb-playground/keda-autoscaling/manifests/seed-jobs.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/seed-jobs.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: seed-pending-jobs
+  namespace: app
+  labels:
+    app.kubernetes.io/part-of: keda-documentdb-demo
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: keda-documentdb-demo
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: seed
+          image: mongodb/mongodb-community-server:8.0-ubuntu2404
+          command:
+            - mongosh
+            - "--eval"
+            - |
+              const db = connect(process.env.MONGODB_URI);
+              db.getSiblingDB("appdb").jobs.insertMany(
+                Array.from({length: 10}, (_, i) => ({
+                  status: "pending",
+                  created: new Date(),
+                  data: "job-" + (i + 1)
+                }))
+              );
+              print("Inserted " + db.getSiblingDB("appdb").jobs.countDocuments({status: "pending"}) + " pending jobs");
+          env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: documentdb-keda-connection
+                  key: connectionString

--- a/documentdb-playground/keda-autoscaling/manifests/seed-jobs.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/seed-jobs.yaml
@@ -15,20 +15,21 @@ spec:
       restartPolicy: Never
       containers:
         - name: seed
-          image: mongodb/mongodb-community-server:8.0-ubuntu2404
+          image: mongo:8.0
           command:
-            - mongosh
-            - "--eval"
+            - /bin/sh
+            - -c
             - |
-              const db = connect(process.env.MONGODB_URI);
-              db.getSiblingDB("appdb").jobs.insertMany(
-                Array.from({length: 10}, (_, i) => ({
-                  status: "pending",
-                  created: new Date(),
-                  data: "job-" + (i + 1)
-                }))
-              );
-              print("Inserted " + db.getSiblingDB("appdb").jobs.countDocuments({status: "pending"}) + " pending jobs");
+              mongosh "$MONGODB_URI" --eval '
+                db.getSiblingDB("appdb").jobs.insertMany(
+                  Array.from({length: 10}, (_, i) => ({
+                    status: "pending",
+                    created: new Date(),
+                    data: "job-" + (i + 1)
+                  }))
+                );
+                print("Pending jobs: " + db.getSiblingDB("appdb").jobs.countDocuments({status: "pending"}));
+              '
           env:
             - name: MONGODB_URI
               valueFrom:

--- a/documentdb-playground/keda-autoscaling/manifests/seed-jobs.yaml
+++ b/documentdb-playground/keda-autoscaling/manifests/seed-jobs.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: seed-pending-jobs
-  namespace: app
   labels:
     app.kubernetes.io/part-of: keda-documentdb-demo
 spec:

--- a/documentdb-playground/keda-autoscaling/scripts/demo.sh
+++ b/documentdb-playground/keda-autoscaling/scripts/demo.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_NAMESPACE="${APP_NAMESPACE:-app}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFESTS_DIR="${SCRIPT_DIR}/../manifests"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+step() { echo -e "\n${CYAN}=== $* ===${NC}\n"; }
+
+pause() {
+    echo -e "${YELLOW}Press Enter to continue...${NC}"
+    read -r
+}
+
+step "Current state"
+kubectl get scaledobject,hpa -n "$APP_NAMESPACE" 2>/dev/null || true
+echo ""
+kubectl get pods -n "$APP_NAMESPACE" 2>/dev/null || true
+
+pause
+
+step "Seeding 10 pending jobs into DocumentDB"
+kubectl delete job seed-pending-jobs -n "$APP_NAMESPACE" --ignore-not-found=true 2>/dev/null
+kubectl apply -f "${MANIFESTS_DIR}/seed-jobs.yaml"
+kubectl wait --for=condition=complete job/seed-pending-jobs -n "$APP_NAMESPACE" --timeout=120s 2>/dev/null || true
+kubectl logs job/seed-pending-jobs -n "$APP_NAMESPACE" 2>/dev/null || true
+
+step "Watching pods scale up (Ctrl+C to continue)"
+log "KEDA polls every 5 seconds. Worker pods should appear within 15-30 seconds."
+timeout 60 kubectl get pods -n "$APP_NAMESPACE" -w 2>/dev/null || true
+
+pause
+
+step "Draining all pending jobs (marking as completed)"
+kubectl delete job drain-pending-jobs -n "$APP_NAMESPACE" --ignore-not-found=true 2>/dev/null
+kubectl apply -f "${MANIFESTS_DIR}/drain-jobs.yaml"
+kubectl wait --for=condition=complete job/drain-pending-jobs -n "$APP_NAMESPACE" --timeout=120s 2>/dev/null || true
+kubectl logs job/drain-pending-jobs -n "$APP_NAMESPACE" 2>/dev/null || true
+
+step "Watching pods scale down (cooldown: 30 seconds)"
+timeout 90 kubectl get pods -n "$APP_NAMESPACE" -w 2>/dev/null || true
+
+step "Final state"
+kubectl get scaledobject,hpa -n "$APP_NAMESPACE" 2>/dev/null || true
+echo ""
+kubectl get pods -n "$APP_NAMESPACE" 2>/dev/null || true
+
+echo ""
+log "Demo complete!"

--- a/documentdb-playground/keda-autoscaling/scripts/demo.sh
+++ b/documentdb-playground/keda-autoscaling/scripts/demo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 APP_NAMESPACE="${APP_NAMESPACE:-app}"

--- a/documentdb-playground/keda-autoscaling/scripts/demo.sh
+++ b/documentdb-playground/keda-autoscaling/scripts/demo.sh
@@ -27,24 +27,25 @@ pause
 
 step "Seeding 10 pending jobs into DocumentDB"
 kubectl delete job seed-pending-jobs -n "$APP_NAMESPACE" --ignore-not-found=true 2>/dev/null
-kubectl apply -f "${MANIFESTS_DIR}/seed-jobs.yaml"
+kubectl apply -n "$APP_NAMESPACE" -f "${MANIFESTS_DIR}/seed-jobs.yaml"
 kubectl wait --for=condition=complete job/seed-pending-jobs -n "$APP_NAMESPACE" --timeout=120s 2>/dev/null || true
 kubectl logs job/seed-pending-jobs -n "$APP_NAMESPACE" 2>/dev/null || true
 
 step "Watching pods scale up (Ctrl+C to continue)"
 log "KEDA polls every 5 seconds. Worker pods should appear within 15-30 seconds."
-timeout 60 kubectl get pods -n "$APP_NAMESPACE" -w 2>/dev/null || true
+# Use perl-based timeout for macOS compatibility (coreutils timeout not available by default)
+perl -e 'alarm 60; exec @ARGV' kubectl get pods -n "$APP_NAMESPACE" -w 2>/dev/null || true
 
 pause
 
 step "Draining all pending jobs (marking as completed)"
 kubectl delete job drain-pending-jobs -n "$APP_NAMESPACE" --ignore-not-found=true 2>/dev/null
-kubectl apply -f "${MANIFESTS_DIR}/drain-jobs.yaml"
+kubectl apply -n "$APP_NAMESPACE" -f "${MANIFESTS_DIR}/drain-jobs.yaml"
 kubectl wait --for=condition=complete job/drain-pending-jobs -n "$APP_NAMESPACE" --timeout=120s 2>/dev/null || true
 kubectl logs job/drain-pending-jobs -n "$APP_NAMESPACE" 2>/dev/null || true
 
 step "Watching pods scale down (cooldown: 30 seconds)"
-timeout 90 kubectl get pods -n "$APP_NAMESPACE" -w 2>/dev/null || true
+perl -e 'alarm 90; exec @ARGV' kubectl get pods -n "$APP_NAMESPACE" -w 2>/dev/null || true
 
 step "Final state"
 kubectl get scaledobject,hpa -n "$APP_NAMESPACE" 2>/dev/null || true

--- a/documentdb-playground/keda-autoscaling/scripts/setup.sh
+++ b/documentdb-playground/keda-autoscaling/scripts/setup.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+DOCUMENTDB_NAMESPACE="${DOCUMENTDB_NAMESPACE:-documentdb-ns}"
+DOCUMENTDB_NAME="${DOCUMENTDB_NAME:-keda-demo}"
+DOCUMENTDB_SECRET="${DOCUMENTDB_SECRET:-documentdb-credentials}"
+APP_NAMESPACE="${APP_NAMESPACE:-app}"
+KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
+KEDA_VERSION="${KEDA_VERSION:-2.17.0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFESTS_DIR="${SCRIPT_DIR}/../manifests"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log()   { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+check_prerequisites() {
+    log "Checking prerequisites..."
+    local missing=0
+
+    for cmd in kubectl helm; do
+        if ! command -v "$cmd" &>/dev/null; then
+            error "$cmd is required but not installed"
+            missing=1
+        fi
+    done
+
+    if ! command -v mongosh &>/dev/null; then
+        warn "mongosh not found — seed/drain jobs run inside the Kubernetes cluster, so this is optional for local debugging"
+    fi
+
+    if ! kubectl cluster-info &>/dev/null; then
+        error "Cannot connect to a Kubernetes cluster. Ensure your kubeconfig is set up."
+        exit 1
+    fi
+
+    if [ "$missing" -eq 1 ]; then
+        exit 1
+    fi
+
+    log "Prerequisites OK"
+}
+
+install_keda() {
+    log "Installing KEDA ${KEDA_VERSION}..."
+
+    if helm list -n "$KEDA_NAMESPACE" 2>/dev/null | grep -q keda; then
+        warn "KEDA is already installed in namespace ${KEDA_NAMESPACE}. Skipping."
+    else
+        helm repo add kedacore https://kedacore.github.io/charts 2>/dev/null || true
+        helm repo update kedacore
+
+        helm install keda kedacore/keda \
+            --namespace "$KEDA_NAMESPACE" \
+            --create-namespace \
+            --version "$KEDA_VERSION" \
+            --wait \
+            --timeout 120s
+    fi
+
+    log "Waiting for KEDA operator to be ready..."
+    kubectl wait --for=condition=available deployment/keda-operator \
+        -n "$KEDA_NAMESPACE" --timeout=120s
+
+    log "KEDA is ready"
+}
+
+deploy_documentdb() {
+    log "Deploying DocumentDB instance '${DOCUMENTDB_NAME}'..."
+
+    kubectl create namespace "$DOCUMENTDB_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+    if kubectl get secret "$DOCUMENTDB_SECRET" -n "$DOCUMENTDB_NAMESPACE" &>/dev/null; then
+        warn "Credentials secret already exists. Skipping."
+    else
+        kubectl create secret generic "$DOCUMENTDB_SECRET" \
+            --namespace "$DOCUMENTDB_NAMESPACE" \
+            --from-literal=username=docdbadmin \
+            --from-literal=password='KedaDemo2024!'
+    fi
+
+    kubectl apply -f "${MANIFESTS_DIR}/documentdb-instance.yaml"
+
+    wait_for_documentdb
+}
+
+wait_for_documentdb() {
+    local timeout=300
+    local interval=10
+    local elapsed=0
+    local svc_name="documentdb-service-${DOCUMENTDB_NAME}"
+
+    log "Waiting for DocumentDB instance to be ready (timeout: ${timeout}s)..."
+
+    while [ "$elapsed" -lt "$timeout" ]; do
+        local ready_pods
+        ready_pods=$(kubectl get pods -n "$DOCUMENTDB_NAMESPACE" \
+            -l "documentdb.io/cluster=${DOCUMENTDB_NAME}" \
+            --field-selector=status.phase=Running \
+            -o name 2>/dev/null | wc -l | tr -d ' ')
+
+        if [ "$ready_pods" -ge 1 ]; then
+            if kubectl get svc "$svc_name" -n "$DOCUMENTDB_NAMESPACE" &>/dev/null; then
+                log "DocumentDB instance is ready (${ready_pods} pod(s) running, service exists)"
+                return 0
+            fi
+        fi
+
+        echo -n "."
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+    done
+
+    echo ""
+    error "Timed out waiting for DocumentDB instance after ${timeout}s"
+    error "Check pods: kubectl get pods -n ${DOCUMENTDB_NAMESPACE}"
+    error "Check events: kubectl get events -n ${DOCUMENTDB_NAMESPACE} --sort-by=.lastTimestamp"
+    exit 1
+}
+
+create_keda_connection_secret() {
+    log "Creating KEDA connection secrets..."
+
+    local user pass conn_string svc_name
+    user=$(kubectl get secret "$DOCUMENTDB_SECRET" -n "$DOCUMENTDB_NAMESPACE" -o jsonpath='{.data.username}' | base64 -d)
+    pass=$(kubectl get secret "$DOCUMENTDB_SECRET" -n "$DOCUMENTDB_NAMESPACE" -o jsonpath='{.data.password}' | base64 -d)
+    svc_name="documentdb-service-${DOCUMENTDB_NAME}.${DOCUMENTDB_NAMESPACE}.svc.cluster.local"
+
+    conn_string="mongodb://${user}:${pass}@${svc_name}:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
+
+    # Create in keda namespace (for ClusterTriggerAuthentication)
+    kubectl create secret generic documentdb-keda-connection \
+        --namespace "$KEDA_NAMESPACE" \
+        --from-literal=connectionString="$conn_string" \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+    # Create in app namespace (for seed/drain jobs)
+    kubectl create secret generic documentdb-keda-connection \
+        --namespace "$APP_NAMESPACE" \
+        --from-literal=connectionString="$conn_string" \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+    log "Connection secrets created in ${KEDA_NAMESPACE} and ${APP_NAMESPACE} namespaces"
+}
+
+deploy_keda_resources() {
+    log "Deploying KEDA resources..."
+
+    kubectl create namespace "$APP_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+    create_keda_connection_secret
+
+    kubectl apply -f "${MANIFESTS_DIR}/keda-trigger-auth.yaml"
+    kubectl apply -f "${MANIFESTS_DIR}/job-worker.yaml"
+    kubectl apply -f "${MANIFESTS_DIR}/keda-scaled-object.yaml"
+
+    log "KEDA resources deployed"
+    kubectl get scaledobject -n "$APP_NAMESPACE" 2>/dev/null || true
+}
+
+seed_test_data() {
+    log "Seeding test data (10 pending jobs)..."
+
+    # Delete previous seed job if it exists
+    kubectl delete job seed-pending-jobs -n "$APP_NAMESPACE" --ignore-not-found=true
+
+    kubectl apply -f "${MANIFESTS_DIR}/seed-jobs.yaml"
+
+    log "Waiting for seed job to complete..."
+    if kubectl wait --for=condition=complete job/seed-pending-jobs \
+        -n "$APP_NAMESPACE" --timeout=120s 2>/dev/null; then
+        log "Seed job completed"
+        kubectl logs job/seed-pending-jobs -n "$APP_NAMESPACE" 2>/dev/null || true
+    else
+        warn "Seed job did not complete within timeout. Check logs:"
+        warn "  kubectl logs job/seed-pending-jobs -n ${APP_NAMESPACE}"
+    fi
+}
+
+main() {
+    echo ""
+    echo "============================================="
+    echo "  KEDA + DocumentDB Autoscaling Playground"
+    echo "============================================="
+    echo ""
+
+    check_prerequisites
+    install_keda
+    deploy_documentdb
+    deploy_keda_resources
+    seed_test_data
+
+    echo ""
+    log "Setup complete! KEDA is now monitoring DocumentDB for pending jobs."
+    echo ""
+    echo "  Verify autoscaling:"
+    echo "    kubectl get scaledobject -n ${APP_NAMESPACE}"
+    echo "    kubectl get hpa -n ${APP_NAMESPACE}"
+    echo "    kubectl get pods -n ${APP_NAMESPACE} -w"
+    echo ""
+    echo "  Add more pending jobs:"
+    echo "    kubectl delete job seed-pending-jobs -n ${APP_NAMESPACE} --ignore-not-found"
+    echo "    kubectl apply -f ${MANIFESTS_DIR}/seed-jobs.yaml"
+    echo ""
+    echo "  Drain all pending jobs (scale back to 0):"
+    echo "    kubectl delete job drain-pending-jobs -n ${APP_NAMESPACE} --ignore-not-found"
+    echo "    kubectl apply -f ${MANIFESTS_DIR}/drain-jobs.yaml"
+    echo ""
+    echo "  Tear down:"
+    echo "    ./scripts/teardown.sh"
+    echo ""
+}
+
+main "$@"

--- a/documentdb-playground/keda-autoscaling/scripts/setup.sh
+++ b/documentdb-playground/keda-autoscaling/scripts/setup.sh
@@ -144,11 +144,26 @@ create_keda_connection_secret() {
         exit 1
     fi
 
-    conn_string=$(eval echo "$raw_conn")
+    conn_string=$(eval "echo \"$raw_conn\"")
 
     # KEDA's Go MongoDB driver requires tlsInsecure=true (not tlsAllowInvalidCertificates)
     # for skipping both certificate AND hostname verification with self-signed certs.
     conn_string=$(echo "$conn_string" | sed 's/tlsAllowInvalidCertificates=true/tlsInsecure=true/g')
+
+    # Remove replicaSet parameter — KEDA's Go driver fails topology negotiation
+    # with DocumentDB's synthetic replica set when replicaSet is specified alongside
+    # directConnection=true.
+    conn_string=$(echo "$conn_string" | sed 's/[&?]replicaSet=rs0//g')
+
+    # Replace ClusterIP with DNS name for cross-namespace resolution.
+    # The status.connectionString uses a ClusterIP that may not resolve from
+    # other namespaces. The DNS name is stable and always works.
+    local svc_name="documentdb-service-${DOCUMENTDB_NAME}.${DOCUMENTDB_NAMESPACE}.svc.cluster.local"
+    local svc_ip
+    svc_ip=$(kubectl get svc "documentdb-service-${DOCUMENTDB_NAME}" -n "$DOCUMENTDB_NAMESPACE"         -o jsonpath='{.spec.clusterIP}' 2>/dev/null) || true
+    if [ -n "$svc_ip" ]; then
+        conn_string=$(echo "$conn_string" | sed "s/$svc_ip/$svc_name/g")
+    fi
 
     # Create in keda namespace (for ClusterTriggerAuthentication)
     kubectl create secret generic documentdb-keda-connection \

--- a/documentdb-playground/keda-autoscaling/scripts/setup.sh
+++ b/documentdb-playground/keda-autoscaling/scripts/setup.sh
@@ -133,7 +133,7 @@ create_keda_connection_secret() {
     pass=$(kubectl get secret "$DOCUMENTDB_SECRET" -n "$DOCUMENTDB_NAMESPACE" -o jsonpath='{.data.password}' | base64 -d)
     svc_name="documentdb-service-${DOCUMENTDB_NAME}.${DOCUMENTDB_NAMESPACE}.svc.cluster.local"
 
-    conn_string="mongodb://${user}:${pass}@${svc_name}:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
+    conn_string="mongodb://${user}:${pass}@${svc_name}:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true"
 
     # Create in keda namespace (for ClusterTriggerAuthentication)
     kubectl create secret generic documentdb-keda-connection \

--- a/documentdb-playground/keda-autoscaling/scripts/setup.sh
+++ b/documentdb-playground/keda-autoscaling/scripts/setup.sh
@@ -6,7 +6,7 @@ DOCUMENTDB_NAMESPACE="${DOCUMENTDB_NAMESPACE:-documentdb-ns}"
 DOCUMENTDB_NAME="${DOCUMENTDB_NAME:-keda-demo}"
 DOCUMENTDB_SECRET="${DOCUMENTDB_SECRET:-documentdb-credentials}"
 DOCUMENTDB_USER="${DOCUMENTDB_USER:-docdbadmin}"
-DOCUMENTDB_PASS="${DOCUMENTDB_PASS:-KedaDemo2024!}"
+DOCUMENTDB_PASS="${DOCUMENTDB_PASS:-$(openssl rand -base64 16 | tr -d '/+=' | head -c 20)}"
 APP_NAMESPACE="${APP_NAMESPACE:-app}"
 KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
 KEDA_VERSION="${KEDA_VERSION:-2.17.0}"
@@ -88,7 +88,10 @@ deploy_documentdb() {
             --from-literal=password="$DOCUMENTDB_PASS"
     fi
 
-    kubectl apply -f "${MANIFESTS_DIR}/documentdb-instance.yaml"
+    sed -e "s/DOCUMENTDB_NAME_PLACEHOLDER/$DOCUMENTDB_NAME/g" \
+        -e "s/DOCUMENTDB_SECRET_PLACEHOLDER/$DOCUMENTDB_SECRET/g" \
+        "${MANIFESTS_DIR}/documentdb-instance.yaml" \
+        | kubectl apply -n "$DOCUMENTDB_NAMESPACE" -f -
 
     wait_for_documentdb
 }
@@ -188,8 +191,8 @@ deploy_keda_resources() {
     create_keda_connection_secret
 
     kubectl apply -f "${MANIFESTS_DIR}/keda-trigger-auth.yaml"
-    kubectl apply -f "${MANIFESTS_DIR}/job-worker.yaml"
-    kubectl apply -f "${MANIFESTS_DIR}/keda-scaled-object.yaml"
+    kubectl apply -n "$APP_NAMESPACE" -f "${MANIFESTS_DIR}/job-worker.yaml"
+    kubectl apply -n "$APP_NAMESPACE" -f "${MANIFESTS_DIR}/keda-scaled-object.yaml"
 
     log "KEDA resources deployed"
     kubectl get scaledobject -n "$APP_NAMESPACE" 2>/dev/null || true
@@ -201,7 +204,7 @@ seed_test_data() {
     # Delete previous seed job if it exists
     kubectl delete job seed-pending-jobs -n "$APP_NAMESPACE" --ignore-not-found=true
 
-    kubectl apply -f "${MANIFESTS_DIR}/seed-jobs.yaml"
+    kubectl apply -n "$APP_NAMESPACE" -f "${MANIFESTS_DIR}/seed-jobs.yaml"
 
     log "Waiting for seed job to complete..."
     if kubectl wait --for=condition=complete job/seed-pending-jobs \
@@ -237,11 +240,11 @@ main() {
     echo ""
     echo "  Add more pending jobs:"
     echo "    kubectl delete job seed-pending-jobs -n ${APP_NAMESPACE} --ignore-not-found"
-    echo "    kubectl apply -f ${MANIFESTS_DIR}/seed-jobs.yaml"
+    echo "    kubectl apply -n ${APP_NAMESPACE} -f ${MANIFESTS_DIR}/seed-jobs.yaml"
     echo ""
     echo "  Drain all pending jobs (scale back to 0):"
     echo "    kubectl delete job drain-pending-jobs -n ${APP_NAMESPACE} --ignore-not-found"
-    echo "    kubectl apply -f ${MANIFESTS_DIR}/drain-jobs.yaml"
+    echo "    kubectl apply -n ${APP_NAMESPACE} -f ${MANIFESTS_DIR}/drain-jobs.yaml"
     echo ""
     echo "  Tear down:"
     echo "    ./scripts/teardown.sh"

--- a/documentdb-playground/keda-autoscaling/scripts/setup.sh
+++ b/documentdb-playground/keda-autoscaling/scripts/setup.sh
@@ -1,10 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Configuration
 DOCUMENTDB_NAMESPACE="${DOCUMENTDB_NAMESPACE:-documentdb-ns}"
 DOCUMENTDB_NAME="${DOCUMENTDB_NAME:-keda-demo}"
 DOCUMENTDB_SECRET="${DOCUMENTDB_SECRET:-documentdb-credentials}"
+DOCUMENTDB_USER="${DOCUMENTDB_USER:-docdbadmin}"
+DOCUMENTDB_PASS="${DOCUMENTDB_PASS:-KedaDemo2024!}"
 APP_NAMESPACE="${APP_NAMESPACE:-app}"
 KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
 KEDA_VERSION="${KEDA_VERSION:-2.17.0}"
@@ -82,8 +84,8 @@ deploy_documentdb() {
     else
         kubectl create secret generic "$DOCUMENTDB_SECRET" \
             --namespace "$DOCUMENTDB_NAMESPACE" \
-            --from-literal=username=docdbadmin \
-            --from-literal=password='KedaDemo2024!'
+            --from-literal=username="$DOCUMENTDB_USER" \
+            --from-literal=password="$DOCUMENTDB_PASS"
     fi
 
     kubectl apply -f "${MANIFESTS_DIR}/documentdb-instance.yaml"
@@ -128,12 +130,25 @@ wait_for_documentdb() {
 create_keda_connection_secret() {
     log "Creating KEDA connection secrets..."
 
-    local user pass conn_string svc_name
-    user=$(kubectl get secret "$DOCUMENTDB_SECRET" -n "$DOCUMENTDB_NAMESPACE" -o jsonpath='{.data.username}' | base64 -d)
-    pass=$(kubectl get secret "$DOCUMENTDB_SECRET" -n "$DOCUMENTDB_NAMESPACE" -o jsonpath='{.data.password}' | base64 -d)
-    svc_name="documentdb-service-${DOCUMENTDB_NAME}.${DOCUMENTDB_NAMESPACE}.svc.cluster.local"
+    local raw_conn conn_string
 
-    conn_string="mongodb://${user}:${pass}@${svc_name}:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true"
+    # Get connection string from DocumentDB resource status.
+    # The status field contains embedded kubectl commands for credentials
+    # that are resolved via eval.
+    raw_conn=$(kubectl get documentdb "$DOCUMENTDB_NAME" -n "$DOCUMENTDB_NAMESPACE" \
+        -o jsonpath='{.status.connectionString}' 2>/dev/null) || true
+
+    if [ -z "$raw_conn" ]; then
+        error "Could not read status.connectionString from DocumentDB resource."
+        error "Ensure the DocumentDB instance is ready: kubectl get documentdb -n $DOCUMENTDB_NAMESPACE"
+        exit 1
+    fi
+
+    conn_string=$(eval echo "$raw_conn")
+
+    # KEDA's Go MongoDB driver requires tlsInsecure=true (not tlsAllowInvalidCertificates)
+    # for skipping both certificate AND hostname verification with self-signed certs.
+    conn_string=$(echo "$conn_string" | sed 's/tlsAllowInvalidCertificates=true/tlsInsecure=true/g')
 
     # Create in keda namespace (for ClusterTriggerAuthentication)
     kubectl create secret generic documentdb-keda-connection \

--- a/documentdb-playground/keda-autoscaling/scripts/teardown.sh
+++ b/documentdb-playground/keda-autoscaling/scripts/teardown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Configuration

--- a/documentdb-playground/keda-autoscaling/scripts/teardown.sh
+++ b/documentdb-playground/keda-autoscaling/scripts/teardown.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+DOCUMENTDB_NAMESPACE="${DOCUMENTDB_NAMESPACE:-documentdb-ns}"
+DOCUMENTDB_NAME="${DOCUMENTDB_NAME:-keda-demo}"
+APP_NAMESPACE="${APP_NAMESPACE:-app}"
+KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log()   { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+
+UNINSTALL_KEDA=false
+DELETE_DOCUMENTDB=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --uninstall-keda)
+            UNINSTALL_KEDA=true
+            shift
+            ;;
+        --delete-documentdb)
+            DELETE_DOCUMENTDB=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --uninstall-keda       Also uninstall KEDA Helm release"
+            echo "  --delete-documentdb    Also delete the DocumentDB instance"
+            echo "  -h, --help             Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+echo ""
+echo "============================================="
+echo "  KEDA + DocumentDB Playground Teardown"
+echo "============================================="
+echo ""
+
+log "Removing KEDA demo resources..."
+
+# Delete ScaledObject first (avoids KEDA errors when HPA targets disappear)
+kubectl delete scaledobject documentdb-worker-scaler -n "$APP_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+kubectl delete clustertriggerauthentication documentdb-trigger-auth --ignore-not-found=true 2>/dev/null || true
+
+# Delete jobs and worker
+kubectl delete job seed-pending-jobs drain-pending-jobs -n "$APP_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+kubectl delete deployment job-worker -n "$APP_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+
+# Delete connection secrets
+kubectl delete secret documentdb-keda-connection -n "$APP_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+kubectl delete secret documentdb-keda-connection -n "$KEDA_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+
+# Delete app namespace
+if kubectl get namespace "$APP_NAMESPACE" &>/dev/null; then
+    log "Deleting namespace ${APP_NAMESPACE}..."
+    kubectl delete namespace "$APP_NAMESPACE" --wait=false 2>/dev/null || true
+fi
+
+if [ "$UNINSTALL_KEDA" = true ]; then
+    log "Uninstalling KEDA..."
+    helm uninstall keda -n "$KEDA_NAMESPACE" 2>/dev/null || warn "KEDA not found or already removed"
+    kubectl delete namespace "$KEDA_NAMESPACE" --wait=false 2>/dev/null || true
+fi
+
+if [ "$DELETE_DOCUMENTDB" = true ]; then
+    log "Deleting DocumentDB instance..."
+    kubectl delete documentdb "$DOCUMENTDB_NAME" -n "$DOCUMENTDB_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+    kubectl delete secret documentdb-credentials -n "$DOCUMENTDB_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+fi
+
+log "Teardown complete"

--- a/documentdb-playground/keda-autoscaling/scripts/teardown.sh
+++ b/documentdb-playground/keda-autoscaling/scripts/teardown.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Configuration
 DOCUMENTDB_NAMESPACE="${DOCUMENTDB_NAMESPACE:-documentdb-ns}"
 DOCUMENTDB_NAME="${DOCUMENTDB_NAME:-keda-demo}"
+DOCUMENTDB_SECRET="${DOCUMENTDB_SECRET:-documentdb-credentials}"
 APP_NAMESPACE="${APP_NAMESPACE:-app}"
 KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
 
@@ -80,7 +81,7 @@ fi
 if [ "$DELETE_DOCUMENTDB" = true ]; then
     log "Deleting DocumentDB instance..."
     kubectl delete documentdb "$DOCUMENTDB_NAME" -n "$DOCUMENTDB_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
-    kubectl delete secret documentdb-credentials -n "$DOCUMENTDB_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+    kubectl delete secret "$DOCUMENTDB_SECRET" -n "$DOCUMENTDB_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
 fi
 
 log "Teardown complete"


### PR DESCRIPTION
## Summary

Adds a self-contained playground demonstrating [KEDA](https://keda.sh/) event-driven autoscaling with DocumentDB. KEDA's [MongoDB scaler](https://keda.sh/docs/2.19/scalers/mongodb/) polls a DocumentDB collection for pending jobs and automatically scales a worker Deployment from 0 to N pods.

**E2E tested on Kind** — full autoscaling cycle verified: 0 → 2 pods on job insert, 2 → 0 pods after drain.

## New files (10)

| File | Description |
|------|-------------|
| `manifests/documentdb-instance.yaml` | DocumentDB CR for Kind (1 node, 2Gi, ClusterIP) |
| `manifests/keda-trigger-auth.yaml` | `ClusterTriggerAuthentication` with DocumentDB connection string |
| `manifests/keda-scaled-object.yaml` | `ScaledObject` with MongoDB trigger on `appdb.jobs` |
| `manifests/job-worker.yaml` | Worker Deployment (scaled by KEDA, starts at 0) |
| `manifests/seed-jobs.yaml` | Job that inserts 10 pending documents |
| `manifests/drain-jobs.yaml` | Job that marks all pending documents as completed |
| `scripts/setup.sh` | Installs KEDA, deploys DocumentDB, configures demo |
| `scripts/teardown.sh` | Cleanup with optional KEDA/DocumentDB removal |
| `scripts/demo.sh` | Interactive walkthrough of scaling behavior |
| `README.md` | Quick start, connection guide, gotchas |

## Key findings from E2E testing

| Finding | Detail |
|---------|--------|
| **`tlsInsecure=true` required** | KEDA's Go MongoDB driver needs `tlsInsecure=true` (not `tlsAllowInvalidCertificates=true`) to skip both cert AND hostname verification with self-signed certs |
| **`directConnection=true` works** | KEDA passes this through correctly |
| **`SCRAM-SHA-256` works** | Standard MongoDB auth handshake compatible |
| **Port 10260** | Must be explicit in connection string |
| **`exposeViaService` required** | DocumentDB CR needs `exposeViaService.serviceType: ClusterIP` for the gateway service to be created |

## Test results

```
Seed 10 pending jobs → ScaledObject ACTIVE: True → HPA TARGETS: 5/5 → 2 worker pods
Drain all jobs       → ScaledObject ACTIVE: False → HPA TARGETS: 0/5 → 0 worker pods (after 30s cooldown)
```