### PR TITLE
feat: propagate mutable spec fields and validate immutable fields

### DIFF
--- a/.github/workflows/test-build-and-package.yml
+++ b/.github/workflows/test-build-and-package.yml
@@ -184,7 +184,7 @@ jobs:
     - name: Build gateway deb
       # Gateway is a pure Rust binary; PG version is a passthrough and does not affect the output.
       # Using pg 17 matches the upstream documentdb repo convention (gateway built once, not per-PG).
-      run: ./packaging/build_gateway_packages.sh --os deb13 --pg 17 --output-dir packages
+      run: ./packaging/gateway/build_gateway_packages.sh --os deb13 --pg 17 --output-dir packages
 
     - name: Upload packages
       uses: actions/upload-artifact@v4

--- a/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
+++ b/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
@@ -1311,7 +1311,6 @@ spec:
                   SchemaVersion controls the desired schema version for the DocumentDB extension.
 
                   The operator never changes your database schema unless you ask:
-                    - Set documentDBVersion → updates the binary (safe to roll back)
                     - Set schemaVersion → updates the database schema (irreversible)
                     - Set schemaVersion: "auto" → schema auto-updates with binary
 

--- a/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
+++ b/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
@@ -1153,6 +1153,9 @@ spec:
                   for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
                   a default secret name `documentdb-credentials` is used.
                 type: string
+                x-kubernetes-validations:
+                - message: credential secret cannot be changed after cluster creation
+                  rule: self == oldSelf
               environment:
                 description: |-
                   Environment specifies the cloud environment for deployment
@@ -1294,6 +1297,9 @@ spec:
                           StorageClass specifies the storage class for DocumentDB persistent volumes.
                           If not specified, the cluster's default storage class will be used.
                         type: string
+                        x-kubernetes-validations:
+                        - message: storage class cannot be changed after cluster creation
+                          rule: self == oldSelf
                     required:
                     - pvcSize
                     type: object
@@ -1304,8 +1310,13 @@ spec:
                 description: |-
                   SchemaVersion controls the desired schema version for the DocumentDB extension.
 
-                  This field decouples the extension binary (image) update from the schema update
-                  (ALTER EXTENSION documentdb UPDATE), providing a rollback-safe upgrade window.
+                  The operator never changes your database schema unless you ask:
+                    - Set documentDBVersion → updates the binary (safe to roll back)
+                    - Set schemaVersion → updates the database schema (irreversible)
+                    - Set schemaVersion: "auto" → schema auto-updates with binary
+
+                  Once the schema has been updated, the operator blocks image rollback below the
+                  installed schema version to prevent running an untested binary/schema combination.
 
                   Values:
                     - "" (empty, default): Two-phase mode. Image upgrades happen automatically,
@@ -1314,7 +1325,7 @@ spec:
                       as it allows rollback by reverting the image before committing the schema change.
                     - "auto": Schema automatically updates to match the binary version whenever
                       the binary is upgraded. This is the simplest mode but provides no rollback
-                      safety window. Recommended for development and testing environments.
+                      safety window.
                     - "<version>" (e.g. "0.112.0"): Schema updates to exactly this version.
                       Must be <= the binary version.
                 pattern: ^(auto|[0-9]+\.[0-9]+\.[0-9]+)?$
@@ -1323,6 +1334,10 @@ spec:
                 description: SidecarInjectorPluginName is the name of the sidecar
                   injector plugin to use.
                 type: string
+                x-kubernetes-validations:
+                - message: sidecar injector plugin name cannot be changed after cluster
+                    creation
+                  rule: self == oldSelf
               timeouts:
                 properties:
                   stopDelay:

--- a/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
+++ b/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
@@ -1152,6 +1152,8 @@ spec:
                   DocumentDbCredentialSecret is the name of the Kubernetes Secret containing credentials
                   for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
                   a default secret name `documentdb-credentials` is used.
+
+                  NOTE: Immutable today; will be relaxed to support credential rotation (see #331).
                 type: string
                 x-kubernetes-validations:
                 - message: credential secret cannot be changed after cluster creation
@@ -1291,6 +1293,7 @@ spec:
                       pvcSize:
                         description: PvcSize is the size of the persistent volume
                           claim for DocumentDB storage (e.g., "10Gi").
+                        minLength: 1
                         type: string
                       storageClass:
                         description: |-
@@ -1324,7 +1327,7 @@ spec:
                       as it allows rollback by reverting the image before committing the schema change.
                     - "auto": Schema automatically updates to match the binary version whenever
                       the binary is upgraded. This is the simplest mode but provides no rollback
-                      safety window.
+                      safety window. Only recommended for single-region clusters.
                     - "<version>" (e.g. "0.112.0"): Schema updates to exactly this version.
                       Must be <= the binary version.
                 pattern: ^(auto|[0-9]+\.[0-9]+\.[0-9]+)?$

--- a/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
+++ b/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
@@ -1153,7 +1153,7 @@ spec:
                   for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
                   a default secret name `documentdb-credentials` is used.
 
-                  NOTE: Immutable today; will be relaxed to support credential rotation (see #331).
+                  NOTE: Immutable today; will be relaxed in a future release to support credential rotation.
                 type: string
                 x-kubernetes-validations:
                 - message: credential secret cannot be changed after cluster creation

--- a/operator/src/api/preview/documentdb_types.go
+++ b/operator/src/api/preview/documentdb_types.go
@@ -55,7 +55,7 @@ type DocumentDBSpec struct {
 	// for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
 	// a default secret name `documentdb-credentials` is used.
 	//
-	// NOTE: Immutable today; will be relaxed to support credential rotation (see #331).
+	// NOTE: Immutable today; will be relaxed in a future release to support credential rotation.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="credential secret cannot be changed after cluster creation"
 	DocumentDbCredentialSecret string `json:"documentDbCredentialSecret,omitempty"`
 

--- a/operator/src/api/preview/documentdb_types.go
+++ b/operator/src/api/preview/documentdb_types.go
@@ -108,7 +108,6 @@ type DocumentDBSpec struct {
 	// SchemaVersion controls the desired schema version for the DocumentDB extension.
 	//
 	// The operator never changes your database schema unless you ask:
-	//   - Set documentDBVersion → updates the binary (safe to roll back)
 	//   - Set schemaVersion → updates the database schema (irreversible)
 	//   - Set schemaVersion: "auto" → schema auto-updates with binary
 	//

--- a/operator/src/api/preview/documentdb_types.go
+++ b/operator/src/api/preview/documentdb_types.go
@@ -54,12 +54,14 @@ type DocumentDBSpec struct {
 	// DocumentDbCredentialSecret is the name of the Kubernetes Secret containing credentials
 	// for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
 	// a default secret name `documentdb-credentials` is used.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="credential secret cannot be changed after cluster creation"
 	DocumentDbCredentialSecret string `json:"documentDbCredentialSecret,omitempty"`
 
 	// ClusterReplication configures cross-cluster replication for DocumentDB.
 	ClusterReplication *ClusterReplication `json:"clusterReplication,omitempty"`
 
 	// SidecarInjectorPluginName is the name of the sidecar injector plugin to use.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="sidecar injector plugin name cannot be changed after cluster creation"
 	SidecarInjectorPluginName string `json:"sidecarInjectorPluginName,omitempty"`
 
 	// WalReplicaPluginName is the name of the wal replica plugin to use.
@@ -189,6 +191,7 @@ type StorageConfiguration struct {
 
 	// StorageClass specifies the storage class for DocumentDB persistent volumes.
 	// If not specified, the cluster's default storage class will be used.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="storage class cannot be changed after cluster creation"
 	StorageClass string `json:"storageClass,omitempty"`
 
 	// PersistentVolumeReclaimPolicy controls what happens to the PersistentVolume when

--- a/operator/src/api/preview/documentdb_types.go
+++ b/operator/src/api/preview/documentdb_types.go
@@ -54,6 +54,8 @@ type DocumentDBSpec struct {
 	// DocumentDbCredentialSecret is the name of the Kubernetes Secret containing credentials
 	// for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
 	// a default secret name `documentdb-credentials` is used.
+	//
+	// NOTE: Immutable today; will be relaxed to support credential rotation (see #331).
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="credential secret cannot be changed after cluster creation"
 	DocumentDbCredentialSecret string `json:"documentDbCredentialSecret,omitempty"`
 
@@ -121,7 +123,7 @@ type DocumentDBSpec struct {
 	//     as it allows rollback by reverting the image before committing the schema change.
 	//   - "auto": Schema automatically updates to match the binary version whenever
 	//     the binary is upgraded. This is the simplest mode but provides no rollback
-	//     safety window.
+	//     safety window. Only recommended for single-region clusters.
 	//   - "<version>" (e.g. "0.112.0"): Schema updates to exactly this version.
 	//     Must be <= the binary version.
 	//
@@ -186,6 +188,7 @@ type Resource struct {
 
 type StorageConfiguration struct {
 	// PvcSize is the size of the persistent volume claim for DocumentDB storage (e.g., "10Gi").
+	// +kubebuilder:validation:MinLength=1
 	PvcSize string `json:"pvcSize"`
 
 	// StorageClass specifies the storage class for DocumentDB persistent volumes.

--- a/operator/src/config/crd/bases/documentdb.io_dbs.yaml
+++ b/operator/src/config/crd/bases/documentdb.io_dbs.yaml
@@ -1311,7 +1311,6 @@ spec:
                   SchemaVersion controls the desired schema version for the DocumentDB extension.
 
                   The operator never changes your database schema unless you ask:
-                    - Set documentDBVersion → updates the binary (safe to roll back)
                     - Set schemaVersion → updates the database schema (irreversible)
                     - Set schemaVersion: "auto" → schema auto-updates with binary
 

--- a/operator/src/config/crd/bases/documentdb.io_dbs.yaml
+++ b/operator/src/config/crd/bases/documentdb.io_dbs.yaml
@@ -1153,6 +1153,9 @@ spec:
                   for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
                   a default secret name `documentdb-credentials` is used.
                 type: string
+                x-kubernetes-validations:
+                - message: credential secret cannot be changed after cluster creation
+                  rule: self == oldSelf
               environment:
                 description: |-
                   Environment specifies the cloud environment for deployment
@@ -1294,6 +1297,9 @@ spec:
                           StorageClass specifies the storage class for DocumentDB persistent volumes.
                           If not specified, the cluster's default storage class will be used.
                         type: string
+                        x-kubernetes-validations:
+                        - message: storage class cannot be changed after cluster creation
+                          rule: self == oldSelf
                     required:
                     - pvcSize
                     type: object
@@ -1304,8 +1310,13 @@ spec:
                 description: |-
                   SchemaVersion controls the desired schema version for the DocumentDB extension.
 
-                  This field decouples the extension binary (image) update from the schema update
-                  (ALTER EXTENSION documentdb UPDATE), providing a rollback-safe upgrade window.
+                  The operator never changes your database schema unless you ask:
+                    - Set documentDBVersion → updates the binary (safe to roll back)
+                    - Set schemaVersion → updates the database schema (irreversible)
+                    - Set schemaVersion: "auto" → schema auto-updates with binary
+
+                  Once the schema has been updated, the operator blocks image rollback below the
+                  installed schema version to prevent running an untested binary/schema combination.
 
                   Values:
                     - "" (empty, default): Two-phase mode. Image upgrades happen automatically,
@@ -1314,7 +1325,7 @@ spec:
                       as it allows rollback by reverting the image before committing the schema change.
                     - "auto": Schema automatically updates to match the binary version whenever
                       the binary is upgraded. This is the simplest mode but provides no rollback
-                      safety window. Recommended for development and testing environments.
+                      safety window.
                     - "<version>" (e.g. "0.112.0"): Schema updates to exactly this version.
                       Must be <= the binary version.
                 pattern: ^(auto|[0-9]+\.[0-9]+\.[0-9]+)?$
@@ -1323,6 +1334,10 @@ spec:
                 description: SidecarInjectorPluginName is the name of the sidecar
                   injector plugin to use.
                 type: string
+                x-kubernetes-validations:
+                - message: sidecar injector plugin name cannot be changed after cluster
+                    creation
+                  rule: self == oldSelf
               timeouts:
                 properties:
                   stopDelay:

--- a/operator/src/config/crd/bases/documentdb.io_dbs.yaml
+++ b/operator/src/config/crd/bases/documentdb.io_dbs.yaml
@@ -1152,6 +1152,8 @@ spec:
                   DocumentDbCredentialSecret is the name of the Kubernetes Secret containing credentials
                   for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
                   a default secret name `documentdb-credentials` is used.
+
+                  NOTE: Immutable today; will be relaxed to support credential rotation (see #331).
                 type: string
                 x-kubernetes-validations:
                 - message: credential secret cannot be changed after cluster creation
@@ -1291,6 +1293,7 @@ spec:
                       pvcSize:
                         description: PvcSize is the size of the persistent volume
                           claim for DocumentDB storage (e.g., "10Gi").
+                        minLength: 1
                         type: string
                       storageClass:
                         description: |-
@@ -1324,7 +1327,7 @@ spec:
                       as it allows rollback by reverting the image before committing the schema change.
                     - "auto": Schema automatically updates to match the binary version whenever
                       the binary is upgraded. This is the simplest mode but provides no rollback
-                      safety window.
+                      safety window. Only recommended for single-region clusters.
                     - "<version>" (e.g. "0.112.0"): Schema updates to exactly this version.
                       Must be <= the binary version.
                 pattern: ^(auto|[0-9]+\.[0-9]+\.[0-9]+)?$

--- a/operator/src/config/crd/bases/documentdb.io_dbs.yaml
+++ b/operator/src/config/crd/bases/documentdb.io_dbs.yaml
@@ -1153,7 +1153,7 @@ spec:
                   for the DocumentDB gateway (expects keys `username` and `password`). If omitted,
                   a default secret name `documentdb-credentials` is used.
 
-                  NOTE: Immutable today; will be relaxed to support credential rotation (see #331).
+                  NOTE: Immutable today; will be relaxed in a future release to support credential rotation.
                 type: string
                 x-kubernetes-validations:
                 - message: credential secret cannot be changed after cluster creation

--- a/operator/src/go.sum
+++ b/operator/src/go.sum
@@ -297,8 +297,6 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0 h1:qPrZsv1cwQiFe
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
 sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
-sigs.k8s.io/controller-tools v0.19.0 h1:OU7jrPPiZusryu6YK0jYSjPqg8Vhf8cAzluP9XGI5uk=
-sigs.k8s.io/controller-tools v0.19.0/go.mod h1:y5HY/iNDFkmFla2CfQoVb2AQXMsBk4ad84iR1PLANB0=
 sigs.k8s.io/gateway-api v1.4.0 h1:ZwlNM6zOHq0h3WUX2gfByPs2yAEsy/EenYJB78jpQfQ=
 sigs.k8s.io/gateway-api v1.4.0/go.mod h1:AR5RSqciWP98OPckEjOjh2XJhAe2Na4LHyXD2FUY7Qk=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/operator/src/go.sum
+++ b/operator/src/go.sum
@@ -297,6 +297,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0 h1:qPrZsv1cwQiFe
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=
 sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
+sigs.k8s.io/controller-tools v0.19.0 h1:OU7jrPPiZusryu6YK0jYSjPqg8Vhf8cAzluP9XGI5uk=
+sigs.k8s.io/controller-tools v0.19.0/go.mod h1:y5HY/iNDFkmFla2CfQoVb2AQXMsBk4ad84iR1PLANB0=
 sigs.k8s.io/gateway-api v1.4.0 h1:ZwlNM6zOHq0h3WUX2gfByPs2yAEsy/EenYJB78jpQfQ=
 sigs.k8s.io/gateway-api v1.4.0/go.mod h1:AR5RSqciWP98OPckEjOjh2XJhAe2Na4LHyXD2FUY7Qk=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/operator/src/internal/cnpg/cnpg_patch.go
+++ b/operator/src/internal/cnpg/cnpg_patch.go
@@ -32,6 +32,13 @@ const (
 	PatchPathExtensionImageFmt     = "/spec/postgresql/extensions/%d/image/reference"
 	PatchPathPluginGatewayImageFmt = "/spec/plugins/%d/parameters/gatewayImage"
 
+	// JSON Patch paths — mutable spec fields
+	PatchPathImageName  = "/spec/imageName"
+	PatchPathStorageSize = "/spec/storage/size"
+	PatchPathLogLevel   = "/spec/logLevel"
+	PatchPathAffinity   = "/spec/affinity"
+	PatchPathMaxStopDelay = "/spec/stopDelay"
+
 	// JSON Patch path for restart annotation.
 	// The '/' in the annotation key is escaped as '~1' per RFC 6901 (JSON Pointer).
 	PatchPathRestartAnnotation = "/metadata/annotations/kubectl.kubernetes.io~1restartedAt"

--- a/operator/src/internal/cnpg/cnpg_patch.go
+++ b/operator/src/internal/cnpg/cnpg_patch.go
@@ -35,6 +35,13 @@ const (
 	// JSON Patch path format string for plugin parameters (require fmt.Sprintf with index and key)
 	PatchPathPluginParamFmt = "/spec/plugins/%d/parameters/%s"
 
+	// JSON Patch paths — mutable spec fields
+	PatchPathImageName    = "/spec/imageName"
+	PatchPathStorageSize  = "/spec/storage/size"
+	PatchPathLogLevel     = "/spec/logLevel"
+	PatchPathAffinity     = "/spec/affinity"
+	PatchPathMaxStopDelay = "/spec/stopDelay"
+
 	// JSON Patch path for restart annotation.
 	// The '/' in the annotation key is escaped as '~1' per RFC 6901 (JSON Pointer).
 	PatchPathRestartAnnotation = "/metadata/annotations/kubectl.kubernetes.io~1restartedAt"

--- a/operator/src/internal/cnpg/cnpg_sync.go
+++ b/operator/src/internal/cnpg/cnpg_sync.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -94,6 +95,69 @@ func SyncCnpgCluster(
 		}
 	}
 
+	// --- Mutable spec fields ---
+	specChanged := false
+
+	// Instances (e.g., instancesPerNode scaling)
+	if current.Spec.Instances != desired.Spec.Instances {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathInstances,
+			Value: desired.Spec.Instances,
+		})
+		// CNPG handles instance count changes natively (no restart needed)
+	}
+
+	// PostgreSQL image (e.g., minor version upgrade)
+	if current.Spec.ImageName != desired.Spec.ImageName {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathImageName,
+			Value: desired.Spec.ImageName,
+		})
+		specChanged = true
+	}
+
+	// Storage size (grow-only; webhook rejects shrink attempts)
+	if current.Spec.StorageConfiguration.Size != desired.Spec.StorageConfiguration.Size {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathStorageSize,
+			Value: desired.Spec.StorageConfiguration.Size,
+		})
+		// CNPG handles PVC resize natively (no restart needed)
+	}
+
+	// Log level
+	if current.Spec.LogLevel != desired.Spec.LogLevel {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathLogLevel,
+			Value: desired.Spec.LogLevel,
+		})
+		specChanged = true
+	}
+
+	// Affinity
+	if !reflect.DeepEqual(current.Spec.Affinity, desired.Spec.Affinity) {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathAffinity,
+			Value: desired.Spec.Affinity,
+		})
+		specChanged = true
+	}
+
+	// Stop delay (maxStopDelay)
+	if current.Spec.MaxStopDelay != desired.Spec.MaxStopDelay {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathMaxStopDelay,
+			Value: desired.Spec.MaxStopDelay,
+		})
+		specChanged = true
+	}
+
 	// Extra operations (e.g., replication changes)
 	patchOps = append(patchOps, extraOps...)
 
@@ -101,7 +165,7 @@ func SyncCnpgCluster(
 	// but NOT for plugin parameter or gateway-only changes. Include a restart annotation
 	// in the same atomic patch to avoid partial-apply state where the spec is updated but
 	// the restart annotation is never applied if a subsequent reconcile no-ops the spec diff.
-	needsRestart := !extensionUpdated && (gatewayUpdated || pluginParamsChanged)
+	needsRestart := !extensionUpdated && (gatewayUpdated || pluginParamsChanged || specChanged)
 	if needsRestart {
 		// Ensure the annotations map exists before adding a key into it.
 		// JSON Patch "add" requires the parent path to exist.

--- a/operator/src/internal/cnpg/cnpg_sync.go
+++ b/operator/src/internal/cnpg/cnpg_sync.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -124,6 +125,69 @@ func SyncCnpgCluster(
 		}
 	}
 
+	// --- Mutable spec fields ---
+	specChanged := false
+
+	// Instances (e.g., instancesPerNode scaling)
+	if current.Spec.Instances != desired.Spec.Instances {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathInstances,
+			Value: desired.Spec.Instances,
+		})
+		// CNPG handles instance count changes natively (no restart needed)
+	}
+
+	// PostgreSQL image (e.g., minor version upgrade)
+	if current.Spec.ImageName != desired.Spec.ImageName {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathImageName,
+			Value: desired.Spec.ImageName,
+		})
+		specChanged = true
+	}
+
+	// Storage size (grow-only; webhook rejects shrink attempts)
+	if current.Spec.StorageConfiguration.Size != desired.Spec.StorageConfiguration.Size {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathStorageSize,
+			Value: desired.Spec.StorageConfiguration.Size,
+		})
+		// CNPG handles PVC resize natively (no restart needed)
+	}
+
+	// Log level
+	if current.Spec.LogLevel != desired.Spec.LogLevel {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathLogLevel,
+			Value: desired.Spec.LogLevel,
+		})
+		specChanged = true
+	}
+
+	// Affinity
+	if !reflect.DeepEqual(current.Spec.Affinity, desired.Spec.Affinity) {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathAffinity,
+			Value: desired.Spec.Affinity,
+		})
+		specChanged = true
+	}
+
+	// Stop delay (maxStopDelay)
+	if current.Spec.MaxStopDelay != desired.Spec.MaxStopDelay {
+		patchOps = append(patchOps, JSONPatch{
+			Op:    PatchOpReplace,
+			Path:  PatchPathMaxStopDelay,
+			Value: desired.Spec.MaxStopDelay,
+		})
+		specChanged = true
+	}
+
 	// Extra operations (e.g., replication changes)
 	patchOps = append(patchOps, extraOps...)
 
@@ -131,7 +195,7 @@ func SyncCnpgCluster(
 	// but NOT for plugin parameter or gateway-only changes. Include a restart annotation
 	// in the same atomic patch to avoid partial-apply state where the spec is updated but
 	// the restart annotation is never applied if a subsequent reconcile no-ops the spec diff.
-	needsRestart := !extensionUpdated && (gatewayUpdated || pluginParamsChanged)
+	needsRestart := !extensionUpdated && (gatewayUpdated || pluginParamsChanged || specChanged)
 	if needsRestart {
 		// Ensure the annotations map exists before adding a key into it.
 		// JSON Patch "add" requires the parent path to exist.

--- a/operator/src/internal/cnpg/cnpg_sync.go
+++ b/operator/src/internal/cnpg/cnpg_sync.go
@@ -126,7 +126,9 @@ func SyncCnpgCluster(
 	}
 
 	// --- Mutable spec fields ---
-	specChanged := false
+	// CNPG natively detects changes to these fields and triggers rolling restarts
+	// when needed (via PodSpec drift detection or image comparison), so we only
+	// need to patch the CNPG Cluster spec — no manual restart annotation required.
 
 	// Instances (e.g., instancesPerNode scaling)
 	if current.Spec.Instances != desired.Spec.Instances {
@@ -135,17 +137,16 @@ func SyncCnpgCluster(
 			Path:  PatchPathInstances,
 			Value: desired.Spec.Instances,
 		})
-		// CNPG handles instance count changes natively (no restart needed)
 	}
 
 	// PostgreSQL image (e.g., minor version upgrade)
+	// CNPG detects image mismatch via checkPodImageIsOutdated and triggers rolling update.
 	if current.Spec.ImageName != desired.Spec.ImageName {
 		patchOps = append(patchOps, JSONPatch{
 			Op:    PatchOpReplace,
 			Path:  PatchPathImageName,
 			Value: desired.Spec.ImageName,
 		})
-		specChanged = true
 	}
 
 	// Storage size (grow-only; webhook rejects shrink attempts)
@@ -155,37 +156,37 @@ func SyncCnpgCluster(
 			Path:  PatchPathStorageSize,
 			Value: desired.Spec.StorageConfiguration.Size,
 		})
-		// CNPG handles PVC resize natively (no restart needed)
 	}
 
 	// Log level
+	// CNPG renders logLevel into the bootstrap container command (--log-level=...),
+	// so changes cause PodSpec drift detected by checkPodSpecIsOutdated.
 	if current.Spec.LogLevel != desired.Spec.LogLevel {
 		patchOps = append(patchOps, JSONPatch{
 			Op:    PatchOpReplace,
 			Path:  PatchPathLogLevel,
 			Value: desired.Spec.LogLevel,
 		})
-		specChanged = true
 	}
 
 	// Affinity
+	// CNPG includes affinity in the generated PodSpec and detects drift via ComparePodSpecs.
 	if !reflect.DeepEqual(current.Spec.Affinity, desired.Spec.Affinity) {
 		patchOps = append(patchOps, JSONPatch{
 			Op:    PatchOpReplace,
 			Path:  PatchPathAffinity,
 			Value: desired.Spec.Affinity,
 		})
-		specChanged = true
 	}
 
 	// Stop delay (maxStopDelay)
+	// CNPG maps this to terminationGracePeriodSeconds in PodSpec, drift triggers rollout.
 	if current.Spec.MaxStopDelay != desired.Spec.MaxStopDelay {
 		patchOps = append(patchOps, JSONPatch{
 			Op:    PatchOpReplace,
 			Path:  PatchPathMaxStopDelay,
 			Value: desired.Spec.MaxStopDelay,
 		})
-		specChanged = true
 	}
 
 	// Extra operations (e.g., replication changes)
@@ -195,7 +196,7 @@ func SyncCnpgCluster(
 	// but NOT for plugin parameter or gateway-only changes. Include a restart annotation
 	// in the same atomic patch to avoid partial-apply state where the spec is updated but
 	// the restart annotation is never applied if a subsequent reconcile no-ops the spec diff.
-	needsRestart := !extensionUpdated && (gatewayUpdated || pluginParamsChanged || specChanged)
+	needsRestart := !extensionUpdated && (gatewayUpdated || pluginParamsChanged)
 	if needsRestart {
 		// Ensure the annotations map exists before adding a key into it.
 		// JSON Patch "add" requires the parent path to exist.

--- a/operator/src/internal/cnpg/cnpg_sync_test.go
+++ b/operator/src/internal/cnpg/cnpg_sync_test.go
@@ -270,6 +270,141 @@ var _ = Describe("SyncCnpgCluster", func() {
 	})
 })
 
+var _ = Describe("SyncCnpgCluster - mutable spec fields", func() {
+	const namespace = "test-ns"
+
+	It("propagates instancesPerNode changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.Instances = 3
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.Instances).To(Equal(3))
+		// CNPG handles instance changes natively — no restart annotation needed
+	})
+
+	It("propagates pvcSize changes (grow)", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.StorageConfiguration.Size = "20Gi"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.StorageConfiguration.Size).To(Equal("20Gi"))
+	})
+
+	It("propagates postgresImage changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		current.Spec.ImageName = "ghcr.io/cloudnative-pg/postgresql:17-minimal-trixie"
+		desired := current.DeepCopy()
+		desired.Spec.ImageName = "ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.ImageName).To(Equal("ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"))
+		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+
+	It("propagates logLevel changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.LogLevel = "debug"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.LogLevel).To(Equal("debug"))
+		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+
+	It("propagates affinity changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.Affinity = cnpgv1.AffinityConfiguration{
+			EnablePodAntiAffinity: pointer.Bool(true),
+		}
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(*updated.Spec.Affinity.EnablePodAntiAffinity).To(BeTrue())
+		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+
+	It("propagates stopDelay changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.MaxStopDelay = 60
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.MaxStopDelay).To(Equal(int32(60)))
+		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+
+	It("handles multiple mutable field changes atomically", func() {
+		current := baseCluster("test-cluster", namespace)
+		current.Spec.ImageName = "ghcr.io/cloudnative-pg/postgresql:17-minimal-trixie"
+		desired := current.DeepCopy()
+		desired.Spec.Instances = 2
+		desired.Spec.ImageName = "ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"
+		desired.Spec.LogLevel = "debug"
+		desired.Spec.StorageConfiguration.Size = "50Gi"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.Instances).To(Equal(2))
+		Expect(updated.Spec.ImageName).To(Equal("ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"))
+		Expect(updated.Spec.LogLevel).To(Equal("debug"))
+		Expect(updated.Spec.StorageConfiguration.Size).To(Equal("50Gi"))
+	})
+
+	It("does not add restart annotation for instances-only or storage-only changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.Instances = 3
+		desired.Spec.StorageConfiguration.Size = "20Gi"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.Instances).To(Equal(3))
+		Expect(updated.Spec.StorageConfiguration.Size).To(Equal("20Gi"))
+		// No restart annotation — CNPG handles instances and storage natively
+		Expect(updated.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+})
+
 var _ = Describe("Helper functions", func() {
 	It("findExtensionImage returns -1 for cluster without extensions", func() {
 		cluster := &cnpgv1.Cluster{

--- a/operator/src/internal/cnpg/cnpg_sync_test.go
+++ b/operator/src/internal/cnpg/cnpg_sync_test.go
@@ -378,7 +378,8 @@ var _ = Describe("SyncCnpgCluster - mutable spec fields", func() {
 		updated := &cnpgv1.Cluster{}
 		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
 		Expect(updated.Spec.ImageName).To(Equal("ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"))
-		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+		// CNPG detects image mismatch natively — no operator restart annotation needed
+		Expect(updated.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/restartedAt"))
 	})
 
 	It("propagates logLevel changes", func() {
@@ -393,7 +394,8 @@ var _ = Describe("SyncCnpgCluster - mutable spec fields", func() {
 		updated := &cnpgv1.Cluster{}
 		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
 		Expect(updated.Spec.LogLevel).To(Equal("debug"))
-		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+		// CNPG detects logLevel drift via PodSpec comparison — no operator restart annotation needed
+		Expect(updated.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/restartedAt"))
 	})
 
 	It("propagates affinity changes", func() {
@@ -410,7 +412,8 @@ var _ = Describe("SyncCnpgCluster - mutable spec fields", func() {
 		updated := &cnpgv1.Cluster{}
 		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
 		Expect(*updated.Spec.Affinity.EnablePodAntiAffinity).To(BeTrue())
-		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+		// CNPG detects affinity drift via PodSpec comparison — no operator restart annotation needed
+		Expect(updated.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/restartedAt"))
 	})
 
 	It("propagates stopDelay changes", func() {
@@ -425,7 +428,8 @@ var _ = Describe("SyncCnpgCluster - mutable spec fields", func() {
 		updated := &cnpgv1.Cluster{}
 		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
 		Expect(updated.Spec.MaxStopDelay).To(Equal(int32(60)))
-		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+		// CNPG detects maxStopDelay drift via PodSpec comparison — no operator restart annotation needed
+		Expect(updated.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/restartedAt"))
 	})
 
 	It("handles multiple mutable field changes atomically", func() {
@@ -449,11 +453,15 @@ var _ = Describe("SyncCnpgCluster - mutable spec fields", func() {
 		Expect(updated.Spec.StorageConfiguration.Size).To(Equal("50Gi"))
 	})
 
-	It("does not add restart annotation for instances-only or storage-only changes", func() {
+	It("does not add restart annotation for any mutable spec field (CNPG handles natively)", func() {
 		current := baseCluster("test-cluster", namespace)
+		current.Spec.ImageName = "ghcr.io/cloudnative-pg/postgresql:17-minimal-trixie"
 		desired := current.DeepCopy()
 		desired.Spec.Instances = 3
 		desired.Spec.StorageConfiguration.Size = "20Gi"
+		desired.Spec.ImageName = "ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"
+		desired.Spec.LogLevel = "debug"
+		desired.Spec.MaxStopDelay = 60
 
 		c := buildFakeClient(current).Build()
 		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
@@ -463,7 +471,10 @@ var _ = Describe("SyncCnpgCluster - mutable spec fields", func() {
 		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
 		Expect(updated.Spec.Instances).To(Equal(3))
 		Expect(updated.Spec.StorageConfiguration.Size).To(Equal("20Gi"))
-		// No restart annotation — CNPG handles instances and storage natively
+		Expect(updated.Spec.ImageName).To(Equal("ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"))
+		Expect(updated.Spec.LogLevel).To(Equal("debug"))
+		Expect(updated.Spec.MaxStopDelay).To(Equal(int32(60)))
+		// No restart annotation — CNPG handles all mutable spec fields natively
 		Expect(updated.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/restartedAt"))
 	})
 })

--- a/operator/src/internal/cnpg/cnpg_sync_test.go
+++ b/operator/src/internal/cnpg/cnpg_sync_test.go
@@ -333,6 +333,141 @@ var _ = Describe("SyncCnpgCluster", func() {
 	})
 })
 
+var _ = Describe("SyncCnpgCluster - mutable spec fields", func() {
+	const namespace = "test-ns"
+
+	It("propagates instancesPerNode changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.Instances = 3
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.Instances).To(Equal(3))
+		// CNPG handles instance changes natively — no restart annotation needed
+	})
+
+	It("propagates pvcSize changes (grow)", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.StorageConfiguration.Size = "20Gi"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.StorageConfiguration.Size).To(Equal("20Gi"))
+	})
+
+	It("propagates postgresImage changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		current.Spec.ImageName = "ghcr.io/cloudnative-pg/postgresql:17-minimal-trixie"
+		desired := current.DeepCopy()
+		desired.Spec.ImageName = "ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.ImageName).To(Equal("ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"))
+		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+
+	It("propagates logLevel changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.LogLevel = "debug"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.LogLevel).To(Equal("debug"))
+		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+
+	It("propagates affinity changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.Affinity = cnpgv1.AffinityConfiguration{
+			EnablePodAntiAffinity: pointer.Bool(true),
+		}
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(*updated.Spec.Affinity.EnablePodAntiAffinity).To(BeTrue())
+		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+
+	It("propagates stopDelay changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.MaxStopDelay = 60
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.MaxStopDelay).To(Equal(int32(60)))
+		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+
+	It("handles multiple mutable field changes atomically", func() {
+		current := baseCluster("test-cluster", namespace)
+		current.Spec.ImageName = "ghcr.io/cloudnative-pg/postgresql:17-minimal-trixie"
+		desired := current.DeepCopy()
+		desired.Spec.Instances = 2
+		desired.Spec.ImageName = "ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"
+		desired.Spec.LogLevel = "debug"
+		desired.Spec.StorageConfiguration.Size = "50Gi"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.Instances).To(Equal(2))
+		Expect(updated.Spec.ImageName).To(Equal("ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"))
+		Expect(updated.Spec.LogLevel).To(Equal("debug"))
+		Expect(updated.Spec.StorageConfiguration.Size).To(Equal("50Gi"))
+	})
+
+	It("does not add restart annotation for instances-only or storage-only changes", func() {
+		current := baseCluster("test-cluster", namespace)
+		desired := current.DeepCopy()
+		desired.Spec.Instances = 3
+		desired.Spec.StorageConfiguration.Size = "20Gi"
+
+		c := buildFakeClient(current).Build()
+		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		updated := &cnpgv1.Cluster{}
+		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
+		Expect(updated.Spec.Instances).To(Equal(3))
+		Expect(updated.Spec.StorageConfiguration.Size).To(Equal("20Gi"))
+		// No restart annotation — CNPG handles instances and storage natively
+		Expect(updated.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+})
+
 var _ = Describe("Helper functions", func() {
 	It("findExtensionImage returns -1 for cluster without extensions", func() {
 		cluster := &cnpgv1.Cluster{

--- a/operator/src/internal/webhook/documentdb_webhook.go
+++ b/operator/src/internal/webhook/documentdb_webhook.go
@@ -6,10 +6,12 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -156,7 +158,8 @@ func (v *DocumentDBValidator) validateChanges(newDB, oldDB *dbpreview.DocumentDB
 	type validationFunc func(newDB, oldDB *dbpreview.DocumentDB) field.ErrorList
 	validations := []validationFunc{
 		v.validateImageRollback,
-		// Add new update-only validations here.
+		v.validateImmutableFields,
+		v.validateStorageResize,
 	}
 	for _, fn := range validations {
 		allErrs = append(allErrs, fn(newDB, oldDB)...)
@@ -208,6 +211,79 @@ func (v *DocumentDBValidator) validateImageRollback(newDB, oldDB *dbpreview.Docu
 		)}
 	}
 	return nil
+}
+
+// validateImmutableFields rejects updates to fields that cannot be changed after creation.
+func (v *DocumentDBValidator) validateImmutableFields(newDB, oldDB *dbpreview.DocumentDB) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// Credential secret is baked into running pods and plugin parameters at creation time.
+	if newDB.Spec.DocumentDbCredentialSecret != oldDB.Spec.DocumentDbCredentialSecret {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "documentDbCredentialSecret"),
+			"credential secret cannot be changed after cluster creation",
+		))
+	}
+
+	// Storage class cannot be changed — PVs cannot be migrated between storage classes.
+	if newDB.Spec.Resource.Storage.StorageClass != oldDB.Spec.Resource.Storage.StorageClass {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "resource", "storage", "storageClass"),
+			"storage class cannot be changed after cluster creation",
+		))
+	}
+
+	// Plugin name is structural — it identifies which CNPG sidecar plugin to use.
+	if newDB.Spec.SidecarInjectorPluginName != oldDB.Spec.SidecarInjectorPluginName {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "sidecarInjectorPluginName"),
+			"sidecar injector plugin name cannot be changed after cluster creation",
+		))
+	}
+
+	// Bootstrap configuration is only used during initial cluster creation.
+	if !isBootstrapEqual(newDB.Spec.Bootstrap, oldDB.Spec.Bootstrap) {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "bootstrap"),
+			"bootstrap configuration cannot be changed after cluster creation",
+		))
+	}
+
+	return allErrs
+}
+
+// validateStorageResize ensures PVC size can only grow, never shrink.
+func (v *DocumentDBValidator) validateStorageResize(newDB, oldDB *dbpreview.DocumentDB) field.ErrorList {
+	oldSize := oldDB.Spec.Resource.Storage.PvcSize
+	newSize := newDB.Spec.Resource.Storage.PvcSize
+	if oldSize == "" || newSize == "" || oldSize == newSize {
+		return nil
+	}
+
+	oldQty, errOld := resource.ParseQuantity(oldSize)
+	newQty, errNew := resource.ParseQuantity(newSize)
+	if errOld != nil || errNew != nil {
+		return nil // Let Kubernetes API server handle invalid quantities
+	}
+
+	if newQty.Cmp(oldQty) < 0 {
+		return field.ErrorList{field.Forbidden(
+			field.NewPath("spec", "resource", "storage", "pvcSize"),
+			fmt.Sprintf("storage size can only be increased; attempted shrink from %s to %s", oldSize, newSize),
+		)}
+	}
+	return nil
+}
+
+// isBootstrapEqual compares two BootstrapConfiguration pointers for equality.
+func isBootstrapEqual(a, b *dbpreview.BootstrapConfiguration) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return reflect.DeepEqual(a, b)
 }
 
 // ---------------------------------------------------------------------------

--- a/operator/src/internal/webhook/documentdb_webhook.go
+++ b/operator/src/internal/webhook/documentdb_webhook.go
@@ -238,19 +238,38 @@ func (v *DocumentDBValidator) validateImmutableFields(newDB, oldDB *dbpreview.Do
 func (v *DocumentDBValidator) validateStorageResize(newDB, oldDB *dbpreview.DocumentDB) field.ErrorList {
 	oldSize := oldDB.Spec.Resource.Storage.PvcSize
 	newSize := newDB.Spec.Resource.Storage.PvcSize
-	if oldSize == "" || newSize == "" || oldSize == newSize {
+	if oldSize == newSize {
 		return nil
 	}
 
+	pvcSizePath := field.NewPath("spec", "resource", "storage", "pvcSize")
+	var allErrs field.ErrorList
+
 	oldQty, errOld := resource.ParseQuantity(oldSize)
+	if errOld != nil {
+		allErrs = append(allErrs, field.Invalid(
+			pvcSizePath,
+			oldSize,
+			fmt.Sprintf("existing pvcSize is not a valid resource quantity: %v", errOld),
+		))
+	}
+
 	newQty, errNew := resource.ParseQuantity(newSize)
-	if errOld != nil || errNew != nil {
-		return nil // Let Kubernetes API server handle invalid quantities
+	if errNew != nil {
+		allErrs = append(allErrs, field.Invalid(
+			pvcSizePath,
+			newSize,
+			fmt.Sprintf("pvcSize must be a valid resource quantity: %v", errNew),
+		))
+	}
+
+	if len(allErrs) > 0 {
+		return allErrs
 	}
 
 	if newQty.Cmp(oldQty) < 0 {
 		return field.ErrorList{field.Forbidden(
-			field.NewPath("spec", "resource", "storage", "pvcSize"),
+			pvcSizePath,
 			fmt.Sprintf("storage size can only be increased; attempted shrink from %s to %s", oldSize, newSize),
 		)}
 	}

--- a/operator/src/internal/webhook/documentdb_webhook.go
+++ b/operator/src/internal/webhook/documentdb_webhook.go
@@ -214,35 +214,17 @@ func (v *DocumentDBValidator) validateImageRollback(newDB, oldDB *dbpreview.Docu
 }
 
 // validateImmutableFields rejects updates to fields that cannot be changed after creation.
+// Note: credentialSecret, storageClass, and sidecarInjectorPluginName are enforced via
+// CEL transition rules on the CRD schema (see documentdb_types.go).
 func (v *DocumentDBValidator) validateImmutableFields(newDB, oldDB *dbpreview.DocumentDB) field.ErrorList {
 	var allErrs field.ErrorList
 
-	// Credential secret is baked into running pods and plugin parameters at creation time.
-	if newDB.Spec.DocumentDbCredentialSecret != oldDB.Spec.DocumentDbCredentialSecret {
-		allErrs = append(allErrs, field.Forbidden(
-			field.NewPath("spec", "documentDbCredentialSecret"),
-			"credential secret cannot be changed after cluster creation",
-		))
-	}
-
-	// Storage class cannot be changed — PVs cannot be migrated between storage classes.
-	if newDB.Spec.Resource.Storage.StorageClass != oldDB.Spec.Resource.Storage.StorageClass {
-		allErrs = append(allErrs, field.Forbidden(
-			field.NewPath("spec", "resource", "storage", "storageClass"),
-			"storage class cannot be changed after cluster creation",
-		))
-	}
-
-	// Plugin name is structural — it identifies which CNPG sidecar plugin to use.
-	if newDB.Spec.SidecarInjectorPluginName != oldDB.Spec.SidecarInjectorPluginName {
-		allErrs = append(allErrs, field.Forbidden(
-			field.NewPath("spec", "sidecarInjectorPluginName"),
-			"sidecar injector plugin name cannot be changed after cluster creation",
-		))
-	}
-
-	// Bootstrap configuration is only used during initial cluster creation.
-	if !isBootstrapEqual(newDB.Spec.Bootstrap, oldDB.Spec.Bootstrap) {
+	// Bootstrap configuration is only used during initial cluster creation and is
+	// ignored afterward. Setting it to nil (cleanup) is allowed, but changing to a
+	// different value is rejected since it cannot re-bootstrap a running cluster.
+	// This is kept in the webhook (not CEL) because it's an optional pointer field
+	// where CEL transition rules don't reliably catch all mutation patterns.
+	if newDB.Spec.Bootstrap != nil && !isBootstrapEqual(newDB.Spec.Bootstrap, oldDB.Spec.Bootstrap) {
 		allErrs = append(allErrs, field.Forbidden(
 			field.NewPath("spec", "bootstrap"),
 			"bootstrap configuration cannot be changed after cluster creation",

--- a/operator/src/internal/webhook/documentdb_webhook_test.go
+++ b/operator/src/internal/webhook/documentdb_webhook_test.go
@@ -6,6 +6,7 @@ package webhook
 import (
 	"context"
 
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -336,5 +337,137 @@ var _ = Describe("extractSemver helper", func() {
 
 	It("returns empty for non-numeric patch", func() {
 		Expect(extractSemver("0.112.abc")).To(BeEmpty())
+	})
+})
+
+var _ = Describe("validateImmutableFields", func() {
+	v := &DocumentDBValidator{}
+
+	It("rejects credential secret change", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		oldDB.Spec.DocumentDbCredentialSecret = "original-secret"
+		newDB := newTestDocumentDB("", "", "")
+		newDB.Spec.DocumentDbCredentialSecret = "new-secret"
+
+		errs := v.validateImmutableFields(newDB, oldDB)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("spec.documentDbCredentialSecret"))
+	})
+
+	It("rejects storage class change", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		oldDB.Spec.Resource.Storage.StorageClass = "standard"
+		newDB := newTestDocumentDB("", "", "")
+		newDB.Spec.Resource.Storage.StorageClass = "premium"
+
+		errs := v.validateImmutableFields(newDB, oldDB)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("spec.resource.storage.storageClass"))
+	})
+
+	It("rejects sidecar plugin name change", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		oldDB.Spec.SidecarInjectorPluginName = "original-plugin"
+		newDB := newTestDocumentDB("", "", "")
+		newDB.Spec.SidecarInjectorPluginName = "new-plugin"
+
+		errs := v.validateImmutableFields(newDB, oldDB)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("spec.sidecarInjectorPluginName"))
+	})
+
+	It("rejects bootstrap config change", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		oldDB.Spec.Bootstrap = &dbpreview.BootstrapConfiguration{
+			Recovery: &dbpreview.RecoveryConfiguration{
+				Backup: cnpgv1.LocalObjectReference{Name: "my-backup"},
+			},
+		}
+		newDB := newTestDocumentDB("", "", "")
+		newDB.Spec.Bootstrap = &dbpreview.BootstrapConfiguration{
+			Recovery: &dbpreview.RecoveryConfiguration{
+				Backup: cnpgv1.LocalObjectReference{Name: "different-backup"},
+			},
+		}
+
+		errs := v.validateImmutableFields(newDB, oldDB)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("spec.bootstrap"))
+	})
+
+	It("allows bootstrap nil-to-nil (both unset)", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		newDB := newTestDocumentDB("", "", "")
+
+		errs := v.validateImmutableFields(newDB, oldDB)
+		Expect(errs).To(BeEmpty())
+	})
+
+	It("allows unchanged immutable fields", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		oldDB.Spec.DocumentDbCredentialSecret = "my-secret"
+		oldDB.Spec.Resource.Storage.StorageClass = "standard"
+		newDB := newTestDocumentDB("", "", "")
+		newDB.Spec.DocumentDbCredentialSecret = "my-secret"
+		newDB.Spec.Resource.Storage.StorageClass = "standard"
+
+		errs := v.validateImmutableFields(newDB, oldDB)
+		Expect(errs).To(BeEmpty())
+	})
+
+	It("reports multiple immutable field violations at once", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		oldDB.Spec.DocumentDbCredentialSecret = "old-secret"
+		oldDB.Spec.Resource.Storage.StorageClass = "standard"
+		newDB := newTestDocumentDB("", "", "")
+		newDB.Spec.DocumentDbCredentialSecret = "new-secret"
+		newDB.Spec.Resource.Storage.StorageClass = "premium"
+
+		errs := v.validateImmutableFields(newDB, oldDB)
+		Expect(errs).To(HaveLen(2))
+	})
+})
+
+var _ = Describe("validateStorageResize", func() {
+	v := &DocumentDBValidator{}
+
+	It("allows storage size increase", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		oldDB.Spec.Resource.Storage.PvcSize = "10Gi"
+		newDB := newTestDocumentDB("", "", "")
+		newDB.Spec.Resource.Storage.PvcSize = "20Gi"
+
+		errs := v.validateStorageResize(newDB, oldDB)
+		Expect(errs).To(BeEmpty())
+	})
+
+	It("rejects storage size decrease", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		oldDB.Spec.Resource.Storage.PvcSize = "20Gi"
+		newDB := newTestDocumentDB("", "", "")
+		newDB.Spec.Resource.Storage.PvcSize = "10Gi"
+
+		errs := v.validateStorageResize(newDB, oldDB)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("spec.resource.storage.pvcSize"))
+		Expect(errs[0].Detail).To(ContainSubstring("shrink"))
+	})
+
+	It("allows same size (no-op)", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		newDB := newTestDocumentDB("", "", "")
+
+		errs := v.validateStorageResize(newDB, oldDB)
+		Expect(errs).To(BeEmpty())
+	})
+
+	It("skips validation when old size is empty", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		oldDB.Spec.Resource.Storage.PvcSize = ""
+		newDB := newTestDocumentDB("", "", "")
+		newDB.Spec.Resource.Storage.PvcSize = "10Gi"
+
+		errs := v.validateStorageResize(newDB, oldDB)
+		Expect(errs).To(BeEmpty())
 	})
 })

--- a/operator/src/internal/webhook/documentdb_webhook_test.go
+++ b/operator/src/internal/webhook/documentdb_webhook_test.go
@@ -456,13 +456,27 @@ var _ = Describe("validateStorageResize", func() {
 		Expect(errs).To(BeEmpty())
 	})
 
-	It("skips validation when old size is empty", func() {
+	It("rejects invalid old pvcSize", func() {
 		oldDB := newTestDocumentDB("", "", "")
-		oldDB.Spec.Resource.Storage.PvcSize = ""
+		oldDB.Spec.Resource.Storage.PvcSize = "not-a-quantity"
 		newDB := newTestDocumentDB("", "", "")
 		newDB.Spec.Resource.Storage.PvcSize = "10Gi"
 
 		errs := v.validateStorageResize(newDB, oldDB)
-		Expect(errs).To(BeEmpty())
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("spec.resource.storage.pvcSize"))
+		Expect(errs[0].Detail).To(ContainSubstring("existing pvcSize is not a valid resource quantity"))
+	})
+
+	It("rejects invalid new pvcSize", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		oldDB.Spec.Resource.Storage.PvcSize = "10Gi"
+		newDB := newTestDocumentDB("", "", "")
+		newDB.Spec.Resource.Storage.PvcSize = "abc"
+
+		errs := v.validateStorageResize(newDB, oldDB)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("spec.resource.storage.pvcSize"))
+		Expect(errs[0].Detail).To(ContainSubstring("pvcSize must be a valid resource quantity"))
 	})
 })

--- a/operator/src/internal/webhook/documentdb_webhook_test.go
+++ b/operator/src/internal/webhook/documentdb_webhook_test.go
@@ -343,38 +343,10 @@ var _ = Describe("extractSemver helper", func() {
 var _ = Describe("validateImmutableFields", func() {
 	v := &DocumentDBValidator{}
 
-	It("rejects credential secret change", func() {
-		oldDB := newTestDocumentDB("", "", "")
-		oldDB.Spec.DocumentDbCredentialSecret = "original-secret"
-		newDB := newTestDocumentDB("", "", "")
-		newDB.Spec.DocumentDbCredentialSecret = "new-secret"
-
-		errs := v.validateImmutableFields(newDB, oldDB)
-		Expect(errs).To(HaveLen(1))
-		Expect(errs[0].Field).To(Equal("spec.documentDbCredentialSecret"))
-	})
-
-	It("rejects storage class change", func() {
-		oldDB := newTestDocumentDB("", "", "")
-		oldDB.Spec.Resource.Storage.StorageClass = "standard"
-		newDB := newTestDocumentDB("", "", "")
-		newDB.Spec.Resource.Storage.StorageClass = "premium"
-
-		errs := v.validateImmutableFields(newDB, oldDB)
-		Expect(errs).To(HaveLen(1))
-		Expect(errs[0].Field).To(Equal("spec.resource.storage.storageClass"))
-	})
-
-	It("rejects sidecar plugin name change", func() {
-		oldDB := newTestDocumentDB("", "", "")
-		oldDB.Spec.SidecarInjectorPluginName = "original-plugin"
-		newDB := newTestDocumentDB("", "", "")
-		newDB.Spec.SidecarInjectorPluginName = "new-plugin"
-
-		errs := v.validateImmutableFields(newDB, oldDB)
-		Expect(errs).To(HaveLen(1))
-		Expect(errs[0].Field).To(Equal("spec.sidecarInjectorPluginName"))
-	})
+	// Note: credentialSecret, storageClass, and sidecarInjectorPluginName immutability
+	// is now enforced via CEL transition rules on the CRD schema (see documentdb_types.go).
+	// Only bootstrap is validated in the webhook because it's an optional pointer field
+	// where CEL transition rules don't reliably catch all mutation patterns.
 
 	It("rejects bootstrap config change", func() {
 		oldDB := newTestDocumentDB("", "", "")
@@ -403,28 +375,51 @@ var _ = Describe("validateImmutableFields", func() {
 		Expect(errs).To(BeEmpty())
 	})
 
-	It("allows unchanged immutable fields", func() {
+	It("allows unchanged bootstrap configuration", func() {
 		oldDB := newTestDocumentDB("", "", "")
-		oldDB.Spec.DocumentDbCredentialSecret = "my-secret"
-		oldDB.Spec.Resource.Storage.StorageClass = "standard"
+		oldDB.Spec.Bootstrap = &dbpreview.BootstrapConfiguration{
+			Recovery: &dbpreview.RecoveryConfiguration{
+				Backup: cnpgv1.LocalObjectReference{Name: "my-backup"},
+			},
+		}
 		newDB := newTestDocumentDB("", "", "")
-		newDB.Spec.DocumentDbCredentialSecret = "my-secret"
-		newDB.Spec.Resource.Storage.StorageClass = "standard"
+		newDB.Spec.Bootstrap = &dbpreview.BootstrapConfiguration{
+			Recovery: &dbpreview.RecoveryConfiguration{
+				Backup: cnpgv1.LocalObjectReference{Name: "my-backup"},
+			},
+		}
 
 		errs := v.validateImmutableFields(newDB, oldDB)
 		Expect(errs).To(BeEmpty())
 	})
 
-	It("reports multiple immutable field violations at once", func() {
+	It("allows bootstrap removal (set to nil is cleanup)", func() {
 		oldDB := newTestDocumentDB("", "", "")
-		oldDB.Spec.DocumentDbCredentialSecret = "old-secret"
-		oldDB.Spec.Resource.Storage.StorageClass = "standard"
+		oldDB.Spec.Bootstrap = &dbpreview.BootstrapConfiguration{
+			Recovery: &dbpreview.RecoveryConfiguration{
+				Backup: cnpgv1.LocalObjectReference{Name: "my-backup"},
+			},
+		}
 		newDB := newTestDocumentDB("", "", "")
-		newDB.Spec.DocumentDbCredentialSecret = "new-secret"
-		newDB.Spec.Resource.Storage.StorageClass = "premium"
+		newDB.Spec.Bootstrap = nil
 
 		errs := v.validateImmutableFields(newDB, oldDB)
-		Expect(errs).To(HaveLen(2))
+		Expect(errs).To(BeEmpty())
+	})
+
+	It("rejects bootstrap addition on running cluster (nil to set)", func() {
+		oldDB := newTestDocumentDB("", "", "")
+		oldDB.Spec.Bootstrap = nil
+		newDB := newTestDocumentDB("", "", "")
+		newDB.Spec.Bootstrap = &dbpreview.BootstrapConfiguration{
+			Recovery: &dbpreview.RecoveryConfiguration{
+				Backup: cnpgv1.LocalObjectReference{Name: "my-backup"},
+			},
+		}
+
+		errs := v.validateImmutableFields(newDB, oldDB)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0].Field).To(Equal("spec.bootstrap"))
 	})
 })
 


### PR DESCRIPTION
## Summary

Extends the consolidated `SyncCnpgCluster()` entry point (from PR #336) to propagate additional mutable spec fields to the underlying CNPG Cluster, and adds validation to reject changes to immutable fields.

This is part 2 of the spec change propagation work (fixes #298, #308).

## Changes

### Mutable Field Sync (`cnpg_sync.go`, `cnpg_patch.go`)

Added propagation for 6 new mutable fields via atomic JSON Patch:

| DocumentDB Field | CNPG Cluster Path | Restart Needed? |
|---|---|---|
| `instancesPerNode` | `/spec/instances` | No (CNPG native) |
| `resource.storage.pvcSize` | `/spec/storage/size` | No (CNPG native) |
| `postgresImage` | `/spec/imageName` | No (CNPG native — image mismatch detected via `checkPodImageIsOutdated`) |
| `logLevel` | `/spec/logLevel` | No (CNPG native — PodSpec drift detected via `checkPodSpecIsOutdated`) |
| `affinity` | `/spec/affinity` | No (CNPG native — PodSpec drift detected via `ComparePodSpecs`) |
| `timeouts.stopDelay` | `/spec/maxStopDelay` | No (CNPG native — maps to `terminationGracePeriodSeconds`, drift triggers rollout) |

All 6 fields are handled natively by CNPG's PodSpec drift detection or image comparison logic. The operator only needs to patch the CNPG Cluster spec — no manual restart annotation is required for any mutable spec field. (The original implementation set `specChanged = true` for 4 of these fields, which was removed after verifying via CNPG v1.28.1 source and live Kind cluster testing that CNPG handles all restarts natively.)

### Immutable Field Validation — Hybrid CEL + Webhook Approach

Immutable fields are protected using two complementary mechanisms:

**CEL transition rules** (`documentdb_types.go`) — for simple string fields:

| Field | CEL Rule | Reason |
|---|---|---|
| `documentDbCredentialSecret` | `self == oldSelf` | Baked into running pods at creation |
| `resource.storage.storageClass` | `self == oldSelf` | Cannot migrate existing PVCs |
| `sidecarInjectorPluginName` | `self == oldSelf` | Structural to CNPG plugin configuration |

This follows the same pattern used by CNPG (e.g., `serviceAccountName`), Cilium, Crossplane, Karpenter, and 780+ other Kubernetes projects for simple immutability.

**Webhook validation** (`documentdb_webhook.go`) — for complex fields:

| Field | Reason for Webhook |
|---|---|
| `bootstrap` | Optional pointer field — CEL transition rules don't fire when field goes from set→nil, losing protection |
| `resource.storage.pvcSize` (shrink) | Requires `resource.ParseQuantity()` comparison; PVC expansion is one-way |
| Image rollback | Complex semver parsing + status field access |
| Schema ≤ binary version | Complex version parsing logic |

None of these immutable fields are enforced by CNPG — our validation is the only line of defense.

### Tests

- 8 new sync tests covering each mutable field, combined changes, and restart annotation behavior
- Webhook tests for bootstrap immutability (change, nil-to-nil, unchanged, set→nil removal)
- PVC shrink rejection and grow allowance tests

## Fixes

- Fixes #298 (PVC resize not propagated)
- Fixes #308 (field mutability policy)
