### PR TITLE
feat: add NODE_TYPE, EKS_VERSION, CLUSTER_TAGS, USE_SPOT options to AWS EKS setup

### DIFF
--- a/documentdb-playground/aws-setup/README.md
+++ b/documentdb-playground/aws-setup/README.md
@@ -85,6 +85,33 @@ export GITHUB_TOKEN="your-token"
 - `--skip-operator` - Skip operator installation (default)
 - `--install-operator` - Install operator (requires GitHub authentication)
 - `--deploy-instance` - Deploy operator + instance (requires GitHub authentication)
+- `--node-type TYPE` - EC2 instance type (default: `m7g.large`, Graviton/ARM)
+- `--eks-version VER` - Kubernetes/EKS version (default: `1.35`)
+- `--spot` - Use Spot-backed managed nodes (dev/test only — see warning below)
+- `--tags TAGS` - Cost allocation tags as comma-separated `key=value` pairs (default: `project=documentdb-playground,environment=dev,managed-by=eksctl`)
+
+#### Spot Instance Warning
+
+When using `--spot`, AWS can terminate instances at any time with only 2 minutes notice.
+This **will interrupt your database** and require recovery. Only use Spot for dev/test
+workloads where brief downtime is acceptable. Spot is disabled by default.
+
+#### Custom Tags
+
+Tags are passed to AWS for cost allocation tracking in Cost Explorer:
+
+```bash
+# Default tags
+./scripts/create-cluster.sh
+# Tags: project=documentdb-playground,environment=dev,managed-by=eksctl
+
+# Custom tags via flag
+./scripts/create-cluster.sh --tags "project=myproj,team=platform,costcenter=1234"
+
+# Or via environment variable
+export CLUSTER_TAGS="project=myproj,team=platform"
+./scripts/create-cluster.sh
+```
 
 ### delete-cluster.sh
 ```bash
@@ -119,13 +146,13 @@ export GITHUB_TOKEN="your-token"
 ## What Gets Created
 
 **create-cluster.sh builds:**
-- EKS cluster with 2 managed nodes (m5.large)
+- EKS cluster with managed nodes (default: `m7g.large` Graviton/ARM, 3 nodes)
 - EBS CSI driver for storage
 - AWS Load Balancer Controller
 - cert-manager for TLS
 - Optimized storage classes
 
-**Estimated cost:** ~$140-230/month (always run delete-cluster.sh when done!)
+**Estimated cost:** ~$140-230/month (always run delete-cluster.sh when done!) — use `--spot` for ~70% savings on dev/test.
 
 ## Support
 

--- a/documentdb-playground/aws-setup/scripts/create-cluster.sh
+++ b/documentdb-playground/aws-setup/scripts/create-cluster.sh
@@ -8,10 +8,17 @@ set -e  # Exit on any error
 # Configuration
 CLUSTER_NAME="documentdb-cluster"
 REGION="us-west-2"
-NODE_TYPE="m5.large"
+K8S_VERSION="${K8S_VERSION:-1.35}"
+NODE_TYPE="${NODE_TYPE:-m7g.large}"
 NODES=3
 NODES_MIN=1
 NODES_MAX=4
+
+# Cost-optimization configuration
+# USE_SPOT: when "true", eksctl provisions Spot-backed managed nodes (dev/test only).
+# CLUSTER_TAGS: comma-separated key=value pairs passed to AWS for cost allocation in Cost Explorer.
+USE_SPOT="${USE_SPOT:-false}"
+CLUSTER_TAGS="${CLUSTER_TAGS:-project=documentdb-playground,environment=dev,managed-by=eksctl}"
 
 # DocumentDB Operator Configuration
 # For production: use documentdb/documentdb-operator (official)
@@ -58,6 +65,22 @@ while [[ $# -gt 0 ]]; do
             GITHUB_TOKEN="$2"
             shift 2
             ;;
+        --node-type)
+            NODE_TYPE="$2"
+            shift 2
+            ;;
+        --eks-version|--k8s-version)
+            K8S_VERSION="$2"
+            shift 2
+            ;;
+        --spot)
+            USE_SPOT="true"
+            shift
+            ;;
+        --tags)
+            CLUSTER_TAGS="$2"
+            shift 2
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo ""
@@ -70,6 +93,14 @@ while [[ $# -gt 0 ]]; do
             echo "  --region REGION       AWS region (default: us-west-2)"
             echo "  --github-username     GitHub username for operator installation"
             echo "  --github-token        GitHub token for operator installation"
+            echo ""
+            echo "Cost-optimization options:"
+            echo "  --node-type TYPE      EC2 instance type (default: m7g.large, Graviton/ARM)"
+            echo "  --eks-version VER     Kubernetes/EKS version (default: 1.35)"
+            echo "  --spot                Use Spot-backed managed nodes (DEV/TEST ONLY - can be terminated)"
+            echo "  --tags TAGS           Cost allocation tags as key=value pairs (comma-separated)"
+            echo "                        (default: project=documentdb-playground,environment=dev,managed-by=eksctl)"
+            echo ""
             echo "  -h, --help           Show this help message"
             echo ""
             echo "Examples:"
@@ -77,6 +108,8 @@ while [[ $# -gt 0 ]]; do
             echo "  $0 --install-operator                 # Create cluster with operator, no instance"
             echo "  $0 --deploy-instance                  # Create cluster with instance (auto-enables operator)"
             echo "  $0 --github-username user --github-token ghp_xxx --install-operator  # With GitHub auth"
+            echo "  $0 --node-type m5.large               # Use x86 instance type instead of Graviton"
+            echo "  $0 --spot --tags \"project=myproj,team=platform\"  # Spot dev cluster with custom tags"
             exit 0
             ;;
         *)
@@ -146,24 +179,43 @@ check_prerequisites() {
 # Create EKS cluster
 create_cluster() {
     log "Creating EKS cluster: $CLUSTER_NAME in region: $REGION"
-    
+
     # Check if cluster already exists
     if eksctl get cluster --name $CLUSTER_NAME --region $REGION &> /dev/null; then
         warn "Cluster $CLUSTER_NAME already exists. Skipping cluster creation."
         return 0
     fi
-    
-    # Create cluster with basic configuration
-    eksctl create cluster \
-        --name $CLUSTER_NAME \
-        --region $REGION \
-        --node-type $NODE_TYPE \
-        --nodes $NODES \
-        --nodes-min $NODES_MIN \
-        --nodes-max $NODES_MAX \
-        --managed \
+
+    if [ "$USE_SPOT" == "true" ]; then
+        warn "============================================================"
+        warn "SPOT INSTANCES ENABLED - FOR DEV/TEST USE ONLY"
+        warn "AWS can terminate Spot instances at any time with 2 minutes"
+        warn "notice. This WILL interrupt your database and require recovery."
+        warn "Do NOT use Spot for production or long-running workloads."
+        warn "============================================================"
+    fi
+
+    local EKSCTL_ARGS=(
+        --name "$CLUSTER_NAME"
+        --region "$REGION"
+        --version "$K8S_VERSION"
+        --nodes "$NODES"
+        --nodes-min "$NODES_MIN"
+        --nodes-max "$NODES_MAX"
+        --managed
         --with-oidc
-    
+        --tags "$CLUSTER_TAGS"
+    )
+
+    if [ "$USE_SPOT" == "true" ]; then
+        # Multiple instance types improve Spot availability; all Graviton to match the default.
+        EKSCTL_ARGS+=(--spot --instance-types "m7g.large,m6g.large,r7g.large,r6g.large,c7g.large,c6g.large")
+    else
+        EKSCTL_ARGS+=(--node-type "$NODE_TYPE")
+    fi
+
+    eksctl create cluster "${EKSCTL_ARGS[@]}"
+
     if [ $? -eq 0 ]; then
         success "EKS cluster created successfully"
     else
@@ -528,11 +580,15 @@ print_summary() {
     echo "=================================================="
     echo "Cluster Name: $CLUSTER_NAME"
     echo "Region: $REGION"
+    echo "Kubernetes: $K8S_VERSION"
+    echo "Node Type: $NODE_TYPE"
+    echo "Spot Instances: $USE_SPOT"
+    echo "Tags: $CLUSTER_TAGS"
     echo "Operator Installed: $INSTALL_OPERATOR"
     echo "Instance Deployed: $DEPLOY_INSTANCE"
     echo ""
     echo "✅ Components installed:"
-    echo "  - EKS cluster with managed nodes"
+    echo "  - EKS cluster with managed nodes ($NODE_TYPE)"
     echo "  - EBS CSI driver"
     echo "  - AWS Load Balancer Controller"
     echo "  - cert-manager"
@@ -567,6 +623,10 @@ main() {
     log "Configuration:"
     log "  Cluster: $CLUSTER_NAME"
     log "  Region: $REGION"
+    log "  Kubernetes: $K8S_VERSION"
+    log "  Node Type: $NODE_TYPE"
+    log "  Spot Instances: $USE_SPOT"
+    log "  Tags: $CLUSTER_TAGS"
     log "  Install Operator: $INSTALL_OPERATOR"
     log "  Deploy Instance: $DEPLOY_INSTANCE"
     echo ""


### PR DESCRIPTION
## Summary

Adds narrowly-scoped cost-optimization options to the AWS EKS playground, per reviewer feedback to keep `documentdb-playground/aws-setup/` simple and DocumentDB-focused:

- `--node-type` / `NODE_TYPE` env var — EC2 instance type (default: `m7g.large`, Graviton/ARM).
- `--eks-version` / `K8S_VERSION` env var — Kubernetes/EKS version (default: `1.35`).
- `--spot` / `USE_SPOT` env var — opt-in Spot-backed managed nodes for dev/test cost reduction (~70%).
- `--tags` / `CLUSTER_TAGS` env var — AWS cost allocation tags for Cost Explorer tracking.

## Why

The EKS setup should be affordable by default and easy to attribute in Cost Explorer. These four knobs cover the straightforward options without introducing AWS-specific infrastructure the core team would need to maintain.

## Scope split

The advanced work originally in this PR (S3 Gateway VPC endpoint, Amazon CloudWatch Observability add-on / Container Insights, EKS control-plane logging, log-group retention, CloudWatch-aware teardown and diagnostics) has been moved to a separate follow-up PR under `documentdb-playground/contrib/telemetry-and-cost-optimized-eks/` so the core scripts stay simple, while users who want the full telemetry+cost-optimized variant can opt in.

## Test plan

- [ ] `./documentdb-playground/aws-setup/scripts/create-cluster.sh` with defaults — cluster created on m7g.large with default tags applied.
- [ ] `./documentdb-playground/aws-setup/scripts/create-cluster.sh --spot` — Spot-backed nodes provisioned, warning banner shown.
- [ ] `./documentdb-playground/aws-setup/scripts/create-cluster.sh --tags "project=myproj,team=platform"` — custom tags present on AWS resources.
- [ ] `./documentdb-playground/aws-setup/scripts/create-cluster.sh --eks-version 1.34 --node-type m5.large` — overrides respected.
- [ ] `./documentdb-playground/aws-setup/scripts/delete-cluster.sh` — teardown completes cleanly (delete-cluster.sh is unchanged in this PR).
