### PR TITLE
refactor: consolidate CNPG Cluster spec mutations into SyncCnpgCluster

### DIFF
--- a/operator/src/internal/cnpg/cnpg_patch.go
+++ b/operator/src/internal/cnpg/cnpg_patch.go
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package cnpg
+
+// JSONPatch represents a single JSON Patch (RFC 6902) operation.
+type JSONPatch struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+const (
+	// JSON Patch operations
+	PatchOpReplace = "replace"
+	PatchOpAdd     = "add"
+	PatchOpRemove  = "remove"
+
+	// JSON Patch paths — replication
+	PatchPathReplicaCluster    = "/spec/replica"
+	PatchPathPostgresConfig    = "/spec/postgresql"
+	PatchPathPostgresConfigSyn = "/spec/postgresql/synchronous"
+	PatchPathInstances         = "/spec/instances"
+	PatchPathPlugins           = "/spec/plugins"
+	PatchPathReplicationSlots  = "/spec/replicationSlots"
+	PatchPathExternalClusters  = "/spec/externalClusters"
+	PatchPathManagedServices   = "/spec/managed/services/additional"
+	PatchPathSynchronous       = "/spec/postgresql/synchronous"
+	PatchPathBootstrap         = "/spec/bootstrap"
+
+	// JSON Patch path format strings for image upgrades (require fmt.Sprintf with index)
+	PatchPathExtensionImageFmt     = "/spec/postgresql/extensions/%d/image/reference"
+	PatchPathPluginGatewayImageFmt = "/spec/plugins/%d/parameters/gatewayImage"
+
+	// JSON Patch path for restart annotation.
+	// The '/' in the annotation key is escaped as '~1' per RFC 6901 (JSON Pointer).
+	PatchPathRestartAnnotation = "/metadata/annotations/kubectl.kubernetes.io~1restartedAt"
+)

--- a/operator/src/internal/cnpg/cnpg_sync.go
+++ b/operator/src/internal/cnpg/cnpg_sync.go
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package cnpg
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// SyncCnpgCluster compares the current and desired CNPG Cluster specs and patches
+// all fields in a single atomic JSON Patch operation. This is the single entry point
+// for ALL CNPG spec mutations (images + plugin params + replication).
+//
+// Only mutable plugin parameters are synced: gatewayImage and gatewayTLSSecret.
+// Other parameters (e.g., documentDbCredentialSecret) are set at cluster creation
+// and do not change during the lifecycle of a DocumentDB resource.
+//
+// extraOps are additional patch operations (e.g., replication changes) to include
+// in the same atomic patch.
+func SyncCnpgCluster(
+	ctx context.Context,
+	c client.Client,
+	current, desired *cnpgv1.Cluster,
+	extraOps []JSONPatch,
+) error {
+	logger := log.FromContext(ctx)
+
+	var patchOps []JSONPatch
+	extensionUpdated := false
+	gatewayUpdated := false
+
+	// Extension image
+	currentExtIndex, currentExtImage := findExtensionImage(current)
+	_, desiredExtImage := findExtensionImage(desired)
+	if currentExtImage != desiredExtImage {
+		if currentExtIndex == -1 {
+			return fmt.Errorf("documentdb extension not found in current CNPG cluster spec")
+		}
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  fmt.Sprintf(PatchPathExtensionImageFmt, currentExtIndex),
+			Value: desiredExtImage,
+		})
+		extensionUpdated = true
+	}
+
+	// Gateway image and plugin parameters share the same plugin lookup
+	pluginParamsChanged := false
+	if len(desired.Spec.Plugins) > 0 {
+		desiredPlugin := desired.Spec.Plugins[0]
+		pluginIdx, currentPlugin := findPlugin(current, desiredPlugin.Name)
+		if pluginIdx != -1 {
+			// Gateway image
+			desiredGwImage := getParam(desiredPlugin.Parameters, "gatewayImage")
+			currentGwImage := getParam(currentPlugin.Parameters, "gatewayImage")
+			if desiredGwImage != "" && currentGwImage != desiredGwImage {
+				patchOps = append(patchOps, JSONPatch{
+					Op:    PatchOpReplace,
+					Path:  fmt.Sprintf(PatchPathPluginGatewayImageFmt, pluginIdx),
+					Value: desiredGwImage,
+				})
+				gatewayUpdated = true
+			}
+
+			// Ensure plugin is enabled
+			if currentPlugin.Enabled == nil || !*currentPlugin.Enabled {
+				patchOps = append(patchOps, JSONPatch{
+					Op:    PatchOpReplace,
+					Path:  fmt.Sprintf("/spec/plugins/%d/enabled", pluginIdx),
+					Value: true,
+				})
+				pluginParamsChanged = true
+			}
+
+			// TLS secret (only synced when BuildDesiredCnpgCluster sets it, i.e. TLS is ready)
+			desiredTLS := getParam(desiredPlugin.Parameters, "gatewayTLSSecret")
+			currentTLS := getParam(currentPlugin.Parameters, "gatewayTLSSecret")
+			if desiredTLS != "" && currentTLS != desiredTLS {
+				patchOps = append(patchOps, JSONPatch{
+					Op:    PatchOpReplace,
+					Path:  fmt.Sprintf("/spec/plugins/%d/parameters/gatewayTLSSecret", pluginIdx),
+					Value: desiredTLS,
+				})
+				pluginParamsChanged = true
+			}
+		}
+	}
+
+	// Extra operations (e.g., replication changes)
+	patchOps = append(patchOps, extraOps...)
+
+	// CNPG auto-restarts pods when extension image changes (ImageVolume PodSpec divergence),
+	// but NOT for plugin parameter or gateway-only changes. Include a restart annotation
+	// in the same atomic patch to avoid partial-apply state where the spec is updated but
+	// the restart annotation is never applied if a subsequent reconcile no-ops the spec diff.
+	needsRestart := !extensionUpdated && (gatewayUpdated || pluginParamsChanged)
+	if needsRestart {
+		// Ensure the annotations map exists before adding a key into it.
+		// JSON Patch "add" requires the parent path to exist.
+		if current.Annotations == nil {
+			patchOps = append(patchOps, JSONPatch{
+				Op:    PatchOpAdd,
+				Path:  "/metadata/annotations",
+				Value: map[string]string{
+					"kubectl.kubernetes.io/restartedAt": time.Now().Format(time.RFC3339Nano),
+				},
+			})
+		} else {
+			patchOps = append(patchOps, JSONPatch{
+				Op:    PatchOpAdd,
+				Path:  PatchPathRestartAnnotation,
+				Value: time.Now().Format(time.RFC3339Nano),
+			})
+		}
+	}
+
+	if len(patchOps) == 0 {
+		return nil
+	}
+
+	// Apply all patches atomically
+	patchBytes, err := json.Marshal(patchOps)
+	if err != nil {
+		return fmt.Errorf("failed to marshal sync patch: %w", err)
+	}
+	if err := c.Patch(ctx, current, client.RawPatch(types.JSONPatchType, patchBytes)); err != nil {
+		return fmt.Errorf("failed to patch CNPG cluster: %w", err)
+	}
+
+	if needsRestart {
+		logger.Info("Added restart annotation for non-extension update", "clusterName", current.Name)
+	}
+
+	return nil
+}
+
+// findExtensionImage returns the index and image reference for the documentdb extension.
+func findExtensionImage(cluster *cnpgv1.Cluster) (int, string) {
+	for i, ext := range cluster.Spec.PostgresConfiguration.Extensions {
+		if ext.Name == "documentdb" {
+			return i, ext.ImageVolumeSource.Reference
+		}
+	}
+	return -1, ""
+}
+
+// findPlugin returns the index and plugin config for a named plugin, or -1 if not found.
+func findPlugin(cluster *cnpgv1.Cluster, name string) (int, *cnpgv1.PluginConfiguration) {
+	for i := range cluster.Spec.Plugins {
+		if cluster.Spec.Plugins[i].Name == name {
+			return i, &cluster.Spec.Plugins[i]
+		}
+	}
+	return -1, nil
+}
+
+// getParam safely retrieves a value from a map, returning "" if the map is nil.
+func getParam(params map[string]string, key string) string {
+	if params == nil {
+		return ""
+	}
+	return params[key]
+}

--- a/operator/src/internal/cnpg/cnpg_sync_test.go
+++ b/operator/src/internal/cnpg/cnpg_sync_test.go
@@ -1,0 +1,326 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package cnpg
+
+import (
+	"context"
+
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	util "github.com/documentdb/documentdb-operator/internal/utils"
+)
+
+func buildFakeClient(objs ...runtime.Object) *fake.ClientBuilder {
+	scheme := runtime.NewScheme()
+	Expect(cnpgv1.AddToScheme(scheme)).To(Succeed())
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if len(objs) > 0 {
+		builder = builder.WithRuntimeObjects(objs...)
+	}
+	return builder
+}
+
+func baseCluster(name, namespace string) *cnpgv1.Cluster {
+	return &cnpgv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: cnpgv1.ClusterSpec{
+			Instances: 1,
+			StorageConfiguration: cnpgv1.StorageConfiguration{
+				Size: "10Gi",
+			},
+			LogLevel:     "info",
+			MaxStopDelay: 30,
+			Affinity:     cnpgv1.AffinityConfiguration{},
+			PostgresConfiguration: cnpgv1.PostgresConfiguration{
+				Extensions: []cnpgv1.ExtensionConfiguration{
+					{
+						Name: "documentdb",
+						ImageVolumeSource: corev1.ImageVolumeSource{
+							Reference: "ghcr.io/documentdb/documentdb:0.109.0",
+						},
+					},
+				},
+				Parameters: map[string]string{
+					"cron.database_name":    "postgres",
+					"max_replication_slots": "10",
+					"max_wal_senders":       "10",
+				},
+			},
+			Plugins: []cnpgv1.PluginConfiguration{
+				{
+					Name:    util.DEFAULT_SIDECAR_INJECTOR_PLUGIN,
+					Enabled: pointer.Bool(true),
+					Parameters: map[string]string{
+						"gatewayImage":               "ghcr.io/documentdb/gateway:0.109.0",
+						"documentDbCredentialSecret": "documentdb-credentials",
+					},
+				},
+			},
+		},
+	}
+}
+
+var _ = Describe("SyncCnpgCluster", func() {
+	const namespace = "test-ns"
+
+	It("does nothing when current matches desired", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("detects extension image changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference = "ghcr.io/documentdb/documentdb:0.110.0"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference).To(Equal("ghcr.io/documentdb/documentdb:0.110.0"))
+	})
+
+	It("detects gateway image changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.110.0"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.Plugins[0].Parameters["gatewayImage"]).To(Equal("ghcr.io/documentdb/gateway:0.110.0"))
+	})
+
+	It("patches plugin parameters (TLS secret sync)", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.Plugins[0].Parameters["gatewayTLSSecret"] = "my-tls-secret"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.Plugins[0].Parameters["gatewayTLSSecret"]).To(Equal("my-tls-secret"))
+
+		// Should also have restart annotation since plugin params changed
+		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+
+	It("re-enables a disabled plugin", func() {
+		current := baseCluster("test-cluster", namespace)
+		current.Spec.Plugins[0].Enabled = pointer.Bool(false)
+		desired := current.DeepCopy()
+		desired.Spec.Plugins[0].Enabled = pointer.Bool(true)
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(*updated.Spec.Plugins[0].Enabled).To(BeTrue())
+		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+
+	It("re-enables a plugin with nil Enabled field", func() {
+		current := baseCluster("test-cluster", namespace)
+		current.Spec.Plugins[0].Enabled = nil
+		desired := current.DeepCopy()
+		desired.Spec.Plugins[0].Enabled = pointer.Bool(true)
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(*updated.Spec.Plugins[0].Enabled).To(BeTrue())
+	})
+
+	It("does not add restart annotation when extension image changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference = "ghcr.io/documentdb/documentdb:0.110.0"
+		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.110.0"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference).To(Equal("ghcr.io/documentdb/documentdb:0.110.0"))
+		Expect(updated.Spec.Plugins[0].Parameters["gatewayImage"]).To(Equal("ghcr.io/documentdb/gateway:0.110.0"))
+		// No restart annotation — CNPG handles restart for extension changes
+		Expect(updated.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+
+	It("applies extra patch operations", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+
+		extraOps := []JSONPatch{
+			{
+				Op:    PatchOpReplace,
+				Path:  "/spec/instances",
+				Value: 3,
+			},
+		}
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, extraOps)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.Instances).To(Equal(3))
+	})
+
+	It("returns error when documentdb extension is not found in current cluster", func() {
+		current := baseCluster("test-cluster", namespace)
+		current.Spec.PostgresConfiguration.Extensions = nil // no extensions
+
+		desired := baseCluster("test-cluster", namespace)
+		desired.Spec.PostgresConfiguration.Extensions = []cnpgv1.ExtensionConfiguration{
+			{
+				Name: "documentdb",
+				ImageVolumeSource: corev1.ImageVolumeSource{
+					Reference: "ghcr.io/documentdb/documentdb:0.110.0",
+				},
+			},
+		}
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("documentdb extension not found"))
+	})
+
+	It("skips plugin sync when desired has no plugins", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.Plugins = nil
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("skips plugin sync when plugin not found in current cluster", func() {
+		current := baseCluster("test-cluster", namespace)
+		current.Spec.Plugins = nil // no plugins in current
+
+		desired := baseCluster("test-cluster", namespace)
+		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.110.0"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("handles gateway and TLS changes together", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.110.0"
+		desired.Spec.Plugins[0].Parameters["gatewayTLSSecret"] = "new-tls-secret"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.Plugins[0].Parameters["gatewayImage"]).To(Equal("ghcr.io/documentdb/gateway:0.110.0"))
+		Expect(updated.Spec.Plugins[0].Parameters["gatewayTLSSecret"]).To(Equal("new-tls-secret"))
+		// Restart annotation because gateway updated (no extension change)
+		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+})
+
+var _ = Describe("Helper functions", func() {
+	It("findExtensionImage returns -1 for cluster without extensions", func() {
+		cluster := &cnpgv1.Cluster{
+			Spec: cnpgv1.ClusterSpec{
+				PostgresConfiguration: cnpgv1.PostgresConfiguration{},
+			},
+		}
+		idx, img := findExtensionImage(cluster)
+		Expect(idx).To(Equal(-1))
+		Expect(img).To(BeEmpty())
+	})
+
+	It("findPlugin returns -1 when plugin not found", func() {
+		cluster := &cnpgv1.Cluster{
+			Spec: cnpgv1.ClusterSpec{
+				Plugins: []cnpgv1.PluginConfiguration{
+					{Name: "other-plugin"},
+				},
+			},
+		}
+		idx, plugin := findPlugin(cluster, "my-plugin")
+		Expect(idx).To(Equal(-1))
+		Expect(plugin).To(BeNil())
+	})
+
+	It("findPlugin returns correct index and plugin", func() {
+		cluster := &cnpgv1.Cluster{
+			Spec: cnpgv1.ClusterSpec{
+				Plugins: []cnpgv1.PluginConfiguration{
+					{Name: "plugin-a"},
+					{Name: "plugin-b"},
+				},
+			},
+		}
+		idx, plugin := findPlugin(cluster, "plugin-b")
+		Expect(idx).To(Equal(1))
+		Expect(plugin).ToNot(BeNil())
+		Expect(plugin.Name).To(Equal("plugin-b"))
+	})
+
+	It("getParam returns empty for nil map", func() {
+		Expect(getParam(nil, "key")).To(BeEmpty())
+	})
+
+	It("getParam returns value for existing key", func() {
+		m := map[string]string{"key": "value"}
+		Expect(getParam(m, "key")).To(Equal("value"))
+	})
+
+	It("getParam returns empty for missing key", func() {
+		m := map[string]string{"other": "value"}
+		Expect(getParam(m, "key")).To(BeEmpty())
+	})
+})

--- a/operator/src/internal/controller/documentdb_controller.go
+++ b/operator/src/internal/controller/documentdb_controller.go
@@ -6,7 +6,6 @@ package controller
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"slices"
 	"strconv"
@@ -186,57 +185,20 @@ func (r *DocumentDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 	}
 
-	// Check if anything has changed in the generated cnpg spec
-	err, requeueTime := r.TryUpdateCluster(ctx, currentCnpgCluster, desiredCnpgCluster, documentdb, replicationContext)
+	// Build replication patch ops (performs side effects: HTTP token reads, service creation).
+	// syncReplicationChanges handles non-replicating cases internally via nil checks.
+	replicationOps, err, requeueTime := r.syncReplicationChanges(ctx, currentCnpgCluster, desiredCnpgCluster, documentdb, replicationContext)
 	if err != nil {
-		logger.Error(err, "Failed to update CNPG Cluster")
+		logger.Error(err, "Failed to build replication patch ops")
 	}
 	if requeueTime > 0 {
 		return ctrl.Result{RequeueAfter: requeueTime}, nil
 	}
 
-	// Sync TLS secret parameter into CNPG Cluster plugin if ready
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: desiredCnpgCluster.Name, Namespace: req.Namespace}, currentCnpgCluster); err == nil {
-		if documentdb.Status.TLS != nil && documentdb.Status.TLS.Ready && documentdb.Status.TLS.SecretName != "" {
-			logger.Info("Syncing TLS secret into CNPG Cluster plugin parameters", "secret", documentdb.Status.TLS.SecretName)
-			updated := false
-			for i := range currentCnpgCluster.Spec.Plugins {
-				p := &currentCnpgCluster.Spec.Plugins[i]
-				if p.Name == desiredCnpgCluster.Spec.Plugins[0].Name { // target our sidecar plugin
-					if p.Enabled == nil || !*p.Enabled {
-						trueVal := true
-						p.Enabled = &trueVal
-						updated = true
-						logger.Info("Enabled sidecar plugin")
-					}
-					if p.Parameters == nil {
-						p.Parameters = map[string]string{}
-					}
-					currentVal := p.Parameters["gatewayTLSSecret"]
-					if currentVal != documentdb.Status.TLS.SecretName {
-						p.Parameters["gatewayTLSSecret"] = documentdb.Status.TLS.SecretName
-						updated = true
-						logger.Info("Updated gatewayTLSSecret parameter", "old", currentVal, "new", documentdb.Status.TLS.SecretName)
-					}
-				}
-			}
-			if updated {
-				if currentCnpgCluster.Annotations == nil {
-					currentCnpgCluster.Annotations = map[string]string{}
-				}
-				// CNPG does not auto-restart pods for plugin parameter changes.
-				// The gatewayTLSSecret is mounted as a volume by the sidecar injector,
-				// so pods must be restarted to pick up the new secret name.
-				// CNPG specifically handles kubectl.kubernetes.io/restartedAt for pod restarts.
-				currentCnpgCluster.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339Nano)
-				if err := r.Client.Update(ctx, currentCnpgCluster); err == nil {
-					logger.Info("Patched CNPG Cluster with TLS settings; requeueing for pod update")
-					return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
-				} else {
-					logger.Error(err, "Failed to update CNPG Cluster with TLS settings")
-				}
-			}
-		}
+	// Sync all CNPG Cluster changes in one atomic patch (images + plugins + replication)
+	if err := cnpg.SyncCnpgCluster(ctx, r.Client, currentCnpgCluster, desiredCnpgCluster, replicationOps); err != nil {
+		logger.Error(err, "Failed to sync CNPG Cluster spec")
+		return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 	}
 
 	if slices.Contains(currentCnpgCluster.Status.InstancesStatus[cnpgv1.PodHealthy], currentCnpgCluster.Status.CurrentPrimary) && replicationContext.IsPrimary() {
@@ -327,9 +289,9 @@ func (r *DocumentDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
-	// Check if documentdb images need to be upgraded (extension + gateway image update, ALTER EXTENSION)
-	if err := r.upgradeDocumentDBIfNeeded(ctx, currentCnpgCluster, desiredCnpgCluster, documentdb); err != nil {
-		logger.Error(err, "Failed to upgrade DocumentDB images")
+	// Check if documentdb extension needs ALTER EXTENSION UPDATE
+	if err := r.handleExtensionUpgrade(ctx, currentCnpgCluster, documentdb); err != nil {
+		logger.Error(err, "Failed to handle DocumentDB extension upgrade")
 		return ctrl.Result{RequeueAfter: RequeueAfterShort}, nil
 	}
 
@@ -833,13 +795,12 @@ func parseExtensionVersionsFromOutput(output string) (defaultVersion, installedV
 	return defaultVersion, installedVersion, true
 }
 
-// upgradeDocumentDBIfNeeded handles the complete DocumentDB image upgrade process:
-// 1. Checks if extension image and/or gateway image need updating (builds a single JSON Patch)
-// 1b. Blocks extension image rollback below the installed schema version (irreversible)
-// 2. If images changed, applies the patch atomically (triggers one CNPG rolling restart) and returns
-// 3. After rolling restart completes, checks spec.schemaVersion to decide whether to run ALTER EXTENSION
-// 4. Updates the DocumentDB status with the new extension version
-func (r *DocumentDBReconciler) upgradeDocumentDBIfNeeded(ctx context.Context, currentCluster, desiredCluster *cnpgv1.Cluster, documentdb *dbpreview.DocumentDB) error {
+// handleExtensionUpgrade handles the ALTER EXTENSION lifecycle after images have been synced
+// by SyncCnpgCluster. It:
+// 1. Updates DocumentDB status with the current images from the CNPG cluster
+// 2. Checks if ALTER EXTENSION UPDATE is needed and runs it (with two-phase upgrade support)
+// 3. Updates the DocumentDB schema version status
+func (r *DocumentDBReconciler) handleExtensionUpgrade(ctx context.Context, currentCluster *cnpgv1.Cluster, documentdb *dbpreview.DocumentDB) error {
 	logger := log.FromContext(ctx)
 
 	// Refetch documentdb to avoid potential race conditions with status updates
@@ -847,76 +808,19 @@ func (r *DocumentDBReconciler) upgradeDocumentDBIfNeeded(ctx context.Context, cu
 		return fmt.Errorf("failed to refetch DocumentDB resource: %w", err)
 	}
 
-	// Step 1: Build patch ops for extension and/or gateway image changes
-	patchOps, extensionUpdated, gatewayUpdated, err := buildImagePatchOps(currentCluster, desiredCluster)
-	if err != nil {
-		return fmt.Errorf("failed to build image patch operations: %w", err)
-	}
-
-	// Note: Image rollback below installed schema version is blocked by the validating
-	// webhook at admission time. The controller trusts that persisted specs are valid.
-
-	// Step 2: Apply patch if any images need updating
-	if len(patchOps) > 0 {
-		patchBytes, err := json.Marshal(patchOps)
-		if err != nil {
-			return fmt.Errorf("failed to marshal image patch: %w", err)
-		}
-
-		if err := r.Client.Patch(ctx, currentCluster, client.RawPatch(types.JSONPatchType, patchBytes)); err != nil {
-			return fmt.Errorf("failed to patch CNPG cluster with new images: %w", err)
-		}
-
-		logger.Info("Updated DocumentDB images in CNPG cluster, waiting for rolling restart",
-			"extensionUpdated", extensionUpdated,
-			"gatewayUpdated", gatewayUpdated,
-			"clusterName", currentCluster.Name)
-
-		// Gateway-only changes: CNPG does not auto-restart for plugin parameter changes
-		// (extension changes trigger restart via ImageVolume PodSpec divergence).
-		// Add a restart annotation to force rolling restart for gateway-only updates.
-		// Note: CNPG specifically handles kubectl.kubernetes.io/restartedAt for pod restarts.
-		if gatewayUpdated && !extensionUpdated {
-			// Use Merge Patch for the annotation to avoid conflicts and handle missing annotations field
-			restartAnnotation := map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"annotations": map[string]string{
-						"kubectl.kubernetes.io/restartedAt": time.Now().Format(time.RFC3339Nano),
-					},
-				},
-			}
-			annotationPatchBytes, err := json.Marshal(restartAnnotation)
-			if err != nil {
-				return fmt.Errorf("failed to marshal restart annotation patch: %w", err)
-			}
-			if err := r.Client.Patch(ctx, currentCluster, client.RawPatch(types.MergePatchType, annotationPatchBytes)); err != nil {
-				return fmt.Errorf("failed to add restart annotation for gateway update: %w", err)
-			}
-			logger.Info("Added restart annotation for gateway-only update", "clusterName", currentCluster.Name)
-		}
-
-		// Update image status fields to reflect what was just applied
-		if err := r.updateImageStatus(ctx, documentdb, desiredCluster); err != nil {
-			logger.Error(err, "Failed to update image status after patching CNPG cluster")
-		}
-
-		// CNPG will trigger a rolling restart. Wait for pods to become healthy
-		// before running ALTER EXTENSION.
-		return nil
-	}
-
-	// Step 2b: Images already match — update status fields if stale
+	// Update image status fields to reflect what's currently applied
 	if err := r.updateImageStatus(ctx, documentdb, currentCluster); err != nil {
 		logger.Error(err, "Failed to update image status")
 	}
 
-	// Step 3: Check if primary pod is healthy before running ALTER EXTENSION
+	// CNPG will trigger a rolling restart when images change. Wait for pods to become healthy
+	// before running ALTER EXTENSION.
 	if !slices.Contains(currentCluster.Status.InstancesStatus[cnpgv1.PodHealthy], currentCluster.Status.CurrentPrimary) {
 		logger.Info("Current primary pod is not healthy; skipping DocumentDB extension upgrade")
 		return nil
 	}
 
-	// Step 4: Check if ALTER EXTENSION UPDATE is needed
+	// Check if ALTER EXTENSION UPDATE is needed
 	checkVersionSQL := "SELECT default_version, installed_version FROM pg_available_extensions WHERE name = 'documentdb'"
 	output, err := r.SQLExecutor(ctx, currentCluster, checkVersionSQL)
 	if err != nil {
@@ -934,7 +838,7 @@ func (r *DocumentDBReconciler) upgradeDocumentDBIfNeeded(ctx context.Context, cu
 		return nil
 	}
 
-	// Step 5: Update DocumentDB schema version in status (even if no upgrade needed)
+	// Update DocumentDB schema version in status (even if no upgrade needed)
 	// Convert from pg_available_extensions format ("0.110-0") to semver ("0.110.0")
 	installedSemver := util.ExtensionVersionToSemver(installedVersion)
 	if documentdb.Status.SchemaVersion != installedSemver {
@@ -955,10 +859,9 @@ func (r *DocumentDBReconciler) upgradeDocumentDBIfNeeded(ctx context.Context, cu
 		return nil
 	}
 
-	// Step 5b: Rollback detection — secondary safety net.
-	// The primary rollback block is in Step 1b (prevents image patch when new image < schema).
-	// This handles edge cases where the binary version is already running but older than schema
-	// (e.g., if Step 1b was added after an earlier rollback already took effect).
+	// Rollback detection — check if the new binary is older than the installed schema.
+	// Note: Image rollback below installed schema version is also blocked by the validating
+	// webhook at admission time. This is a defense-in-depth guard.
 	cmp, err := util.CompareExtensionVersions(defaultVersion, installedVersion)
 	if err != nil {
 		logger.Error(err, "Failed to compare extension versions, skipping ALTER EXTENSION as a safety measure",
@@ -968,7 +871,6 @@ func (r *DocumentDBReconciler) upgradeDocumentDBIfNeeded(ctx context.Context, cu
 	}
 
 	if cmp < 0 {
-		// Rollback detected: the binary (defaultVersion) is older than the installed schema (installedVersion).
 		// ALTER EXTENSION UPDATE would attempt an unsupported downgrade. Skip it and warn the user.
 		msg := fmt.Sprintf(
 			"Extension rollback detected: binary offers version %s but schema is at %s. "+
@@ -983,20 +885,14 @@ func (r *DocumentDBReconciler) upgradeDocumentDBIfNeeded(ctx context.Context, cu
 		return nil
 	}
 
-	// Step 6: Determine schema target based on spec.schemaVersion (two-phase upgrade logic)
-	//
-	// Three modes:
-	//   - "" (empty): Two-phase mode — do NOT auto-update schema. User must explicitly
-	//     set spec.schemaVersion to finalize. This provides a rollback-safe window.
-	//   - "auto": Auto-finalize — update schema to match binary version automatically.
-	//   - "<version>": Explicit pin — update schema to exactly this version.
+	// Determine schema target based on spec.schemaVersion (two-phase upgrade logic)
 	schemaTarget, updateSQL := r.determineSchemaTarget(ctx, documentdb, defaultVersion, installedVersion)
 	if schemaTarget == "" {
 		// Two-phase mode or validation failure — do not run ALTER EXTENSION
 		return nil
 	}
 
-	// Step 7: Run ALTER EXTENSION to upgrade
+	// Run ALTER EXTENSION to upgrade
 	logger.Info("Upgrading DocumentDB extension",
 		"fromVersion", installedVersion,
 		"toVersion", schemaTarget)
@@ -1009,12 +905,10 @@ func (r *DocumentDBReconciler) upgradeDocumentDBIfNeeded(ctx context.Context, cu
 		"fromVersion", installedVersion,
 		"toVersion", schemaTarget)
 
-	// Step 8: Update DocumentDB schema version in status after upgrade
-	// Re-fetch to get latest resourceVersion before status update
+	// Update DocumentDB schema version in status after upgrade
 	if err := r.Get(ctx, types.NamespacedName{Name: documentdb.Name, Namespace: documentdb.Namespace}, documentdb); err != nil {
 		return fmt.Errorf("failed to refetch DocumentDB after schema upgrade: %w", err)
 	}
-	// Convert from pg_available_extensions format ("0.110-0") to semver ("0.110.0")
 	documentdb.Status.SchemaVersion = util.ExtensionVersionToSemver(schemaTarget)
 	if err := r.Status().Update(ctx, documentdb); err != nil {
 		logger.Error(err, "Failed to update DocumentDB status after schema upgrade")
@@ -1065,11 +959,11 @@ func (r *DocumentDBReconciler) determineSchemaTarget(
 
 	default:
 		// Explicit version: update to that specific version.
-		// Note: schemaVersion <= binary version is enforced by the validating webhook at
-		// admission time. This is a defense-in-depth guard.
 		targetPgVersion := util.SemverToExtensionVersion(specSchemaVersion)
 
-		// Guard: target must not exceed binary version
+		// Guard: target must not exceed binary version.
+		// Note: schemaVersion <= binary version is enforced by the validating webhook at
+		// admission time. This is a defense-in-depth guard.
 		targetCmp, err := util.CompareExtensionVersions(targetPgVersion, binaryVersion)
 		if err != nil {
 			logger.Error(err, "Failed to compare target schema version with binary version",
@@ -1107,83 +1001,6 @@ func (r *DocumentDBReconciler) determineSchemaTarget(
 	}
 }
 
-// buildImagePatchOps compares the current and desired CNPG cluster specs and returns
-// JSON Patch operations for any image differences (extension image settings and/or gateway image).
-// This is a pure function with no API calls. Returns:
-//   - patchOps: JSON Patch operations to align image-related fields
-//   - extensionUpdated: true if extension image settings differ
-//   - gatewayUpdated: true if gateway image differs
-//   - err: non-nil if the documentdb extension is not found in the current cluster
-func buildImagePatchOps(currentCluster, desiredCluster *cnpgv1.Cluster) ([]util.JSONPatch, bool, bool, error) {
-	var patchOps []util.JSONPatch
-	extensionUpdated := false
-	gatewayUpdated := false
-
-	// --- Extension image comparison ---
-	currentExtIndex := -1
-	var currentExtImage string
-	for i, ext := range currentCluster.Spec.PostgresConfiguration.Extensions {
-		if ext.Name == "documentdb" {
-			currentExtIndex = i
-			currentExtImage = ext.ImageVolumeSource.Reference
-			break
-		}
-	}
-
-	var desiredExtImage string
-	for _, ext := range desiredCluster.Spec.PostgresConfiguration.Extensions {
-		if ext.Name == "documentdb" {
-			desiredExtImage = ext.ImageVolumeSource.Reference
-			break
-		}
-	}
-
-	if currentExtImage != desiredExtImage {
-		if currentExtIndex == -1 {
-			return nil, false, false, fmt.Errorf("documentdb extension not found in current CNPG cluster spec")
-		}
-		patchOps = append(patchOps, util.JSONPatch{
-			Op:    util.JSON_PATCH_OP_REPLACE,
-			Path:  fmt.Sprintf(util.JSON_PATCH_PATH_EXTENSION_IMAGE_FMT, currentExtIndex),
-			Value: desiredExtImage,
-		})
-		extensionUpdated = true
-	}
-
-	// --- Gateway image comparison ---
-	// Find the target plugin name from the desired cluster
-	if len(desiredCluster.Spec.Plugins) > 0 {
-		desiredPluginName := desiredCluster.Spec.Plugins[0].Name
-		desiredGatewayImage := ""
-		if desiredCluster.Spec.Plugins[0].Parameters != nil {
-			desiredGatewayImage = desiredCluster.Spec.Plugins[0].Parameters["gatewayImage"]
-		}
-
-		// Only check gateway if there's actually a desired gateway image
-		if desiredGatewayImage != "" {
-			for i, plugin := range currentCluster.Spec.Plugins {
-				if plugin.Name == desiredPluginName {
-					currentGatewayImage := ""
-					if plugin.Parameters != nil {
-						currentGatewayImage = plugin.Parameters["gatewayImage"]
-					}
-
-					if currentGatewayImage != desiredGatewayImage {
-						patchOps = append(patchOps, util.JSONPatch{
-							Op:    util.JSON_PATCH_OP_REPLACE,
-							Path:  fmt.Sprintf(util.JSON_PATCH_PATH_PLUGIN_GATEWAY_IMAGE_FMT, i),
-							Value: desiredGatewayImage,
-						})
-						gatewayUpdated = true
-					}
-					break
-				}
-			}
-		}
-	}
-
-	return patchOps, extensionUpdated, gatewayUpdated, nil
-}
 
 // updateImageStatus reads the current extension and gateway images from the CNPG cluster
 // and persists them into the DocumentDB status fields. This is a no-op if both fields

--- a/operator/src/internal/controller/documentdb_controller_test.go
+++ b/operator/src/internal/controller/documentdb_controller_test.go
@@ -62,526 +62,7 @@ var _ = Describe("DocumentDB Controller", func() {
 		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	})
 
-	Describe("buildImagePatchOps", func() {
-		It("should return 0 ops when both extension and gateway images are the same", func() {
-			currentCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v1.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v1.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			patchOps, extUpdated, gwUpdated, err := buildImagePatchOps(currentCluster, desiredCluster)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patchOps).To(BeEmpty())
-			Expect(extUpdated).To(BeFalse())
-			Expect(gwUpdated).To(BeFalse())
-		})
-
-		It("should return 1 op when only extension image differs", func() {
-			currentCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v1.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v2.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v1.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			patchOps, extUpdated, gwUpdated, err := buildImagePatchOps(currentCluster, desiredCluster)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patchOps).To(HaveLen(1))
-			Expect(patchOps[0].Op).To(Equal("replace"))
-			Expect(patchOps[0].Path).To(Equal("/spec/postgresql/extensions/0/image/reference"))
-			Expect(patchOps[0].Value).To(Equal("documentdb/documentdb:v2.0.0"))
-			Expect(extUpdated).To(BeTrue())
-			Expect(gwUpdated).To(BeFalse())
-		})
-
-		It("should return 1 op when only gateway image differs", func() {
-			currentCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v1.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v2.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			patchOps, extUpdated, gwUpdated, err := buildImagePatchOps(currentCluster, desiredCluster)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patchOps).To(HaveLen(1))
-			Expect(patchOps[0].Op).To(Equal("replace"))
-			Expect(patchOps[0].Path).To(Equal("/spec/plugins/0/parameters/gatewayImage"))
-			Expect(patchOps[0].Value).To(Equal("gateway:v2.0.0"))
-			Expect(extUpdated).To(BeFalse())
-			Expect(gwUpdated).To(BeTrue())
-		})
-
-		It("should return 2 ops when both extension and gateway images differ", func() {
-			currentCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v1.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v2.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v2.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			patchOps, extUpdated, gwUpdated, err := buildImagePatchOps(currentCluster, desiredCluster)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patchOps).To(HaveLen(2))
-			// First op: extension image
-			Expect(patchOps[0].Op).To(Equal("replace"))
-			Expect(patchOps[0].Path).To(Equal("/spec/postgresql/extensions/0/image/reference"))
-			Expect(patchOps[0].Value).To(Equal("documentdb/documentdb:v2.0.0"))
-			// Second op: gateway image
-			Expect(patchOps[1].Op).To(Equal("replace"))
-			Expect(patchOps[1].Path).To(Equal("/spec/plugins/0/parameters/gatewayImage"))
-			Expect(patchOps[1].Value).To(Equal("gateway:v2.0.0"))
-			Expect(extUpdated).To(BeTrue())
-			Expect(gwUpdated).To(BeTrue())
-		})
-
-		It("should return error when documentdb extension is not found in current cluster", func() {
-			currentCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "other-extension",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "other/image:v1.0.0",
-								},
-							},
-						},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v2.0.0",
-								},
-							},
-						},
-					},
-				},
-			}
-
-			_, _, _, err := buildImagePatchOps(currentCluster, desiredCluster)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("documentdb extension not found"))
-		})
-
-		It("should use correct index when documentdb is not the first extension", func() {
-			currentCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "pg_stat_statements",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "postgres/pg_stat_statements:v1.0.0",
-								},
-							},
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-							{
-								Name: "pg_cron",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "postgres/pg_cron:v1.0.0",
-								},
-							},
-						},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "pg_stat_statements",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "postgres/pg_stat_statements:v1.0.0",
-								},
-							},
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v2.0.0",
-								},
-							},
-							{
-								Name: "pg_cron",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "postgres/pg_cron:v1.0.0",
-								},
-							},
-						},
-					},
-				},
-			}
-
-			patchOps, extUpdated, gwUpdated, err := buildImagePatchOps(currentCluster, desiredCluster)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patchOps).To(HaveLen(1))
-			Expect(patchOps[0].Path).To(Equal("/spec/postgresql/extensions/1/image/reference"))
-			Expect(patchOps[0].Value).To(Equal("documentdb/documentdb:v2.0.0"))
-			Expect(extUpdated).To(BeTrue())
-			Expect(gwUpdated).To(BeFalse())
-		})
-
-		It("should skip gateway check when plugin is not found in current cluster", func() {
-			currentCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{}, // No plugins
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v2.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			patchOps, extUpdated, gwUpdated, err := buildImagePatchOps(currentCluster, desiredCluster)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patchOps).To(BeEmpty())
-			Expect(extUpdated).To(BeFalse())
-			Expect(gwUpdated).To(BeFalse())
-		})
-
-		It("should skip gateway check when current plugin has nil Parameters", func() {
-			currentCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name:       "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: nil,
-						},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v2.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			patchOps, extUpdated, gwUpdated, err := buildImagePatchOps(currentCluster, desiredCluster)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patchOps).To(HaveLen(1))
-			Expect(patchOps[0].Path).To(Equal("/spec/plugins/0/parameters/gatewayImage"))
-			Expect(patchOps[0].Value).To(Equal("gateway:v2.0.0"))
-			Expect(extUpdated).To(BeFalse())
-			Expect(gwUpdated).To(BeTrue())
-		})
-
-		It("should return 0 ops when no extensions exist in either cluster", func() {
-			currentCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{},
-					},
-				},
-			}
-
-			patchOps, extUpdated, gwUpdated, err := buildImagePatchOps(currentCluster, desiredCluster)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patchOps).To(BeEmpty())
-			Expect(extUpdated).To(BeFalse())
-			Expect(gwUpdated).To(BeFalse())
-		})
-
-		It("should use correct plugin index when sidecar plugin is not the first plugin", func() {
-			currentCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-wal-replica.documentdb.io",
-							Parameters: map[string]string{
-								"someParam": "value",
-							},
-						},
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v1.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v2.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			patchOps, extUpdated, gwUpdated, err := buildImagePatchOps(currentCluster, desiredCluster)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(patchOps).To(HaveLen(1))
-			Expect(patchOps[0].Path).To(Equal("/spec/plugins/1/parameters/gatewayImage"))
-			Expect(patchOps[0].Value).To(Equal("gateway:v2.0.0"))
-			Expect(extUpdated).To(BeFalse())
-			Expect(gwUpdated).To(BeTrue())
-		})
-	})
-
-	Describe("upgradeDocumentDBIfNeeded", func() {
+	Describe("handleExtensionUpgrade", func() {
 		It("should return nil when primary pod is not healthy", func() {
 			cluster := &cnpgv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -608,25 +89,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-				},
-			}
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -645,7 +107,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				Scheme: scheme,
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -673,25 +135,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-				},
-			}
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -710,7 +153,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				Scheme: scheme,
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -740,25 +183,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v2.0.0",
-								},
-							},
-						},
-					},
-				},
-			}
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -775,16 +199,20 @@ var _ = Describe("DocumentDB Controller", func() {
 			reconciler := &DocumentDBReconciler{
 				Client: fakeClient,
 				Scheme: scheme,
+				SQLExecutor: func(ctx context.Context, cluster *cnpgv1.Cluster, sql string) (string, error) {
+					return "0.109-0|0.109-0", nil
+				},
 			}
 
-			// Should update image and return nil (waiting for pod to become healthy)
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			// Should return nil early (waiting for rolling restart after extension update)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify image was updated
-			result := &cnpgv1.Cluster{}
-			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, result)).To(Succeed())
-			Expect(result.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference).To(Equal("documentdb/documentdb:v2.0.0"))
+			// Image patching is now done by SyncCnpgCluster; handleExtensionUpgrade only
+			// updates image status and returns early when ExtensionUpdated is true
+			updatedDB := &dbpreview.DocumentDB{}
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "test-documentdb", Namespace: clusterNamespace}, updatedDB)).To(Succeed())
+			Expect(updatedDB.Status.DocumentDBImage).To(Equal("documentdb/documentdb:v1.0.0"))
 		})
 
 		It("should update image status fields after patching CNPG cluster", func() {
@@ -821,33 +249,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v2.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "documentdb-sidecar",
-							Parameters: map[string]string{
-								"gatewayImage": "documentdb/gateway:v2.0.0",
-							},
-						},
-					},
-				},
-			}
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -865,16 +266,19 @@ var _ = Describe("DocumentDB Controller", func() {
 				Client:   fakeClient,
 				Scheme:   scheme,
 				Recorder: recorder,
+				SQLExecutor: func(ctx context.Context, cluster *cnpgv1.Cluster, sql string) (string, error) {
+					return "0.109-0|0.109-0", nil
+				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify image status fields were updated on the DocumentDB resource
+			// handleExtensionUpgrade reads current images from the CNPG cluster and updates status
 			updatedDB := &dbpreview.DocumentDB{}
 			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "test-documentdb", Namespace: clusterNamespace}, updatedDB)).To(Succeed())
-			Expect(updatedDB.Status.DocumentDBImage).To(Equal("documentdb/documentdb:v2.0.0"))
-			Expect(updatedDB.Status.GatewayImage).To(Equal("documentdb/gateway:v2.0.0"))
+			Expect(updatedDB.Status.DocumentDBImage).To(Equal("documentdb/documentdb:v1.0.0"))
+			Expect(updatedDB.Status.GatewayImage).To(Equal("documentdb/gateway:v1.0.0"))
 		})
 
 		It("should return error when DocumentDB resource cannot be refetched", func() {
@@ -897,8 +301,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			// DocumentDB resource does NOT exist in the fake client — refetch will fail
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
@@ -918,266 +320,9 @@ var _ = Describe("DocumentDB Controller", func() {
 				Scheme: scheme,
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to refetch DocumentDB resource"))
-		})
-
-		It("should return error when documentdb extension is missing from current cluster", func() {
-			cluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "other-extension",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "other/image:v1.0.0",
-								},
-							},
-						},
-					},
-				},
-				Status: cnpgv1.ClusterStatus{
-					CurrentPrimary: "test-cluster-1",
-					InstancesStatus: map[cnpgv1.PodStatus][]string{
-						cnpgv1.PodHealthy: {"test-cluster-1"},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v2.0.0",
-								},
-							},
-						},
-					},
-				},
-			}
-
-			documentdb := &dbpreview.DocumentDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-documentdb",
-					Namespace: clusterNamespace,
-				},
-			}
-
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(cluster, documentdb).
-				WithStatusSubresource(&dbpreview.DocumentDB{}).
-				Build()
-
-			reconciler := &DocumentDBReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
-			}
-
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to build image patch operations"))
-		})
-
-		It("should add restart annotation for gateway-only update", func() {
-			cluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v1.0.0",
-							},
-						},
-					},
-				},
-				Status: cnpgv1.ClusterStatus{
-					CurrentPrimary: "test-cluster-1",
-					InstancesStatus: map[cnpgv1.PodStatus][]string{
-						cnpgv1.PodHealthy: {"test-cluster-1"},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0", // Same extension image
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v2.0.0", // Only gateway differs
-							},
-						},
-					},
-				},
-			}
-
-			documentdb := &dbpreview.DocumentDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-documentdb",
-					Namespace: clusterNamespace,
-				},
-			}
-
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(cluster, documentdb).
-				WithStatusSubresource(&dbpreview.DocumentDB{}).
-				Build()
-
-			reconciler := &DocumentDBReconciler{
-				Client:   fakeClient,
-				Scheme:   scheme,
-				Recorder: recorder,
-			}
-
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Verify gateway image was updated
-			result := &cnpgv1.Cluster{}
-			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, result)).To(Succeed())
-
-			// Verify restart annotation was added for gateway-only update
-			Expect(result.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
-
-			// Verify gateway image status was updated
-			updatedDB := &dbpreview.DocumentDB{}
-			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "test-documentdb", Namespace: clusterNamespace}, updatedDB)).To(Succeed())
-			Expect(updatedDB.Status.GatewayImage).To(Equal("gateway:v2.0.0"))
-		})
-
-		It("should not add restart annotation when extension image also changes", func() {
-			cluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v1.0.0",
-							},
-						},
-					},
-				},
-				Status: cnpgv1.ClusterStatus{
-					CurrentPrimary: "test-cluster-1",
-					InstancesStatus: map[cnpgv1.PodStatus][]string{
-						cnpgv1.PodHealthy: {"test-cluster-1"},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v2.0.0", // Both differ
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v2.0.0", // Both differ
-							},
-						},
-					},
-				},
-			}
-
-			documentdb := &dbpreview.DocumentDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-documentdb",
-					Namespace: clusterNamespace,
-				},
-			}
-
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(cluster, documentdb).
-				WithStatusSubresource(&dbpreview.DocumentDB{}).
-				Build()
-
-			reconciler := &DocumentDBReconciler{
-				Client:   fakeClient,
-				Scheme:   scheme,
-				Recorder: recorder,
-			}
-
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Verify images were updated
-			result := &cnpgv1.Cluster{}
-			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, result)).To(Succeed())
-			Expect(result.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference).To(Equal("documentdb/documentdb:v2.0.0"))
-
-			// Restart annotation should NOT be added when extension also changes
-			// (CNPG handles restart via ImageVolume PodSpec divergence)
-			Expect(result.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/restartedAt"))
 		})
 
 		It("should return nil when images match and primary is not healthy", func() {
@@ -1214,8 +359,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -1234,7 +377,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				Scheme: scheme,
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Image status should still be updated even though primary isn't healthy
@@ -1276,8 +419,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			// Status has stale/old image values
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1301,7 +442,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				Scheme: scheme,
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify stale status was corrected
@@ -1335,8 +476,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -1358,7 +497,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				Scheme: scheme,
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Cluster should remain unchanged (no patch applied)
@@ -1395,8 +534,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -1419,7 +556,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to check documentdb extension versions"))
 		})
@@ -1450,8 +587,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -1474,7 +609,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -1504,8 +639,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -1528,7 +661,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -1558,8 +691,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -1582,7 +713,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Status should reflect the installed version as semver
@@ -1617,8 +748,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -1644,7 +773,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Only the version-check SQL should have been called (no ALTER EXTENSION)
@@ -1689,8 +818,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -1723,7 +850,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify both SQL calls were made
@@ -1763,8 +890,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -1797,7 +922,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to run ALTER EXTENSION documentdb UPDATE"))
 		})
@@ -1828,8 +953,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -1855,170 +978,11 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Only version-check call, no ALTER EXTENSION (skipped as safety measure)
 			Expect(sqlCallCount).To(Equal(1))
-		})
-
-		It("should return error when CNPG cluster patch fails for image update", func() {
-			cluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v2.0.0",
-								},
-							},
-						},
-					},
-				},
-			}
-
-			documentdb := &dbpreview.DocumentDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-documentdb",
-					Namespace: clusterNamespace,
-				},
-			}
-
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(cluster, documentdb).
-				WithStatusSubresource(&dbpreview.DocumentDB{}).
-				WithInterceptorFuncs(interceptor.Funcs{
-					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-						return fmt.Errorf("patch conflict")
-					},
-				}).
-				Build()
-
-			reconciler := &DocumentDBReconciler{
-				Client:   fakeClient,
-				Scheme:   scheme,
-				Recorder: recorder,
-			}
-
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to patch CNPG cluster with new images"))
-		})
-
-		It("should return error when restart annotation patch fails for gateway-only update", func() {
-			cluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v1.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-					Plugins: []cnpgv1.PluginConfiguration{
-						{
-							Name: "cnpg-i-sidecar-injector.documentdb.io",
-							Parameters: map[string]string{
-								"gatewayImage": "gateway:v2.0.0",
-							},
-						},
-					},
-				},
-			}
-
-			documentdb := &dbpreview.DocumentDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-documentdb",
-					Namespace: clusterNamespace,
-				},
-			}
-
-			patchCallCount := 0
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(cluster, documentdb).
-				WithStatusSubresource(&dbpreview.DocumentDB{}).
-				WithInterceptorFuncs(interceptor.Funcs{
-					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-						patchCallCount++
-						if patchCallCount == 1 {
-							// First patch (JSONPatch for gateway image) succeeds
-							return c.Patch(ctx, obj, patch, opts...)
-						}
-						// Second patch (MergePatch for restart annotation) fails
-						return fmt.Errorf("restart annotation patch failed")
-					},
-				}).
-				Build()
-
-			reconciler := &DocumentDBReconciler{
-				Client:   fakeClient,
-				Scheme:   scheme,
-				Recorder: recorder,
-			}
-
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to add restart annotation for gateway update"))
 		})
 
 		It("should log error but return nil when updateImageStatus fails after patching", func() {
@@ -2034,25 +998,6 @@ var _ = Describe("DocumentDB Controller", func() {
 								Name: "documentdb",
 								ImageVolumeSource: corev1.ImageVolumeSource{
 									Reference: "documentdb/documentdb:v1.0.0",
-								},
-							},
-						},
-					},
-				},
-			}
-
-			desiredCluster := &cnpgv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      clusterName,
-					Namespace: clusterNamespace,
-				},
-				Spec: cnpgv1.ClusterSpec{
-					PostgresConfiguration: cnpgv1.PostgresConfiguration{
-						Extensions: []cnpgv1.ExtensionConfiguration{
-							{
-								Name: "documentdb",
-								ImageVolumeSource: corev1.ImageVolumeSource{
-									Reference: "documentdb/documentdb:v2.0.0",
 								},
 							},
 						},
@@ -2088,7 +1033,7 @@ var _ = Describe("DocumentDB Controller", func() {
 			}
 
 			// Should return nil because updateImageStatus error is only logged, not returned
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -2116,8 +1061,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -2143,7 +1086,7 @@ var _ = Describe("DocumentDB Controller", func() {
 			}
 
 			// images match, primary not healthy => hits step 2b updateImageStatus (fails) then returns nil
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -2172,8 +1115,6 @@ var _ = Describe("DocumentDB Controller", func() {
 					},
 				},
 			}
-
-			desiredCluster := cluster.DeepCopy()
 
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2209,7 +1150,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to update DocumentDB status with schema version"))
 		})
@@ -2239,8 +1180,6 @@ var _ = Describe("DocumentDB Controller", func() {
 					},
 				},
 			}
-
-			desiredCluster := cluster.DeepCopy()
 
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2284,7 +1223,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to update DocumentDB status after schema upgrade"))
 			Expect(sqlCalls).To(HaveLen(2))
@@ -2318,8 +1257,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			// schemaVersion is empty (default) → two-phase mode
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2346,7 +1283,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Only version-check SQL should have been called (no ALTER EXTENSION)
@@ -2390,8 +1327,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -2422,7 +1357,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Both version-check and ALTER EXTENSION should have been called
@@ -2462,8 +1397,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			// Explicit version: update to 0.110.0 (binary is also 0.110-0)
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2496,7 +1429,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Should run ALTER EXTENSION UPDATE TO specific version
@@ -2539,8 +1472,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			// Explicit version 0.112.0 exceeds binary version 0.110-0
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2570,7 +1501,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Only version-check SQL should have been called (no ALTER EXTENSION)
@@ -2608,8 +1539,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			// Explicit version matches installed → no-op
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2639,7 +1568,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Only version-check SQL should have been called (no ALTER EXTENSION)
@@ -2672,8 +1601,6 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			desiredCluster := cluster.DeepCopy()
-
 			documentdb := &dbpreview.DocumentDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-documentdb",
@@ -2702,7 +1629,7 @@ var _ = Describe("DocumentDB Controller", func() {
 				},
 			}
 
-			err := reconciler.upgradeDocumentDBIfNeeded(ctx, cluster, desiredCluster, documentdb)
+			err := reconciler.handleExtensionUpgrade(ctx, cluster, documentdb)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Only version-check SQL called, no ALTER EXTENSION (graceful skip)
@@ -4066,9 +2993,12 @@ var _ = Describe("DocumentDB Controller", func() {
 				Client:   fakeClient,
 				Scheme:   scheme,
 				Recorder: recorder,
+				SQLExecutor: func(_ context.Context, _ *cnpgv1.Cluster, _ string) (string, error) {
+					return "", nil
+				},
 			}
 
-			result, err := reconciler.Reconcile(ctx, ctrl.Request{
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      documentDBName,
 					Namespace: documentDBNamespace,
@@ -4076,7 +3006,8 @@ var _ = Describe("DocumentDB Controller", func() {
 			})
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(RequeueAfterShort))
+			// TLS secret changes are now handled seamlessly by SyncCnpgCluster as part of
+			// the normal reconcile flow, so the reconcile completes without early requeue.
 
 			// Verify CNPG cluster was updated with new TLS secret and restart annotation
 			updatedCluster := &cnpgv1.Cluster{}

--- a/operator/src/internal/controller/physical_replication.go
+++ b/operator/src/internal/controller/physical_replication.go
@@ -5,7 +5,6 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +14,7 @@ import (
 
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	dbpreview "github.com/documentdb/documentdb-operator/api/preview"
+	"github.com/documentdb/documentdb-operator/internal/cnpg"
 	util "github.com/documentdb/documentdb-operator/internal/utils"
 	fleetv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -317,25 +317,29 @@ func (r *DocumentDBReconciler) CreateServiceImportAndExport(ctx context.Context,
 	return nil
 }
 
-func (r *DocumentDBReconciler) TryUpdateCluster(ctx context.Context, current, desired *cnpgv1.Cluster, documentdb *dbpreview.DocumentDB, replicationContext *util.ReplicationContext) (error, time.Duration) {
+// syncReplicationChanges builds replication-specific CNPG Cluster patch operations (primary change,
+// replica list change).
+// It performs side effects (HTTP token reads, service creation, goroutines) but returns the
+// patch ops for the caller to include in the consolidated SyncCnpgCluster patch.
+func (r *DocumentDBReconciler) syncReplicationChanges(ctx context.Context, current, desired *cnpgv1.Cluster, documentdb *dbpreview.DocumentDB, replicationContext *util.ReplicationContext) ([]cnpg.JSONPatch, error, time.Duration) {
 	if current.Spec.ReplicaCluster == nil || desired.Spec.ReplicaCluster == nil {
 		// FOR NOW assume that we aren't going to turn on or off physical replication
-		return nil, -1
+		return nil, nil, -1
 	}
 
 	if current.Spec.ReplicaCluster.Self != desired.Spec.ReplicaCluster.Self {
-		return fmt.Errorf("self cannot be changed"), time.Second * 60
+		return nil, fmt.Errorf("self cannot be changed"), time.Second * 60
 	}
 
 	// Create JSON patch operations for all replica cluster updates
-	var patchOps []util.JSONPatch
+	var patchOps []cnpg.JSONPatch
 
 	// Update if the primary has changed
 	primaryChanged := current.Spec.ReplicaCluster.Primary != desired.Spec.ReplicaCluster.Primary
 	if primaryChanged {
 		err, refreshTime := r.getPrimaryChangePatchOps(ctx, &patchOps, current, desired, documentdb, replicationContext)
 		if refreshTime > 0 || err != nil {
-			return err, refreshTime
+			return nil, err, refreshTime
 		}
 	}
 
@@ -345,36 +349,25 @@ func (r *DocumentDBReconciler) TryUpdateCluster(ctx context.Context, current, de
 		getReplicasChangePatchOps(&patchOps, desired, replicationContext)
 	}
 
-	if len(patchOps) > 0 {
-		patch, err := json.Marshal(patchOps)
-		if err != nil {
-			return fmt.Errorf("failed to marshal patch operations: %w", err), time.Second * 10
-		}
-		err = r.Client.Patch(ctx, current, client.RawPatch(types.JSONPatchType, patch))
-		if err != nil {
-			return err, time.Second * 10
-		}
-	}
-
-	return nil, -1
+	return patchOps, nil, -1
 }
 
-func (r *DocumentDBReconciler) getPrimaryChangePatchOps(ctx context.Context, patchOps *[]util.JSONPatch, current, desired *cnpgv1.Cluster, documentdb *dbpreview.DocumentDB, replicationContext *util.ReplicationContext) (error, time.Duration) {
+func (r *DocumentDBReconciler) getPrimaryChangePatchOps(ctx context.Context, patchOps *[]cnpg.JSONPatch, current, desired *cnpgv1.Cluster, documentdb *dbpreview.DocumentDB, replicationContext *util.ReplicationContext) (error, time.Duration) {
 
 	// Remove old bootstrap method if present
 	if current.Spec.Bootstrap != nil {
-		*patchOps = append(*patchOps, util.JSONPatch{
-			Op:   util.JSON_PATCH_OP_REMOVE,
-			Path: util.JSON_PATCH_PATH_BOOTSTRAP,
+		*patchOps = append(*patchOps, cnpg.JSONPatch{
+			Op:   cnpg.PatchOpRemove,
+			Path: cnpg.PatchPathBootstrap,
 		})
 	}
 
 	if current.Spec.ReplicaCluster.Primary == current.Spec.ReplicaCluster.Self {
 		// Primary => replica
 		// demote
-		*patchOps = append(*patchOps, util.JSONPatch{
-			Op:    util.JSON_PATCH_OP_REPLACE,
-			Path:  util.JSON_PATCH_PATH_REPLICA_CLUSTER,
+		*patchOps = append(*patchOps, cnpg.JSONPatch{
+			Op:    cnpg.PatchOpReplace,
+			Path:  cnpg.PatchPathReplicaCluster,
 			Value: desired.Spec.ReplicaCluster,
 		})
 
@@ -383,19 +376,19 @@ func (r *DocumentDBReconciler) getPrimaryChangePatchOps(ctx context.Context, pat
 			// Only add remove operation if synchronous field exists, otherwise there's an error
 			// TODO this wouldn't be true if our "wait for token" logic wasn't reliant on a failure
 			if current.Spec.PostgresConfiguration.Synchronous != nil {
-				*patchOps = append(*patchOps, util.JSONPatch{
-					Op:   util.JSON_PATCH_OP_REMOVE,
-					Path: util.JSON_PATCH_PATH_POSTGRES_CONFIG_SYNC,
+				*patchOps = append(*patchOps, cnpg.JSONPatch{
+					Op:   cnpg.PatchOpRemove,
+					Path: cnpg.PatchPathPostgresConfigSyn,
 				})
 			}
-			*patchOps = append(*patchOps, util.JSONPatch{
-				Op:    util.JSON_PATCH_OP_REPLACE,
-				Path:  util.JSON_PATCH_PATH_INSTANCES,
+			*patchOps = append(*patchOps, cnpg.JSONPatch{
+				Op:    cnpg.PatchOpReplace,
+				Path:  cnpg.PatchPathInstances,
 				Value: desired.Spec.Instances,
 			})
-			*patchOps = append(*patchOps, util.JSONPatch{
-				Op:    util.JSON_PATCH_OP_REPLACE,
-				Path:  util.JSON_PATCH_PATH_PLUGINS,
+			*patchOps = append(*patchOps, cnpg.JSONPatch{
+				Op:    cnpg.PatchOpReplace,
+				Path:  cnpg.PatchPathPlugins,
 				Value: desired.Spec.Plugins,
 			})
 		}
@@ -426,41 +419,41 @@ func (r *DocumentDBReconciler) getPrimaryChangePatchOps(ctx context.Context, pat
 			replicaClusterConfig.PromotionToken = token
 		}
 
-		*patchOps = append(*patchOps, util.JSONPatch{
-			Op:    util.JSON_PATCH_OP_REPLACE,
-			Path:  util.JSON_PATCH_PATH_REPLICA_CLUSTER,
+		*patchOps = append(*patchOps, cnpg.JSONPatch{
+			Op:    cnpg.PatchOpReplace,
+			Path:  cnpg.PatchPathReplicaCluster,
 			Value: replicaClusterConfig,
 		})
 
 		if documentdb.Spec.ClusterReplication.HighAvailability {
 			// need to add second instance and wal replica
-			*patchOps = append(*patchOps, util.JSONPatch{
-				Op:    util.JSON_PATCH_OP_REPLACE,
-				Path:  util.JSON_PATCH_PATH_POSTGRES_CONFIG,
+			*patchOps = append(*patchOps, cnpg.JSONPatch{
+				Op:    cnpg.PatchOpReplace,
+				Path:  cnpg.PatchPathPostgresConfig,
 				Value: desired.Spec.PostgresConfiguration,
 			})
-			*patchOps = append(*patchOps, util.JSONPatch{
-				Op:    util.JSON_PATCH_OP_REPLACE,
-				Path:  util.JSON_PATCH_PATH_INSTANCES,
+			*patchOps = append(*patchOps, cnpg.JSONPatch{
+				Op:    cnpg.PatchOpReplace,
+				Path:  cnpg.PatchPathInstances,
 				Value: desired.Spec.Instances,
 			})
-			*patchOps = append(*patchOps, util.JSONPatch{
-				Op:    util.JSON_PATCH_OP_REPLACE,
-				Path:  util.JSON_PATCH_PATH_PLUGINS,
+			*patchOps = append(*patchOps, cnpg.JSONPatch{
+				Op:    cnpg.PatchOpReplace,
+				Path:  cnpg.PatchPathPlugins,
 				Value: desired.Spec.Plugins,
 			})
-			*patchOps = append(*patchOps, util.JSONPatch{
-				Op:    util.JSON_PATCH_OP_REPLACE,
-				Path:  util.JSON_PATCH_PATH_REPLICATION_SLOTS,
+			*patchOps = append(*patchOps, cnpg.JSONPatch{
+				Op:    cnpg.PatchOpReplace,
+				Path:  cnpg.PatchPathReplicationSlots,
 				Value: desired.Spec.ReplicationSlots,
 			})
 		}
 		log.Log.Info("Applying patch for Replica => Primary transition", "cluster", current.Name, "hasToken", replicaClusterConfig.PromotionToken != "")
 	} else {
 		// Replica => replica
-		*patchOps = append(*patchOps, util.JSONPatch{
-			Op:    util.JSON_PATCH_OP_REPLACE,
-			Path:  util.JSON_PATCH_PATH_REPLICA_CLUSTER,
+		*patchOps = append(*patchOps, cnpg.JSONPatch{
+			Op:    cnpg.PatchOpReplace,
+			Path:  cnpg.PatchPathReplicaCluster,
 			Value: desired.Spec.ReplicaCluster,
 		})
 
@@ -494,23 +487,23 @@ func externalClusterNamesChanged(currentClusters, desiredClusters []cnpgv1.Exter
 	return len(nameSet) != 0
 }
 
-func getReplicasChangePatchOps(patchOps *[]util.JSONPatch, desired *cnpgv1.Cluster, replicationContext *util.ReplicationContext) {
-	*patchOps = append(*patchOps, util.JSONPatch{
-		Op:    util.JSON_PATCH_OP_REPLACE,
-		Path:  util.JSON_PATCH_PATH_EXTERNAL_CLUSTERS,
+func getReplicasChangePatchOps(patchOps *[]cnpg.JSONPatch, desired *cnpgv1.Cluster, replicationContext *util.ReplicationContext) {
+	*patchOps = append(*patchOps, cnpg.JSONPatch{
+		Op:    cnpg.PatchOpReplace,
+		Path:  cnpg.PatchPathExternalClusters,
 		Value: desired.Spec.ExternalClusters,
 	})
 	if replicationContext.IsAzureFleetNetworking() {
-		*patchOps = append(*patchOps, util.JSONPatch{
-			Op:    util.JSON_PATCH_OP_REPLACE,
-			Path:  util.JSON_PATCH_PATH_MANAGED_SERVICES,
+		*patchOps = append(*patchOps, cnpg.JSONPatch{
+			Op:    cnpg.PatchOpReplace,
+			Path:  cnpg.PatchPathManagedServices,
 			Value: desired.Spec.Managed.Services.Additional,
 		})
 	}
 	if replicationContext.IsPrimary() {
-		*patchOps = append(*patchOps, util.JSONPatch{
-			Op:    util.JSON_PATCH_OP_REPLACE,
-			Path:  util.JSON_PATCH_PATH_SYNCHRONOUS,
+		*patchOps = append(*patchOps, cnpg.JSONPatch{
+			Op:    cnpg.PatchOpReplace,
+			Path:  cnpg.PatchPathSynchronous,
 			Value: desired.Spec.PostgresConfiguration.Synchronous,
 		})
 	}

--- a/operator/src/internal/controller/physical_replication_test.go
+++ b/operator/src/internal/controller/physical_replication_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	dbpreview "github.com/documentdb/documentdb-operator/api/preview"
+	"github.com/documentdb/documentdb-operator/internal/cnpg"
 	util "github.com/documentdb/documentdb-operator/internal/utils"
 )
 
@@ -114,6 +115,370 @@ var _ = Describe("Physical Replication", func() {
 		Expect(errors.IsNotFound(err)).To(BeTrue())
 	})
 
+	It("returns nil when ReplicaCluster is nil (non-replicated)", func() {
+		ctx := context.Background()
+		namespace := "default"
+
+		documentdb := baseDocumentDB("docdb-norepl", namespace)
+
+		current := &cnpgv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "docdb-norepl",
+				Namespace: namespace,
+			},
+			Spec: cnpgv1.ClusterSpec{},
+		}
+		desired := current.DeepCopy()
+
+		reconciler := buildDocumentDBReconciler(current)
+		patchOps, err, requeue := reconciler.syncReplicationChanges(ctx, current, desired, documentdb, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(patchOps).To(BeNil())
+		Expect(requeue).To(Equal(time.Duration(-1)))
+	})
+
+	It("returns error when Self is changed", func() {
+		ctx := context.Background()
+		namespace := "default"
+
+		documentdb := baseDocumentDB("docdb-selferr", namespace)
+
+		current := &cnpgv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "docdb-selferr",
+				Namespace: namespace,
+			},
+			Spec: cnpgv1.ClusterSpec{
+				ReplicaCluster: &cnpgv1.ReplicaClusterConfiguration{
+					Self:    "cluster-a",
+					Primary: "cluster-a",
+					Source:  "cluster-a",
+				},
+			},
+		}
+		desired := current.DeepCopy()
+		desired.Spec.ReplicaCluster.Self = "cluster-b"
+
+		reconciler := buildDocumentDBReconciler(current)
+		_, err, requeue := reconciler.syncReplicationChanges(ctx, current, desired, documentdb, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("self cannot be changed"))
+		Expect(requeue).To(Equal(time.Second * 60))
+	})
+
+	It("builds patch ops for replica => replica primary change", func() {
+		ctx := context.Background()
+		namespace := "default"
+
+		documentdb := baseDocumentDB("docdb-r2r", namespace)
+		documentdb.Spec.ClusterReplication = &dbpreview.ClusterReplication{
+			CrossCloudNetworkingStrategy: string(util.None),
+			Primary:                      "cluster-c",
+			ClusterList: []dbpreview.MemberCluster{
+				{Name: "cluster-a"},
+				{Name: "cluster-b"},
+				{Name: "cluster-c"},
+			},
+		}
+
+		current := &cnpgv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "docdb-r2r",
+				Namespace: namespace,
+			},
+			Spec: cnpgv1.ClusterSpec{
+				ReplicaCluster: &cnpgv1.ReplicaClusterConfiguration{
+					Self:    "cluster-a",
+					Primary: "cluster-b",
+					Source:  "cluster-b",
+				},
+				ExternalClusters: []cnpgv1.ExternalCluster{
+					{Name: "cluster-a"},
+					{Name: "cluster-b"},
+					{Name: "cluster-c"},
+				},
+			},
+		}
+
+		desired := current.DeepCopy()
+		desired.Spec.ReplicaCluster.Primary = "cluster-c"
+		desired.Spec.ReplicaCluster.Source = "cluster-c"
+
+		reconciler := buildDocumentDBReconciler(current)
+		replicationContext, err := util.GetReplicationContext(ctx, reconciler.Client, *documentdb)
+		Expect(err).ToNot(HaveOccurred())
+
+		patchOps, err, requeue := reconciler.syncReplicationChanges(ctx, current, desired, documentdb, replicationContext)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(requeue).To(Equal(time.Duration(-1)))
+		// Should have a ReplicaCluster replace patch
+		Expect(patchOps).ToNot(BeEmpty())
+		found := false
+		for _, op := range patchOps {
+			if op.Path == cnpg.PatchPathReplicaCluster {
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue())
+	})
+
+	It("builds patch ops for replica => primary promotion without old primary", func() {
+		ctx := context.Background()
+		namespace := "default"
+
+		documentdb := baseDocumentDB("docdb-r2p", namespace)
+		documentdb.Spec.ClusterReplication = &dbpreview.ClusterReplication{
+			CrossCloudNetworkingStrategy: string(util.None),
+			Primary:                      "cluster-a",
+			ClusterList: []dbpreview.MemberCluster{
+				{Name: "cluster-a"},
+				{Name: "cluster-b"},
+			},
+		}
+
+		current := &cnpgv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "docdb-r2p",
+				Namespace: namespace,
+			},
+			Spec: cnpgv1.ClusterSpec{
+				ReplicaCluster: &cnpgv1.ReplicaClusterConfiguration{
+					Self:    "cluster-a",
+					Primary: "cluster-b",
+					Source:  "cluster-b",
+				},
+				ExternalClusters: []cnpgv1.ExternalCluster{
+					{Name: "cluster-a"},
+					{Name: "cluster-b"},
+				},
+			},
+		}
+
+		desired := current.DeepCopy()
+		// Promote cluster-a to primary
+		desired.Spec.ReplicaCluster.Primary = "cluster-a"
+
+		reconciler := buildDocumentDBReconciler(current)
+		// Empty OtherCNPGClusterNames means old primary is not available
+		replicationContext := &util.ReplicationContext{
+			OtherCNPGClusterNames: []string{}, // old primary not available
+		}
+
+		patchOps, err, requeue := reconciler.syncReplicationChanges(ctx, current, desired, documentdb, replicationContext)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(requeue).To(Equal(time.Duration(-1)))
+		Expect(patchOps).ToNot(BeEmpty())
+		found := false
+		for _, op := range patchOps {
+			if op.Path == cnpg.PatchPathReplicaCluster {
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue())
+	})
+
+	It("builds patch ops for primary => replica demotion", func() {
+		ctx := context.Background()
+		namespace := "default"
+
+		documentdb := baseDocumentDB("docdb-p2r", namespace)
+		documentdb.Spec.ClusterReplication = &dbpreview.ClusterReplication{
+			CrossCloudNetworkingStrategy: string(util.None),
+			Primary:                      "cluster-b",
+			ClusterList: []dbpreview.MemberCluster{
+				{Name: "cluster-a"},
+				{Name: "cluster-b"},
+			},
+		}
+
+		current := &cnpgv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "docdb-p2r",
+				Namespace: namespace,
+			},
+			Spec: cnpgv1.ClusterSpec{
+				ReplicaCluster: &cnpgv1.ReplicaClusterConfiguration{
+					Self:    "cluster-a",
+					Primary: "cluster-a",
+					Source:  "cluster-a",
+				},
+				ExternalClusters: []cnpgv1.ExternalCluster{
+					{Name: "cluster-a"},
+					{Name: "cluster-b"},
+				},
+				Bootstrap: &cnpgv1.BootstrapConfiguration{
+					PgBaseBackup: &cnpgv1.BootstrapPgBaseBackup{
+						Source: "cluster-b",
+					},
+				},
+			},
+		}
+
+		desired := current.DeepCopy()
+		desired.Spec.ReplicaCluster.Primary = "cluster-b"
+
+		reconciler := buildDocumentDBReconciler(current)
+		replicationContext := &util.ReplicationContext{
+			OtherCNPGClusterNames: []string{"cluster-b"},
+		}
+
+		patchOps, err, requeue := reconciler.syncReplicationChanges(ctx, current, desired, documentdb, replicationContext)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(requeue).To(Equal(time.Duration(-1)))
+		Expect(patchOps).ToNot(BeEmpty())
+		// Should have bootstrap remove and replica cluster replace
+		hasBootstrapRemove := false
+		hasReplicaReplace := false
+		for _, op := range patchOps {
+			if op.Path == cnpg.PatchPathBootstrap && op.Op == cnpg.PatchOpRemove {
+				hasBootstrapRemove = true
+			}
+			if op.Path == cnpg.PatchPathReplicaCluster && op.Op == cnpg.PatchOpReplace {
+				hasReplicaReplace = true
+			}
+		}
+		Expect(hasBootstrapRemove).To(BeTrue())
+		Expect(hasReplicaReplace).To(BeTrue())
+	})
+
+	It("builds patch ops for primary => replica demotion with HA", func() {
+		ctx := context.Background()
+		namespace := "default"
+
+		documentdb := baseDocumentDB("docdb-p2r-ha", namespace)
+		documentdb.Spec.ClusterReplication = &dbpreview.ClusterReplication{
+			CrossCloudNetworkingStrategy: string(util.None),
+			Primary:                      "cluster-b",
+			HighAvailability:             true,
+			ClusterList: []dbpreview.MemberCluster{
+				{Name: "cluster-a"},
+				{Name: "cluster-b"},
+			},
+		}
+
+		current := &cnpgv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "docdb-p2r-ha",
+				Namespace: namespace,
+			},
+			Spec: cnpgv1.ClusterSpec{
+				Instances: 2,
+				ReplicaCluster: &cnpgv1.ReplicaClusterConfiguration{
+					Self:    "cluster-a",
+					Primary: "cluster-a",
+					Source:  "cluster-a",
+				},
+				ExternalClusters: []cnpgv1.ExternalCluster{
+					{Name: "cluster-a"},
+					{Name: "cluster-b"},
+				},
+				PostgresConfiguration: cnpgv1.PostgresConfiguration{
+					Synchronous: &cnpgv1.SynchronousReplicaConfiguration{
+						Method: cnpgv1.SynchronousReplicaConfigurationMethodAny,
+						Number: 1,
+					},
+				},
+				Plugins: []cnpgv1.PluginConfiguration{
+					{Name: "my-plugin"},
+				},
+			},
+		}
+
+		desired := current.DeepCopy()
+		desired.Spec.ReplicaCluster.Primary = "cluster-b"
+		desired.Spec.Instances = 1
+		desired.Spec.Plugins = []cnpgv1.PluginConfiguration{{Name: "my-plugin-updated"}}
+
+		reconciler := buildDocumentDBReconciler(current)
+		replicationContext := &util.ReplicationContext{
+			OtherCNPGClusterNames: []string{"cluster-b"},
+		}
+
+		patchOps, err, requeue := reconciler.syncReplicationChanges(ctx, current, desired, documentdb, replicationContext)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(requeue).To(Equal(time.Duration(-1)))
+		// HA demotion should include: bootstrap remove, replica replace, sync remove, instances replace, plugins replace
+		Expect(len(patchOps)).To(BeNumerically(">=", 4))
+
+		paths := make(map[string]bool)
+		for _, op := range patchOps {
+			paths[op.Path] = true
+		}
+		Expect(paths).To(HaveKey(cnpg.PatchPathReplicaCluster))
+		Expect(paths).To(HaveKey(cnpg.PatchPathInstances))
+		Expect(paths).To(HaveKey(cnpg.PatchPathPlugins))
+		Expect(paths).To(HaveKey(cnpg.PatchPathPostgresConfigSyn))
+	})
+
+	It("builds patch ops for replica => primary promotion with HA", func() {
+		ctx := context.Background()
+		namespace := "default"
+
+		documentdb := baseDocumentDB("docdb-r2p-ha", namespace)
+		documentdb.Spec.ClusterReplication = &dbpreview.ClusterReplication{
+			CrossCloudNetworkingStrategy: string(util.None),
+			Primary:                      "cluster-a",
+			HighAvailability:             true,
+			ClusterList: []dbpreview.MemberCluster{
+				{Name: "cluster-a"},
+				{Name: "cluster-b"},
+			},
+		}
+
+		current := &cnpgv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "docdb-r2p-ha",
+				Namespace: namespace,
+			},
+			Spec: cnpgv1.ClusterSpec{
+				Instances: 1,
+				ReplicaCluster: &cnpgv1.ReplicaClusterConfiguration{
+					Self:    "cluster-a",
+					Primary: "cluster-b",
+					Source:  "cluster-b",
+				},
+				ExternalClusters: []cnpgv1.ExternalCluster{
+					{Name: "cluster-a"},
+					{Name: "cluster-b"},
+				},
+			},
+		}
+
+		desired := current.DeepCopy()
+		desired.Spec.ReplicaCluster.Primary = "cluster-a"
+		desired.Spec.Instances = 2
+		desired.Spec.PostgresConfiguration = cnpgv1.PostgresConfiguration{
+			Synchronous: &cnpgv1.SynchronousReplicaConfiguration{
+				Method: cnpgv1.SynchronousReplicaConfigurationMethodAny,
+				Number: 1,
+			},
+		}
+		desired.Spec.Plugins = []cnpgv1.PluginConfiguration{{Name: "my-plugin"}}
+		desired.Spec.ReplicationSlots = &cnpgv1.ReplicationSlotsConfiguration{}
+
+		reconciler := buildDocumentDBReconciler(current)
+		// Old primary not available — skip token read
+		replicationContext := &util.ReplicationContext{
+			OtherCNPGClusterNames: []string{},
+		}
+
+		patchOps, err, requeue := reconciler.syncReplicationChanges(ctx, current, desired, documentdb, replicationContext)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(requeue).To(Equal(time.Duration(-1)))
+		// HA promotion should include: replica replace, postgres config, instances, plugins, replication slots
+		Expect(len(patchOps)).To(BeNumerically(">=", 4))
+
+		paths := make(map[string]bool)
+		for _, op := range patchOps {
+			paths[op.Path] = true
+		}
+		Expect(paths).To(HaveKey(cnpg.PatchPathReplicaCluster))
+		Expect(paths).To(HaveKey(cnpg.PatchPathInstances))
+		Expect(paths).To(HaveKey(cnpg.PatchPathPlugins))
+		Expect(paths).To(HaveKey(cnpg.PatchPathPostgresConfig))
+		Expect(paths).To(HaveKey(cnpg.PatchPathReplicationSlots))
+	})
+
 	It("updates external clusters and synchronous config", func() {
 		ctx := context.Background()
 		namespace := "default"
@@ -167,9 +532,13 @@ var _ = Describe("Physical Replication", func() {
 		replicationContext, err := util.GetReplicationContext(ctx, reconciler.Client, *documentdb)
 		Expect(err).ToNot(HaveOccurred())
 
-		err, requeue := reconciler.TryUpdateCluster(ctx, current, desired, documentdb, replicationContext)
+		patchOps, err, requeue := reconciler.syncReplicationChanges(ctx, current, desired, documentdb, replicationContext)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(requeue).To(Equal(time.Duration(-1)))
+
+		// Apply the ops via SyncCnpgCluster (consolidates all patches)
+		syncErr := cnpg.SyncCnpgCluster(ctx, reconciler.Client, current, desired, patchOps)
+		Expect(syncErr).ToNot(HaveOccurred())
 
 		updated := &cnpgv1.Cluster{}
 		Expect(reconciler.Client.Get(ctx, types.NamespacedName{Name: current.Name, Namespace: namespace}, updated)).To(Succeed())

--- a/operator/src/internal/utils/constants.go
+++ b/operator/src/internal/utils/constants.go
@@ -56,27 +56,6 @@ const (
 
 	CNPG_MAX_CLUSTER_NAME_LENGTH = 50
 
-	// JSON Patch paths
-	JSON_PATCH_PATH_REPLICA_CLUSTER      = "/spec/replica"
-	JSON_PATCH_PATH_POSTGRES_CONFIG      = "/spec/postgresql"
-	JSON_PATCH_PATH_POSTGRES_CONFIG_SYNC = "/spec/postgresql/synchronous"
-	JSON_PATCH_PATH_INSTANCES            = "/spec/instances"
-	JSON_PATCH_PATH_PLUGINS              = "/spec/plugins"
-	JSON_PATCH_PATH_REPLICATION_SLOTS    = "/spec/replicationSlots"
-	JSON_PATCH_PATH_EXTERNAL_CLUSTERS    = "/spec/externalClusters"
-	JSON_PATCH_PATH_MANAGED_SERVICES     = "/spec/managed/services/additional"
-	JSON_PATCH_PATH_SYNCHRONOUS          = "/spec/postgresql/synchronous"
-	JSON_PATCH_PATH_BOOTSTRAP            = "/spec/bootstrap"
-
-	// JSON Patch path format strings for image upgrades (require fmt.Sprintf with index)
-	JSON_PATCH_PATH_EXTENSION_IMAGE_FMT      = "/spec/postgresql/extensions/%d/image/reference"
-	JSON_PATCH_PATH_PLUGIN_GATEWAY_IMAGE_FMT = "/spec/plugins/%d/parameters/gatewayImage"
-
-	// JSON Patch operations
-	JSON_PATCH_OP_REPLACE = "replace"
-	JSON_PATCH_OP_ADD     = "add"
-	JSON_PATCH_OP_REMOVE  = "remove"
-
 	// SQL job resource requirements and container security context
 	SQL_JOB_REQUESTS_MEMORY  = "32Mi"
 	SQL_JOB_REQUESTS_CPU     = "10m"

--- a/operator/src/internal/utils/util.go
+++ b/operator/src/internal/utils/util.go
@@ -28,12 +28,6 @@ import (
 	dbpreview "github.com/documentdb/documentdb-operator/api/preview"
 )
 
-type JSONPatch struct {
-	Op    string      `json:"op"`
-	Path  string      `json:"path"`
-	Value interface{} `json:"value,omitempty"`
-}
-
 // GetDocumentDBServiceDefinition returns the LoadBalancer Service definition for a given DocumentDB instance
 func GetDocumentDBServiceDefinition(documentdb *dbpreview.DocumentDB, replicationContext *ReplicationContext, namespace string, serviceType corev1.ServiceType) *corev1.Service {
 	// If no local HA, these two should be empty


### PR DESCRIPTION
## Summary

Consolidates all scattered CNPG Cluster spec mutations into a single `SyncCnpgCluster()` entry point, applied as one atomic JSON Patch. This consolidates the scattered mutation sites into a single code path, making it easier to reason about what gets synced and to add new mutable fields in the future.

Fixes #306

## Changes

### New files
- **`internal/cnpg/cnpg_sync.go`**  Single `SyncCnpgCluster()` function that diffs current vs desired CNPG Cluster and builds JSON Patch ops for: extension image, gateway image, plugin parameters (TLS secret), and replication changes (via `extraOps`). Applies all ops in one atomic patch.
- **`internal/cnpg/cnpg_patch.go`**  `JSONPatch` struct and all JSON Patch constants (ops, paths, format strings), moved from `utils/`.
- **`internal/cnpg/cnpg_sync_test.go`**  Unit tests covering no-op, extension image, gateway image, plugin params, TLS secret sync, restart annotation, plugin re-enable, extra ops, error cases, and helper functions.

### Modified files
- **`internal/controller/documentdb_controller.go`**  Replaced 3 scattered CNPG mutation sites with a single `SyncCnpgCluster()` call. Refactored `upgradeDocumentDBIfNeeded()`  `handleExtensionUpgrade()` (image patching is now handled by `SyncCnpgCluster`; this function only runs `ALTER EXTENSION UPDATE`).
- **`internal/controller/physical_replication.go`**  Renamed `TryUpdateCluster`  `syncReplicationChanges`, returns `([]JSONPatch, error, time.Duration)` instead of applying patches directly. Replication ops are passed to `SyncCnpgCluster` as `extraOps` for atomic application.
- **`internal/controller/physical_replication_test.go`**  Added tests for all `syncReplicationChanges` / `getPrimaryChangePatchOps` paths: nil ReplicaCluster, Self change error, replicareplica, replicaprimary, primaryreplica, HA demotion, HA promotion.
- **`internal/utils/constants.go`**  Removed JSON Patch constants (moved to `cnpg_patch.go`).
- **`internal/utils/util.go`**  Removed `JSONPatch` struct (moved to `cnpg_patch.go`).

### Architecture

```
reconcileDocumentDB()
    syncReplicationChanges()  []JSONPatch (side effects: token reads, goroutines)
    SyncCnpgCluster(current, desired, extraOps)
         diff extension image
         diff gateway image
         diff plugin parameters (TLS secret, enabled state)
         append extraOps (replication)
         atomic JSON Patch (one API call)
         MergePatch restart annotation (if needed for non-extension changes)
    handleExtensionUpgrade()  ALTER EXTENSION UPDATE lifecycle
```

All CNPG spec mutations go through one function, one patch call. Replication logic stays in its own function for separation of concerns (side effects), but ops are merged into the same atomic patch.

## Testing

- All existing tests pass
- New unit tests for `SyncCnpgCluster` cover image upgrades, plugin param changes, TLS secret sync, restart annotation logic, plugin re-enable, extra ops, and error cases
- New unit tests for `syncReplicationChanges` / `getPrimaryChangePatchOps` cover all replication transition paths (primaryreplica, replicaprimary, replicareplica) with and without HA

## Future Work

This PR lays the groundwork for:
- **Mutable field propagation** (#298, #308): Add more spec fields to `SyncCnpgCluster` (e.g., instances, storage size, log level, affinity, PG parameters) so user changes to the DocumentDB spec are propagated to the underlying CNPG Cluster.
- **Immutable field validation**: Add CEL validation rules or webhook checks to enforce immutability for fields that cannot be safely changed after creation (e.g., storage class, environment variables).
