### PR TITLE
docs: add containerd runtime requirement for minikube in quickstart

### DIFF
--- a/docs/operator-public-documentation/preview/getting-started/before-you-start.md
+++ b/docs/operator-public-documentation/preview/getting-started/before-you-start.md
@@ -24,8 +24,8 @@ Before installing the DocumentDB Kubernetes Operator, ensure you have the follow
 | **Helm** | 3.x | Package manager for Kubernetes | [Install Helm](https://helm.sh/docs/intro/install/) |
 | **cert-manager** | 1.19+ | TLS certificate management | [Install cert-manager](https://cert-manager.io/docs/installation/) |
 
-!!! warning "Kubernetes 1.35+ Required"
-    The operator requires Kubernetes 1.35 or later because it uses the [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature (GA in Kubernetes 1.35) to mount the DocumentDB extension into PostgreSQL pods.
+!!! warning "Kubernetes 1.35+ with containerd or CRI-O Required"
+    The operator requires Kubernetes 1.35 or later because it uses the [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature (GA in Kubernetes 1.35) to mount the DocumentDB extension into PostgreSQL pods. The cluster must use a **containerd** or **CRI-O** container runtime — Docker does not support ImageVolumes.
 
 ### Optional components
 
@@ -48,11 +48,11 @@ The operator runs on any conformant Kubernetes distribution (1.35+). Choose base
     - **[minikube](https://minikube.sigs.k8s.io/)** - Local Kubernetes cluster
     
     ```bash
-    # Kind (recommended)
+    # Kind (recommended — uses containerd by default)
     kind create cluster --image kindest/node:v1.35.0
     
-    # Minikube
-    minikube start --kubernetes-version=v1.35.0
+    # Minikube (--container-runtime=containerd is required for ImageVolume support)
+    minikube start --kubernetes-version=v1.35.0 --container-runtime=containerd
     ```
 
 === "Cloud Production"

--- a/docs/operator-public-documentation/preview/index.md
+++ b/docs/operator-public-documentation/preview/index.md
@@ -17,7 +17,7 @@ Follow these steps to install the operator, deploy a DocumentDB cluster, and con
 
 - [Helm](https://helm.sh/docs/intro/install/) installed.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/) installed.
-- A **Kubernetes 1.35+** cluster. The operator uses the [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature (GA in K8s 1.35) to mount the DocumentDB extension. A local cluster such as [minikube](https://minikube.sigs.k8s.io/docs/start/) or [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (v0.31+) works for this quickstart.
+- A **Kubernetes 1.35+** cluster with a **containerd** or **CRI-O** container runtime. The operator uses the [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature (GA in K8s 1.35) to mount the DocumentDB extension, which is not supported by the Docker container runtime. A local cluster such as [minikube](https://minikube.sigs.k8s.io/docs/start/) or [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (v0.31+) works for this quickstart.
 - [mongosh](https://www.mongodb.com/docs/mongodb-shell/install/) installed to connect to the DocumentDB cluster.
 
 ### Start a local Kubernetes cluster
@@ -25,10 +25,13 @@ Follow these steps to install the operator, deploy a DocumentDB cluster, and con
 If you're using `minikube`:
 
 ```sh
-minikube start --kubernetes-version=v1.35.0
+minikube start --kubernetes-version=v1.35.0 --container-runtime=containerd
 ```
 
-If you are using `kind` (v0.31+), use the following command:
+!!! important
+    The `--container-runtime=containerd` flag is required. Minikube defaults to Docker, which does not support ImageVolumes. Without this flag, pods will fail with `CreateContainerError: invalid mount config for type "bind": field Source must not be empty`.
+
+If you are using `kind` (v0.31+), use the following command (kind uses containerd by default):
 
 ```sh
 kind create cluster --image kindest/node:v1.35.0


### PR DESCRIPTION
## Problem

Users following the quickstart guide with minikube hit `Init:CreateContainerError` when deploying a DocumentDB cluster:

```
Error response from daemon: invalid mount config for type "bind": field Source must not be empty
```

**Root cause:** The operator uses Kubernetes [ImageVolumes](https://kubernetes.io/docs/concepts/storage/volumes/#image) (GA in K8s 1.35) to mount the DocumentDB extension. Minikube defaults to Docker as its container runtime, and Docker does not support ImageVolumes — causing the bind mount source to be empty.

## Fix

Add `--container-runtime=containerd` to all minikube commands in the documentation and add callouts explaining the requirement.

### Files changed
- `docs/operator-public-documentation/preview/index.md` — Quickstart page (prerequisites + minikube command + admonition)
- `docs/operator-public-documentation/preview/getting-started/before-you-start.md` — Before You Start page (warning box + minikube command)

## Verification

Tested on an Azure VM (Ubuntu 24.04, Standard_D4s_v3):

| Scenario | Command | Result |
|----------|---------|--------|
| Docker runtime (default) | `minikube start --kubernetes-version=v1.35.0` | ❌ `Init:CreateContainerError` — reproduced |
| containerd runtime | `minikube start --kubernetes-version=v1.35.0 --container-runtime=containerd` | ✅ `2/2 Running` |
