### PR TITLE
 feat: add LightRAG + DocumentDB playground

### DIFF
--- a/.github/workflows/build_documentdb_images.yml
+++ b/.github/workflows/build_documentdb_images.yml
@@ -13,6 +13,14 @@ on:
         description: 'Released DocumentDB version to package (for example 0.109.0)'
         required: false
         default: '0.109.0'
+      documentdb_repo:
+        description: 'GitHub repo for DocumentDB extension releases (owner/repo)'
+        required: false
+        default: 'documentdb/documentdb'
+      gateway_source_repo:
+        description: 'GHCR repo for gateway source image (without ghcr.io/ prefix)'
+        required: false
+        default: 'documentdb/documentdb/documentdb-local'
 
   repository_dispatch:
     types: [documentdb-release]
@@ -24,8 +32,8 @@ permissions:
 
 env:
   DEFAULT_DOCUMENTDB_VERSION: '0.109.0'
-  DOCUMENTDB_RELEASE_REPO: documentdb/documentdb
-  GATEWAY_SOURCE_IMAGE_REPO: ghcr.io/documentdb/documentdb/documentdb-local
+  DOCUMENTDB_RELEASE_REPO: ${{ github.event.inputs.documentdb_repo || 'documentdb/documentdb' }}
+  GATEWAY_SOURCE_IMAGE_REPO: ghcr.io/${{ github.event.inputs.gateway_source_repo || 'documentdb/documentdb/documentdb-local' }}
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/build_documentdb_images.yml
+++ b/.github/workflows/build_documentdb_images.yml
@@ -13,14 +13,6 @@ on:
         description: 'Released DocumentDB version to package (for example 0.109.0)'
         required: false
         default: '0.109.0'
-      documentdb_repo:
-        description: 'GitHub repo for DocumentDB extension releases (owner/repo)'
-        required: false
-        default: 'documentdb/documentdb'
-      gateway_source_repo:
-        description: 'GHCR repo for gateway source image (without ghcr.io/ prefix)'
-        required: false
-        default: 'documentdb/documentdb/documentdb-local'
 
   repository_dispatch:
     types: [documentdb-release]
@@ -32,8 +24,8 @@ permissions:
 
 env:
   DEFAULT_DOCUMENTDB_VERSION: '0.109.0'
-  DOCUMENTDB_RELEASE_REPO: ${{ github.event.inputs.documentdb_repo || 'documentdb/documentdb' }}
-  GATEWAY_SOURCE_IMAGE_REPO: ghcr.io/${{ github.event.inputs.gateway_source_repo || 'documentdb/documentdb/documentdb-local' }}
+  DOCUMENTDB_RELEASE_REPO: documentdb/documentdb
+  GATEWAY_SOURCE_IMAGE_REPO: ghcr.io/documentdb/documentdb/documentdb-local
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/documentdb-playground/lightrag/README.md
+++ b/documentdb-playground/lightrag/README.md
@@ -116,7 +116,8 @@ To get your connection string from the DocumentDB resource status:
 ```bash
 # The connection string contains embedded kubectl commands for credentials.
 # Use eval to resolve them into a usable URI.
-CONNECTION_STRING=$(eval echo "$(kubectl get documentdb <cluster-name> -n <documentdb-namespace> -o jsonpath='{.status.connectionString}')")
+RAW_CONN=$(kubectl get documentdb <cluster-name> -n <documentdb-namespace> -o jsonpath='{.status.connectionString}')
+CONNECTION_STRING=$(eval "echo \"$RAW_CONN\"")
 echo "$CONNECTION_STRING"
 ```
 

--- a/documentdb-playground/lightrag/README.md
+++ b/documentdb-playground/lightrag/README.md
@@ -111,18 +111,16 @@ env:
   MONGO_DATABASE: "LightRAG"
 ```
 
-To get your connection details:
+To get your connection string from the DocumentDB resource status:
 
 ```bash
-# Get the gateway service
-kubectl get svc -n <documentdb-namespace> | grep documentdb-service
-
-# Get credentials
-kubectl get secret documentdb-credentials -n <documentdb-namespace> \
-  -o jsonpath='{.data.username}' | base64 -d
-kubectl get secret documentdb-credentials -n <documentdb-namespace> \
-  -o jsonpath='{.data.password}' | base64 -d
+# The connection string contains embedded kubectl commands for credentials.
+# Use eval to resolve them into a usable URI.
+CONNECTION_STRING=$(eval echo "$(kubectl get documentdb <cluster-name> -n <documentdb-namespace> -o jsonpath='{.status.connectionString}')")
+echo "$CONNECTION_STRING"
 ```
+
+> **Note:** The `eval` command executes shell expansions in the connection string. This is safe when the string comes from your own DocumentDB resource, but never pipe untrusted input through `eval`.
 
 ### LLM Configuration
 

--- a/documentdb-playground/lightrag/README.md
+++ b/documentdb-playground/lightrag/README.md
@@ -1,0 +1,208 @@
+# LightRAG with DocumentDB
+
+This playground deploys [LightRAG](https://github.com/HKUDS/LightRAG) — a graph-based Retrieval-Augmented Generation (RAG) engine — using DocumentDB as its MongoDB-compatible storage backend.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  Kubernetes Cluster                  │
+│                                                     │
+│  ┌──────────────┐    ┌──────────────┐               │
+│  │   LightRAG   │───▶│   Ollama     │               │
+│  │  (RAG Engine)│    │ (LLM + Embed)│               │
+│  └──────┬───────┘    └──────────────┘               │
+│         │                                           │
+│         │ MongoDB wire protocol                     │
+│         ▼                                           │
+│  ┌──────────────┐    ┌──────────────┐               │
+│  │  DocumentDB  │───▶│  PostgreSQL  │               │
+│  │  (Gateway)   │    │   (CNPG)     │               │
+│  └──────────────┘    └──────────────┘               │
+│                                                     │
+│  Storage mapping:                                   │
+│  ├─ KV storage      → MongoKVStorage (DocumentDB)   │
+│  ├─ Graph storage   → MongoGraphStorage (DocumentDB) │
+│  ├─ Doc status      → MongoDocStatusStorage (DocDB)  │
+│  └─ Vector storage  → NanoVectorDBStorage (local)    │
+└─────────────────────────────────────────────────────┘
+```
+
+LightRAG stores knowledge graph nodes, edges, document metadata, and LLM response caches in DocumentDB collections. Vector embeddings use local file-based storage because DocumentDB does not support the Atlas `$vectorSearch` operator.
+
+## Prerequisites
+
+- A running Kubernetes cluster with the DocumentDB operator installed
+- A healthy DocumentDB instance (see [Quick Start](../../docs/operator-public-documentation/preview/index.md))
+- [Helm](https://helm.sh/docs/intro/install/) v3.0+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) configured for your cluster
+
+## Quick Start
+
+```bash
+# Deploy everything (Ollama + LightRAG) with default settings
+./scripts/deploy.sh
+
+# Clean up
+./scripts/cleanup.sh
+```
+
+## Step-by-Step Deployment
+
+### 1. Verify DocumentDB is Running
+
+```bash
+kubectl get documentdb --all-namespaces
+# Expected: STATUS = "Cluster in healthy state"
+```
+
+### 2. Deploy Ollama (LLM Backend)
+
+```bash
+kubectl apply -f helm/ollama.yaml
+kubectl wait --for=condition=ready pod -l app=ollama -n lightrag --timeout=120s
+
+# Pull models (required on first run)
+OLLAMA_POD=$(kubectl get pod -l app=ollama -n lightrag -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n lightrag "$OLLAMA_POD" -- ollama pull nomic-embed-text
+kubectl exec -n lightrag "$OLLAMA_POD" -- ollama pull qwen2.5:3b
+```
+
+### 3. Deploy LightRAG
+
+Edit `helm/lightrag-values.yaml` to set your DocumentDB connection string, then:
+
+```bash
+helm upgrade --install lightrag helm/lightrag \
+  -n lightrag \
+  -f helm/lightrag-values.yaml
+```
+
+### 4. Access the WebUI
+
+```bash
+kubectl port-forward svc/lightrag 9621:9621 -n lightrag
+# Open http://localhost:9621
+```
+
+### 5. Test Document Ingestion
+
+```bash
+# Insert a document
+curl -X POST http://localhost:9621/documents/text \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Your document text here..."}'
+
+# Query with graph-enhanced RAG
+curl -X POST http://localhost:9621/query \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What is this document about?", "mode": "hybrid"}'
+```
+
+## Configuration
+
+### DocumentDB Connection
+
+Update the `MONGO_URI` in `helm/lightrag-values.yaml`:
+
+```yaml
+env:
+  MONGO_URI: "mongodb://<user>:<password>@<service>.<namespace>.svc.cluster.local:<port>/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
+  MONGO_DATABASE: "LightRAG"
+```
+
+To get your connection details:
+
+```bash
+# Get the gateway service
+kubectl get svc -n <documentdb-namespace> | grep documentdb-service
+
+# Get credentials
+kubectl get secret documentdb-credentials -n <documentdb-namespace> \
+  -o jsonpath='{.data.username}' | base64 -d
+kubectl get secret documentdb-credentials -n <documentdb-namespace> \
+  -o jsonpath='{.data.password}' | base64 -d
+```
+
+### LLM Configuration
+
+The default configuration uses [Ollama](https://ollama.com) with `qwen2.5:3b` for text generation and `nomic-embed-text` for embeddings. To use OpenAI instead:
+
+```yaml
+env:
+  LLM_BINDING: openai
+  LLM_MODEL: gpt-4o-mini
+  LLM_BINDING_API_KEY: "sk-..."
+  EMBEDDING_BINDING: openai
+  EMBEDDING_MODEL: text-embedding-3-small
+  EMBEDDING_DIM: "1536"
+  EMBEDDING_BINDING_API_KEY: "sk-..."
+```
+
+### Storage Configuration
+
+| Storage Type | Backend | Notes |
+|---|---|---|
+| KV Storage | `MongoKVStorage` | Documents, chunks, entities, relations |
+| Graph Storage | `MongoGraphStorage` | Knowledge graph nodes and edges |
+| Doc Status | `MongoDocStatusStorage` | Document processing state |
+| Vector Storage | `NanoVectorDBStorage` | Local file-based (PVC) |
+
+> **Why not MongoVectorDBStorage?** DocumentDB does not support the MongoDB Atlas `$vectorSearch` aggregation operator required by `MongoVectorDBStorage`. The file-based `NanoVectorDBStorage` works without limitations.
+
+## DocumentDB Compatibility
+
+LightRAG's MongoDB storage assumes MongoDB Atlas features. This playground includes an init container that patches the LightRAG code for DocumentDB compatibility:
+
+| Feature | MongoDB Atlas | DocumentDB | Workaround |
+|---|---|---|---|
+| `$vectorSearch` | ✅ | ❌ | Use NanoVectorDBStorage |
+| `$listSearchIndexes` | ✅ | ❌ | Graceful fallback to regex |
+| `createIndex` with collation | ✅ | ❌ | Skip collation indexes |
+| `createIndex` (secondary) | ✅ | Hangs | Skip via init-container patch |
+| Basic CRUD operations | ✅ | ✅ | Works natively |
+| Aggregation pipelines | ✅ | ✅ | `$group`, `$match`, `$sort` work |
+
+The init container applies these patches automatically — no manual configuration is needed.
+
+## Verified Operations
+
+The following LightRAG operations have been tested with DocumentDB:
+
+- ✅ Document ingestion and chunking
+- ✅ Entity and relationship extraction (via LLM)
+- ✅ Knowledge graph storage and traversal
+- ✅ LLM response caching
+- ✅ Naive, local, global, and hybrid RAG queries
+- ✅ Document status tracking
+- ✅ WebUI for graph visualization
+
+## Troubleshooting
+
+### LightRAG pod stuck in `Running` but not `Ready`
+
+The most common cause is `createIndex` hanging on DocumentDB. Verify the init container patch applied correctly:
+
+```bash
+POD=$(kubectl get pod -l app.kubernetes.io/name=lightrag -n lightrag -o jsonpath='{.items[0].metadata.name}')
+kubectl logs -n lightrag "$POD" -c patch-for-documentdb
+# Should show: "DocumentDB compatibility patches applied"
+```
+
+### Cannot connect to DocumentDB
+
+Verify the gateway service is reachable from the lightrag namespace:
+
+```bash
+kubectl run mongo-test --rm -it --restart=Never -n lightrag --image=mongo:7 \
+  --command -- mongosh "<your-connection-string>" --eval 'db.adminCommand({ping:1})'
+```
+
+### LLM errors during document processing
+
+Check that Ollama has the models pulled:
+
+```bash
+OLLAMA_POD=$(kubectl get pod -l app=ollama -n lightrag -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n lightrag "$OLLAMA_POD" -- ollama list
+```

--- a/documentdb-playground/lightrag/README.md
+++ b/documentdb-playground/lightrag/README.md
@@ -161,7 +161,30 @@ LightRAG's MongoDB storage assumes MongoDB Atlas features. This playground inclu
 | Basic CRUD operations | ✅ | ✅ | Works natively |
 | Aggregation pipelines | ✅ | ✅ | `$group`, `$match`, `$sort` work |
 
-The init container applies these patches automatically — no manual configuration is needed.
+### How the Init-Container Patches Work
+
+The Helm chart's `deployment.yaml` includes an init container (`patch-for-documentdb`) that runs before the main LightRAG container starts. It modifies LightRAG's MongoDB storage layer in-place to skip operations that are incompatible with DocumentDB.
+
+**What gets patched:**
+
+Three async methods in `lightrag/kg/mongo_impl.py` are stubbed out with an early `return`:
+
+| Method | Why it's patched |
+|---|---|
+| `create_and_migrate_indexes_if_not_exists` | Calls `createIndex` with collation and secondary indexes. DocumentDB rejects collation (`"not implemented yet"`) and hangs indefinitely on secondary index creation. |
+| `create_search_index_if_not_exists` | Calls `$listSearchIndexes` which DocumentDB doesn't support. While LightRAG catches the `PyMongoError` gracefully, skipping it avoids unnecessary error logs. |
+| `create_vector_index_if_not_exists` | Creates Atlas `$vectorSearch` indexes. Not applicable because this playground uses `NanoVectorDBStorage` (local) instead of `MongoVectorDBStorage`. |
+
+**How it works:**
+
+1. The init container shares the same image as the main LightRAG container.
+2. A Python script inserts `return` statements at the top of each method, effectively making them no-ops.
+3. Both code locations are patched — `/app/lightrag/` (dev install) and `/app/.venv/lib/python3.12/site-packages/lightrag/` (venv install) — because the LightRAG Docker image includes two copies.
+4. Bytecode caches (`__pycache__/mongo_impl*.pyc`) are cleared to prevent stale compiled code from being loaded.
+
+**Impact:** LightRAG operates normally without indexes. All CRUD, aggregation, and graph traversal operations work correctly. The only trade-off is that queries on large datasets may be slower without secondary indexes, which is acceptable for a playground.
+
+The patches are applied automatically — no manual configuration is needed.
 
 ## Verified Operations
 

--- a/documentdb-playground/lightrag/README.md
+++ b/documentdb-playground/lightrag/README.md
@@ -1,16 +1,18 @@
 # LightRAG with DocumentDB
 
-This playground deploys [LightRAG](https://github.com/HKUDS/LightRAG) — a graph-based Retrieval-Augmented Generation (RAG) engine — using DocumentDB as its MongoDB-compatible storage backend.
+This playground deploys [LightRAG](https://github.com/HKUDS/LightRAG) — a
+graph-based Retrieval-Augmented Generation engine — using DocumentDB as its
+MongoDB-compatible storage backend.
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│                  Kubernetes Cluster                  │
+│                  Kubernetes Cluster                 │
 │                                                     │
 │  ┌──────────────┐    ┌──────────────┐               │
 │  │   LightRAG   │───▶│   Ollama     │               │
-│  │  (RAG Engine)│    │ (LLM + Embed)│               │
+│  │ (RAG Engine) │    │ (LLM + Embed)│               │
 │  └──────┬───────┘    └──────────────┘               │
 │         │                                           │
 │         │ MongoDB wire protocol                     │
@@ -21,111 +23,79 @@ This playground deploys [LightRAG](https://github.com/HKUDS/LightRAG) — a grap
 │  └──────────────┘    └──────────────┘               │
 │                                                     │
 │  Storage mapping:                                   │
-│  ├─ KV storage      → MongoKVStorage (DocumentDB)   │
-│  ├─ Graph storage   → MongoGraphStorage (DocumentDB) │
-│  ├─ Doc status      → MongoDocStatusStorage (DocDB)  │
-│  └─ Vector storage  → NanoVectorDBStorage (local)    │
+│  ├─ KV storage      → MongoKVStorage  (DocumentDB)  │
+│  ├─ Graph storage   → MongoGraphStorage (DocumentDB)│
+│  ├─ Doc status      → MongoDocStatusStorage (DocDB) │
+│  └─ Vector storage  → NanoVectorDBStorage  (local)  │
 └─────────────────────────────────────────────────────┘
 ```
 
-LightRAG stores knowledge graph nodes, edges, document metadata, and LLM response caches in DocumentDB collections. Vector embeddings use local file-based storage because DocumentDB does not support the Atlas `$vectorSearch` operator.
+LightRAG stores knowledge graph nodes, edges, document metadata, and LLM
+response caches in DocumentDB collections. Vector embeddings use local
+file-based storage because DocumentDB does not implement the MongoDB Atlas
+`$vectorSearch` operator.
 
 ## Prerequisites
 
-- A running Kubernetes cluster with the DocumentDB operator installed
-- A healthy DocumentDB instance (see [Quick Start](../../docs/operator-public-documentation/preview/index.md))
-- [Helm](https://helm.sh/docs/intro/install/) v3.0+
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) configured for your cluster
+- A Kubernetes cluster with the [DocumentDB operator](../../README.md) installed
+- Helm v3.0+ and kubectl configured for your cluster
+- ~10 GiB free memory on a single node (Ollama needs 4–8 GiB for the default
+  model, LightRAG needs ~2 GiB)
+- Python with `pymongo` if you want to run the verification script in
+  [Verification](#verification)
 
 ## Quick Start
 
+> **Before applying `documentdb.yaml`**, edit it and replace the placeholder
+> password (`ChangeMe!ReplaceBeforeUsing`) with a real one.
+
 ```bash
-# Deploy everything (Ollama + LightRAG) with default settings
+# 1. Deploy a DocumentDB instance (skip if you already have one)
+kubectl create namespace documentdb-test
+kubectl apply -f documentdb.yaml
+kubectl wait --for=jsonpath='{.status.status}'="Cluster in healthy state" \
+    documentdb/documentdb-cluster -n documentdb-test --timeout=300s
+
+# 2. Deploy LightRAG + Ollama
 ./scripts/deploy.sh
 
-# Clean up
+# 3. Access the UI
+kubectl port-forward svc/lightrag 9621:9621 -n lightrag
+# Open http://localhost:9621
+
+# Cleanup when done
 ./scripts/cleanup.sh
 ```
 
-## Step-by-Step Deployment
-
-### 1. Verify DocumentDB is Running
-
-```bash
-kubectl get documentdb --all-namespaces
-# Expected: STATUS = "Cluster in healthy state"
-```
-
-### 2. Deploy Ollama (LLM Backend)
+`scripts/deploy.sh` defaults to `DOCUMENTDB_NAMESPACE=documentdb-test`,
+`DOCUMENTDB_CLUSTER=documentdb-cluster`, and `LIGHTRAG_NAMESPACE=lightrag`.
+Override via env vars if your cluster uses different names:
 
 ```bash
-kubectl apply -f helm/ollama.yaml
-kubectl wait --for=condition=ready pod -l app=ollama -n lightrag --timeout=120s
-
-# Pull models (required on first run)
-OLLAMA_POD=$(kubectl get pod -l app=ollama -n lightrag -o jsonpath='{.items[0].metadata.name}')
-kubectl exec -n lightrag "$OLLAMA_POD" -- ollama pull nomic-embed-text
-kubectl exec -n lightrag "$OLLAMA_POD" -- ollama pull qwen2.5:3b
+DOCUMENTDB_NAMESPACE=my-ns DOCUMENTDB_CLUSTER=my-cluster LIGHTRAG_NAMESPACE=rag \
+    ./scripts/deploy.sh
 ```
 
-### 3. Deploy LightRAG
+## What the Scripts Do
 
-Edit `helm/lightrag-values.yaml` to set your DocumentDB connection string, then:
+`scripts/deploy.sh`:
 
-```bash
-helm upgrade --install lightrag helm/lightrag \
-  -n lightrag \
-  -f helm/lightrag-values.yaml
-```
-
-### 4. Access the WebUI
-
-```bash
-kubectl port-forward svc/lightrag 9621:9621 -n lightrag
-# Open http://localhost:9621
-```
-
-### 5. Test Document Ingestion
-
-```bash
-# Insert a document
-curl -X POST http://localhost:9621/documents/text \
-  -H "Content-Type: application/json" \
-  -d '{"text": "Your document text here..."}'
-
-# Query with graph-enhanced RAG
-curl -X POST http://localhost:9621/query \
-  -H "Content-Type: application/json" \
-  -d '{"query": "What is this document about?", "mode": "hybrid"}'
-```
+1. Applies [`helm/ollama.yaml`](helm/ollama.yaml) (Namespace, PVC, Deployment,
+   Service) and waits for the pod to become Ready.
+2. Pulls the embedding model (`nomic-embed-text`, ~274 MB) and the LLM
+   (`qwen2.5:3b`, ~1.9 GB) into the Ollama PVC.
+3. Reads the connection string from the `DocumentDB` resource's
+   `status.connectionString`, resolves the embedded `kubectl get secret`
+   commands, swaps the ClusterIP for the in-cluster DNS name, and strips the
+   `replicaSet=rs0` query parameter (incompatible with `directConnection=true`
+   when talking directly to the gateway).
+4. Installs the `helm/lightrag` chart with the resolved `MONGO_URI`.
 
 ## Configuration
 
-### DocumentDB Connection
+### Switching to OpenAI
 
-Update the `MONGO_URI` in `helm/lightrag-values.yaml`:
-
-```yaml
-env:
-  MONGO_URI: "mongodb://<user>:<password>@<service>.<namespace>.svc.cluster.local:<port>/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
-  MONGO_DATABASE: "LightRAG"
-```
-
-To get your connection string from the DocumentDB resource status:
-
-```bash
-# The connection string contains embedded kubectl commands for credentials.
-# Use eval to resolve them into a usable URI.
-RAW_CONN=$(kubectl get documentdb <cluster-name> -n <documentdb-namespace> -o jsonpath='{.status.connectionString}')
-CONNECTION_STRING=$(eval "echo \"$RAW_CONN\"")
-echo "$CONNECTION_STRING"
-```
-
-> **Note:** The `eval` command executes shell expansions in the connection string. This is safe when the string comes from your own DocumentDB resource, but never pipe untrusted input through `eval`.
-
-### LLM Configuration
-
-The default configuration uses [Ollama](https://ollama.com) with `qwen2.5:3b` for text generation and `nomic-embed-text` for embeddings. To use OpenAI instead:
+Edit [`helm/lightrag-values.yaml`](helm/lightrag-values.yaml):
 
 ```yaml
 env:
@@ -138,374 +108,112 @@ env:
   EMBEDDING_BINDING_API_KEY: "sk-..."
 ```
 
-### Storage Configuration
+OpenAI is much faster than CPU Ollama. You can also drop `LLM_TIMEOUT` and
+`MAX_ASYNC` overrides when using a hosted provider.
 
-| Storage Type | Backend | Notes |
-|---|---|---|
-| KV Storage | `MongoKVStorage` | Documents, chunks, entities, relations |
-| Graph Storage | `MongoGraphStorage` | Knowledge graph nodes and edges |
-| Doc Status | `MongoDocStatusStorage` | Document processing state |
-| Vector Storage | `NanoVectorDBStorage` | Local file-based (PVC) |
+### Tuning for slow CPU inference
 
-> **Why not MongoVectorDBStorage?** DocumentDB does not support the MongoDB Atlas `$vectorSearch` aggregation operator required by `MongoVectorDBStorage`. The file-based `NanoVectorDBStorage` works without limitations.
+The default values pin a generous LLM timeout because `qwen2.5:3b` on CPU can
+take 5–10 minutes per chunk for entity extraction:
 
-## DocumentDB Compatibility
+```yaml
+env:
+  LLM_TIMEOUT: "900"        # default 180s — too short for CPU Ollama
+  EMBEDDING_TIMEOUT: "120"
+  MAX_ASYNC: "2"            # cap concurrent LLM calls per Ollama replica
+```
 
-LightRAG's MongoDB storage assumes MongoDB Atlas features. This playground includes an init container that patches the LightRAG code for DocumentDB compatibility:
+### Storage backends
 
-| Feature | MongoDB Atlas | DocumentDB | Workaround |
-|---|---|---|---|
-| `$vectorSearch` | ✅ | ❌ | Use NanoVectorDBStorage |
-| `$listSearchIndexes` | ✅ | ❌ | Graceful fallback to regex |
-| `createIndex` with collation | ✅ | ❌ | Skip collation indexes |
-| `createIndex` (secondary) | ✅ | Hangs | Skip via init-container patch |
-| `find_one({'_id': id})` | ✅ | ⚠️ v0.109-0 bug | Upgrade to v0.110-0+ |
-| Basic CRUD operations | ✅ | ✅ | Works natively |
-| Aggregation pipelines | ✅ | ✅ | `$group`, `$match`, `$sort` work |
+| Store          | Backend                | Notes                           |
+| -------------- | ---------------------- | ------------------------------- |
+| KV             | `MongoKVStorage`       | Documents, chunks, entities     |
+| Graph          | `MongoGraphStorage`    | Knowledge graph nodes and edges |
+| Doc status     | `MongoDocStatusStorage`| Per-document processing state   |
+| Vectors        | `NanoVectorDBStorage`  | Local file (PVC) — see below    |
 
-### How the Init-Container Patches Work
+`NanoVectorDBStorage` is used instead of `MongoVectorDBStorage` because
+DocumentDB does not implement the MongoDB Atlas `$vectorSearch` aggregation
+operator that `MongoVectorDBStorage` requires.
 
-The Helm chart's `deployment.yaml` includes an init container (`patch-for-documentdb`) that runs before the main LightRAG container starts. It modifies LightRAG's MongoDB storage layer in-place to skip operations that are incompatible with DocumentDB.
+## DocumentDB Compatibility Patches
 
-**What gets patched:**
+The `helm/lightrag` chart's `deployment.yaml` runs an init container
+(`patch-for-documentdb`) that no-ops three async methods in
+`lightrag/kg/mongo_impl.py` before the main container starts:
 
-Three async methods in `lightrag/kg/mongo_impl.py` are stubbed out with an early `return`:
+| Method                                    | Reason                                                                                                                |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `create_and_migrate_indexes_if_not_exists`| Calls `createIndex` with collation (DocumentDB returns `not implemented yet`) and secondary indexes (hangs).          |
+| `create_search_index_if_not_exists`       | Calls `$listSearchIndexes` (Atlas-only). LightRAG already swallows the error; the patch silences the noisy log line.  |
+| `create_vector_index_if_not_exists`       | Creates Atlas `$vectorSearch` indexes — not relevant because we use `NanoVectorDBStorage`.                            |
 
-| Method | Why it's patched |
-|---|---|
-| `create_and_migrate_indexes_if_not_exists` | Calls `createIndex` with collation and secondary indexes. DocumentDB rejects collation (`"not implemented yet"`) and hangs indefinitely on secondary index creation. |
-| `create_search_index_if_not_exists` | Calls `$listSearchIndexes` which DocumentDB doesn't support. While LightRAG catches the `PyMongoError` gracefully, skipping it avoids unnecessary error logs. |
-| `create_vector_index_if_not_exists` | Creates Atlas `$vectorSearch` indexes. Not applicable because this playground uses `NanoVectorDBStorage` (local) instead of `MongoVectorDBStorage`. |
+The patches are applied to both `/app/lightrag/` (dev install) and
+`/app/.venv/lib/python3.12/site-packages/lightrag/` (venv install) because the
+upstream image ships both copies, and the bytecode caches are cleared so the
+modified source is reloaded on import.
 
-**How it works:**
+LightRAG operates normally without these indexes. The trade-off is slower
+queries on very large datasets, which is acceptable for a playground.
 
-1. The init container shares the same image as the main LightRAG container.
-2. A Python script inserts `return` statements at the top of each method, effectively making them no-ops.
-3. Both code locations are patched — `/app/lightrag/` (dev install) and `/app/.venv/lib/python3.12/site-packages/lightrag/` (venv install) — because the LightRAG Docker image includes two copies.
-4. Bytecode caches (`__pycache__/mongo_impl*.pyc`) are cleared to prevent stale compiled code from being loaded.
+## Verification
 
-**Impact:** LightRAG operates normally without indexes. All CRUD, aggregation, and graph traversal operations work correctly. The only trade-off is that queries on large datasets may be slower without secondary indexes, which is acceptable for a playground.
-
-The patches are applied automatically — no manual configuration is needed.
-
-## Verified Operations
-
-The following LightRAG operations have been tested with DocumentDB v0.112.0+:
-
-- ✅ Document ingestion and chunking
-- ✅ Entity and relationship extraction (via LLM)
-- ✅ Knowledge graph storage and traversal
-- ✅ LLM response caching
-- ✅ Naive, local, global, and hybrid RAG queries
-- ✅ Document status tracking
-- ✅ WebUI for graph visualization
-
-> **Note:** DocumentDB v0.109-0 had a bug where `_id` lookups failed after writes. Use v0.110-0 or later.
-
-## Testing Guide
-
-Use this guide to verify LightRAG + DocumentDB integration is working correctly.
-
-### Prerequisites
-
-Ensure you have:
-- DocumentDB operator installed
-- LightRAG and Ollama pods running (`kubectl get pods -n lightrag`)
-- Port-forward active: `kubectl port-forward svc/lightrag 9621:9621 -n lightrag &`
-- Python with pymongo installed for verification tests
-
-### Deploy DocumentDB with Custom Images (Required)
-
-The official DocumentDB v0.109-0 images have a bug that breaks LightRAG. You must deploy with custom images from the `hossain-rayhan` fork that include the fix:
+After `deploy.sh` finishes and you have port-forward running:
 
 ```bash
-# Create namespace and credentials
-kubectl create namespace documentdb-test
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Secret
-metadata:
-  name: documentdb-credentials
-  namespace: documentdb-test
-type: Opaque
-stringData:
-  username: docdbadmin
-  password: SecurePassword123!
-EOF
+# 1. Health
+curl -s http://localhost:9621/health | jq -r .status
+# Expected: healthy
 
-# Create image pull secret for the custom images
-kubectl create secret docker-registry ghcr-pull-secret \
-    -n documentdb-test \
-    --docker-server=ghcr.io \
-    --docker-username=<your-github-username> \
-    --docker-password=<your-github-token>
-
-# Patch default service account to use the pull secret
-kubectl patch serviceaccount default -n documentdb-test \
-    -p '{"imagePullSecrets": [{"name": "ghcr-pull-secret"}]}'
-
-# Deploy DocumentDB with custom images
-kubectl apply -f - <<EOF
-apiVersion: documentdb.io/preview
-kind: DocumentDB
-metadata:
-  name: lightrag-test
-  namespace: documentdb-test
-spec:
-  environment: aks
-  nodeCount: 1
-  instancesPerNode: 1
-  # Custom images with _id lookup fix (v0.112.0+)
-  documentDBImage: ghcr.io/hossain-rayhan/documentdb-kubernetes-operator/documentdb:0.112.0
-  gatewayImage: ghcr.io/hossain-rayhan/documentdb-kubernetes-operator/gateway:0.112.0
-  documentDbCredentialSecret: documentdb-credentials
-  resource:
-    storage:
-      pvcSize: 10Gi
-  exposeViaService:
-    serviceType: LoadBalancer
-  sidecarInjectorPluginName: cnpg-i-sidecar-injector.documentdb.io
-EOF
-
-# Wait for DocumentDB to be healthy
-kubectl wait --for=jsonpath='{.status.phase}'="Cluster in healthy state" \
-    documentdb/lightrag-test -n documentdb-test --timeout=300s
-```
-
-Verify the custom images are being used:
-```bash
-kubectl get pod -n documentdb-test -l documentdb.io/name=lightrag-test \
-    -o jsonpath='{.items[0].spec.volumes[?(@.name=="documentdb")].image.reference}{"\n"}'
-# Expected: ghcr.io/hossain-rayhan/documentdb-kubernetes-operator/documentdb:0.112.0
-```
-
-### Test 1: Verify `_id` Lookup Fix
-
-This test confirms the DocumentDB `_id` lookup bug (fixed in v0.110-0+) is resolved:
-
-```bash
-python3 -c "
-from pymongo import MongoClient
-
-# Update with your DocumentDB connection details
-client = MongoClient('mongodb://<user>:<password>@<host>:10260/?authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&directConnection=true')
-db = client['test_id_lookup']
-col = db['test']
-col.drop()
-
-# Insert and immediately read back by _id
-result = col.insert_one({'name': 'test', 'value': 42})
-print(f'Inserted _id: {result.inserted_id}')
-
-# This was failing with 'pruned relation' error in v0.109-0
-found = col.find_one({'_id': result.inserted_id})
-if found:
-    print(f'SUCCESS: _id lookup works! Found: {found}')
-else:
-    print('FAILED: _id lookup returned None')
-
-col.drop()
-client.close()
-"
-```
-
-**Expected output:**
-```
-Inserted _id: <ObjectId>
-SUCCESS: _id lookup works! Found: {'_id': ObjectId('...'), 'name': 'test', 'value': 42}
-```
-
-### Test 2: Document Ingestion
-
-Test that documents can be ingested without "pruned relation" errors:
-
-```bash
-# Insert a short document (faster processing)
+# 2. Insert a document
 curl -s -X POST http://localhost:9621/documents/text \
   -H "Content-Type: application/json" \
-  -d '{"text": "Microsoft Azure is a cloud computing platform. It competes with AWS and Google Cloud."}' | jq .
-```
+  -d '{"text": "Amazon Web Services (AWS) is a cloud platform. AWS competes with Microsoft Azure and Google Cloud Platform."}' | jq .
+# Expected: {"status": "success", "track_id": "..."}
 
-**Expected output:**
-```json
-{
-  "status": "success",
-  "message": "Text successfully received. Processing will continue in background.",
-  "track_id": "insert_..."
-}
-```
+# 3. Wait for processing (5–10 minutes on CPU Ollama)
+watch -n 30 'curl -s http://localhost:9621/documents/status_counts | jq .'
+# Expected: {"status_counts": {"processed": 1, "all": 1}}
+# (macOS users without `watch`: `while sleep 30; do curl -s http://localhost:9621/documents/status_counts | jq .; done`)
 
-Check processing status in logs (wait 2-3 minutes for LLM to complete):
-```bash
-kubectl logs -n lightrag -l app.kubernetes.io/name=lightrag --tail=20 | grep -E "(Completed|Processing|Extracting)"
-```
-
-**Expected:** `INFO: Completed processing file X/X: unknown_source`
-
-### Test 3: RAG Queries
-
-Test different query modes:
-
-```bash
-# Naive mode (direct retrieval)
+# 4. Query
 curl -s -X POST http://localhost:9621/query \
   -H "Content-Type: application/json" \
-  -d '{"query": "What is AWS?", "mode": "naive"}' | jq .
-
-# Local mode (uses knowledge graph)
-curl -s -X POST http://localhost:9621/query \
-  -H "Content-Type: application/json" \
-  -d '{"query": "What companies compete with AWS?", "mode": "local"}' | jq .
-
-# Hybrid mode (combines local + global)
-curl -s -X POST http://localhost:9621/query \
-  -H "Content-Type: application/json" \
-  -d '{"query": "What is cloud computing?", "mode": "hybrid"}' | jq .
+  -d '{"query": "What is AWS?", "mode": "hybrid"}' | jq -r .response
 ```
 
-**Expected:** Each query should return a `response` with relevant information.
+Open <http://localhost:9621> for the WebUI:
 
-### Test 4: Verify Data in DocumentDB
-
-Verify entities, relations, and documents are stored in DocumentDB:
-
-```bash
-python3 -c "
-from pymongo import MongoClient
-
-# Update with your DocumentDB connection details
-c = MongoClient('mongodb://<user>:<password>@<host>:10260/?authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&directConnection=true')
-db = c['lightrag']
-
-print('=== COLLECTIONS ===')
-for col in sorted(db.list_collection_names()):
-    count = db[col].count_documents({})
-    print(f'  {col}: {count} docs')
-
-print('\n=== ENTITIES ===')
-for e in db['entity_chunks'].find():
-    print(f'  - {e.get(\"_id\", \"?\")}')
-
-print('\n=== RELATIONS ===')
-for r in db['relation_chunks'].find():
-    print(f'  - {r.get(\"_id\", \"?\")}')
-
-print('\n=== DOC STATUS ===')
-for d in db['doc_status'].find({}, {'_id': 1, 'status': 1}):
-    status = d.get('status', '?')
-    doc_id = str(d.get('_id', '?'))[:40]
-    print(f'  - {doc_id}... : {status}')
-
-c.close()
-"
-```
-
-**Expected output:**
-```
-=== COLLECTIONS ===
-  chunk_entity_relation: X docs
-  doc_status: X docs
-  entity_chunks: X docs
-  full_docs: X docs
-  ...
-
-=== ENTITIES ===
-  - AWS
-  - Microsoft Azure
-  - Google Cloud
-  ...
-
-=== RELATIONS ===
-  - AWS<SEP>Amazon
-  ...
-
-=== DOC STATUS ===
-  - doc-xxx... : processed
-  ...
-```
-
-### Test 5: WebUI Verification
-
-1. Open http://localhost:9621 in your browser
-2. **Documents tab**: Should show ingested documents with status (Completed/Failed)
-3. **Knowledge Graph tab**: Should display entity nodes (AWS, Azure, etc.) with connecting edges
-4. **Query tab**: Enter "What is AWS?" and select a mode — should return contextual answer
-
-### Test Summary Checklist
-
-| Test | Command/Action | Expected Result |
-|------|---------------|-----------------|
-| `_id` lookup | Python pymongo test | "SUCCESS: _id lookup works!" |
-| Document ingestion | POST /documents/text | `"status": "success"` |
-| No pruned errors | Check logs | No "pruned relation" errors |
-| Entity extraction | Check logs | "Completed processing file" |
-| RAG query | POST /query | Returns relevant `response` |
-| Data persistence | Python collection count | Collections have documents |
-| WebUI Documents | Browser | Shows document list with status |
-| WebUI Graph | Browser | Shows entity nodes and edges |
-
-### Common Issues
-
-| Issue | Cause | Solution |
-|-------|-------|----------|
-| "pruned relation" error | DocumentDB < v0.110-0 | Upgrade to v0.110-0+ |
-| Document status: Failed | LLM timeout | Try shorter documents; check Ollama resources |
-| Empty query response | Document still processing | Wait 2-3 min; check logs for completion |
-| Graph shows no edges | LLM output format errors | Normal for some docs; relation extraction is LLM-dependent |
-
-## Known Issues
-
-### "Pruned Relation" Error on `_id` Lookups (Fixed in v0.110-0)
-
-**Status:** Fixed in DocumentDB v0.110-0 ([PR #459](https://github.com/documentdb/documentdb/pull/459))
-
-**Affected versions:** DocumentDB extension ≤ v0.109-0
-
-There is a bug in DocumentDB where queries using the `_id` index fail after any write operation:
-
-```
-trying to open a pruned relation, full error: {
-  'ok': 0.0, 
-  'code': 1, 
-  'codeName': 'SqlState(EXX000)', 
-  'errmsg': 'trying to open a pruned relation'
-}
-```
-
-**Root Cause:** In PostgreSQL 18, the custom planner's fast-path read plan did not correctly set `unprunableRelIds`, causing the `_id` index relation to be incorrectly marked as prunable. The fix ([commit e2c5520](https://github.com/documentdb/documentdb/commit/e2c552023f455b3abfa261439e7809f80afeeeec)) properly sets non-prunable RT indexes for PG 18.
-
-**What fails vs. what works:**
-
-| Operation | Result |
-|-----------|--------|
-| `insert_one({...})` | ✅ Works |
-| `find_one({})` (empty filter) | ✅ Works |
-| `find_one({'name': value})` | ✅ Works |
-| `count_documents({})` | ✅ Works |
-| `find_one({'_id': id})` after any write | ❌ **FAILS** |
-
-**Timeline:**
-| Event | Date |
-|-------|------|
-| Bug fix merged to main | Feb 25, 2026 |
-| v0.109-0 released (does NOT include fix) | Mar 9, 2026 |
-| v0.112.0 (verified fix) | Apr 21, 2026 |
-
-**Resolution:** Upgrade to DocumentDB extension v0.110-0 or later. Tested and verified working with v0.112.0.
-
-**Impact:** This prevents LightRAG document ingestion from working because the ingestion workflow reads back document status immediately after writing it using `find_one({'_id': inserted_id})`.
+- **Documents** — ingestion status
+- **Knowledge Graph** — extracted entities and relationships
+- **Query** — interactive RAG with `naive`, `local`, `global`, `hybrid` modes
 
 ## Troubleshooting
 
-### LightRAG pod stuck in `Running` but not `Ready`
+### Document stays in `processing` for a long time then fails
 
-The most common cause is `createIndex` hanging on DocumentDB. Verify the init container patch applied correctly:
+The most common cause is the LLM call exceeding `LLM_TIMEOUT`. Check the
+LightRAG logs:
 
 ```bash
-POD=$(kubectl get pod -l app.kubernetes.io/name=lightrag -n lightrag -o jsonpath='{.items[0].metadata.name}')
-kubectl logs -n lightrag "$POD" -c patch-for-documentdb
-# Should show: "DocumentDB compatibility patches applied"
+kubectl logs -n lightrag deployment/lightrag --tail=100 | grep -E "(httpx.ReadTimeout|workers initialized)"
 ```
+
+You should see `LLM func: 2 new workers initialized (Timeouts: Func: 900s, ...)`.
+If `Func` is still `180s`, your override didn't apply — re-check
+`helm/lightrag-values.yaml` and `helm upgrade`.
+
+### Document fails with "model requires more system memory"
+
+Ollama's qwen2.5:3b needs ~2 GiB of free memory inside the container. The
+default Ollama deployment requests 4 GiB and limits to 8 GiB. If your nodes
+are tight, scale Ollama down or use a smaller model (`qwen2.5:1.5b`).
+
+### LightRAG pod crashes with `ServerSelectionTimeoutError ... 'rs0' but ... 'None'`
+
+The MongoDB URI contains `replicaSet=rs0` but the gateway exposes itself as a
+standalone server. `scripts/deploy.sh` strips this parameter automatically; if
+you set `MONGO_URI` manually, make sure to remove `replicaSet=rs0`.
 
 ### Cannot connect to DocumentDB
 
@@ -516,11 +224,28 @@ kubectl run mongo-test --rm -it --restart=Never -n lightrag --image=mongo:7 \
   --command -- mongosh "<your-connection-string>" --eval 'db.adminCommand({ping:1})'
 ```
 
-### LLM errors during document processing
+### Ollama model is missing after a pod restart
 
-Check that Ollama has the models pulled:
+Models live on the `ollama-models` PVC defined in `helm/ollama.yaml`. If your
+StorageClass deleted the PV (`reclaimPolicy: Delete`), re-pull manually:
 
 ```bash
 OLLAMA_POD=$(kubectl get pod -l app=ollama -n lightrag -o jsonpath='{.items[0].metadata.name}')
-kubectl exec -n lightrag "$OLLAMA_POD" -- ollama list
+kubectl exec -n lightrag "$OLLAMA_POD" -- ollama pull nomic-embed-text
+kubectl exec -n lightrag "$OLLAMA_POD" -- ollama pull qwen2.5:3b
 ```
+
+## Version Compatibility
+
+| Component           | Tested version                |
+| ------------------- | ----------------------------- |
+| DocumentDB operator | 0.2.0                         |
+| DocumentDB images   | 0.110.0+ (required for `_id` lookup fix) |
+| LightRAG            | `ghcr.io/hkuds/lightrag:latest` (core 1.4.x) |
+| Ollama              | `ollama/ollama:latest`        |
+| Kubernetes          | 1.30+                         |
+
+_Last verified: April 2026._
+
+The `helm/lightrag` chart is intentionally local-only — it is a playground
+sample, not a published or supported product chart.

--- a/documentdb-playground/lightrag/README.md
+++ b/documentdb-playground/lightrag/README.md
@@ -159,6 +159,7 @@ LightRAG's MongoDB storage assumes MongoDB Atlas features. This playground inclu
 | `$listSearchIndexes` | ✅ | ❌ | Graceful fallback to regex |
 | `createIndex` with collation | ✅ | ❌ | Skip collation indexes |
 | `createIndex` (secondary) | ✅ | Hangs | Skip via init-container patch |
+| `find_one({'_id': id})` | ✅ | ⚠️ v0.109-0 bug | Upgrade to v0.110-0+ |
 | Basic CRUD operations | ✅ | ✅ | Works natively |
 | Aggregation pipelines | ✅ | ✅ | `$group`, `$match`, `$sort` work |
 
@@ -189,7 +190,7 @@ The patches are applied automatically — no manual configuration is needed.
 
 ## Verified Operations
 
-The following LightRAG operations have been tested with DocumentDB:
+The following LightRAG operations have been tested with DocumentDB v0.112.0+:
 
 - ✅ Document ingestion and chunking
 - ✅ Entity and relationship extraction (via LLM)
@@ -198,6 +199,301 @@ The following LightRAG operations have been tested with DocumentDB:
 - ✅ Naive, local, global, and hybrid RAG queries
 - ✅ Document status tracking
 - ✅ WebUI for graph visualization
+
+> **Note:** DocumentDB v0.109-0 had a bug where `_id` lookups failed after writes. Use v0.110-0 or later.
+
+## Testing Guide
+
+Use this guide to verify LightRAG + DocumentDB integration is working correctly.
+
+### Prerequisites
+
+Ensure you have:
+- DocumentDB operator installed
+- LightRAG and Ollama pods running (`kubectl get pods -n lightrag`)
+- Port-forward active: `kubectl port-forward svc/lightrag 9621:9621 -n lightrag &`
+- Python with pymongo installed for verification tests
+
+### Deploy DocumentDB with Custom Images (Required)
+
+The official DocumentDB v0.109-0 images have a bug that breaks LightRAG. You must deploy with custom images from the `hossain-rayhan` fork that include the fix:
+
+```bash
+# Create namespace and credentials
+kubectl create namespace documentdb-test
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: documentdb-credentials
+  namespace: documentdb-test
+type: Opaque
+stringData:
+  username: docdbadmin
+  password: SecurePassword123!
+EOF
+
+# Create image pull secret for the custom images
+kubectl create secret docker-registry ghcr-pull-secret \
+    -n documentdb-test \
+    --docker-server=ghcr.io \
+    --docker-username=<your-github-username> \
+    --docker-password=<your-github-token>
+
+# Patch default service account to use the pull secret
+kubectl patch serviceaccount default -n documentdb-test \
+    -p '{"imagePullSecrets": [{"name": "ghcr-pull-secret"}]}'
+
+# Deploy DocumentDB with custom images
+kubectl apply -f - <<EOF
+apiVersion: documentdb.io/preview
+kind: DocumentDB
+metadata:
+  name: lightrag-test
+  namespace: documentdb-test
+spec:
+  environment: aks
+  nodeCount: 1
+  instancesPerNode: 1
+  # Custom images with _id lookup fix (v0.112.0+)
+  documentDBImage: ghcr.io/hossain-rayhan/documentdb-kubernetes-operator/documentdb:0.112.0
+  gatewayImage: ghcr.io/hossain-rayhan/documentdb-kubernetes-operator/gateway:0.112.0
+  documentDbCredentialSecret: documentdb-credentials
+  resource:
+    storage:
+      pvcSize: 10Gi
+  exposeViaService:
+    serviceType: LoadBalancer
+  sidecarInjectorPluginName: cnpg-i-sidecar-injector.documentdb.io
+EOF
+
+# Wait for DocumentDB to be healthy
+kubectl wait --for=jsonpath='{.status.phase}'="Cluster in healthy state" \
+    documentdb/lightrag-test -n documentdb-test --timeout=300s
+```
+
+Verify the custom images are being used:
+```bash
+kubectl get pod -n documentdb-test -l documentdb.io/name=lightrag-test \
+    -o jsonpath='{.items[0].spec.volumes[?(@.name=="documentdb")].image.reference}{"\n"}'
+# Expected: ghcr.io/hossain-rayhan/documentdb-kubernetes-operator/documentdb:0.112.0
+```
+
+### Test 1: Verify `_id` Lookup Fix
+
+This test confirms the DocumentDB `_id` lookup bug (fixed in v0.110-0+) is resolved:
+
+```bash
+python3 -c "
+from pymongo import MongoClient
+
+# Update with your DocumentDB connection details
+client = MongoClient('mongodb://<user>:<password>@<host>:10260/?authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&directConnection=true')
+db = client['test_id_lookup']
+col = db['test']
+col.drop()
+
+# Insert and immediately read back by _id
+result = col.insert_one({'name': 'test', 'value': 42})
+print(f'Inserted _id: {result.inserted_id}')
+
+# This was failing with 'pruned relation' error in v0.109-0
+found = col.find_one({'_id': result.inserted_id})
+if found:
+    print(f'SUCCESS: _id lookup works! Found: {found}')
+else:
+    print('FAILED: _id lookup returned None')
+
+col.drop()
+client.close()
+"
+```
+
+**Expected output:**
+```
+Inserted _id: <ObjectId>
+SUCCESS: _id lookup works! Found: {'_id': ObjectId('...'), 'name': 'test', 'value': 42}
+```
+
+### Test 2: Document Ingestion
+
+Test that documents can be ingested without "pruned relation" errors:
+
+```bash
+# Insert a short document (faster processing)
+curl -s -X POST http://localhost:9621/documents/text \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Microsoft Azure is a cloud computing platform. It competes with AWS and Google Cloud."}' | jq .
+```
+
+**Expected output:**
+```json
+{
+  "status": "success",
+  "message": "Text successfully received. Processing will continue in background.",
+  "track_id": "insert_..."
+}
+```
+
+Check processing status in logs (wait 2-3 minutes for LLM to complete):
+```bash
+kubectl logs -n lightrag -l app.kubernetes.io/name=lightrag --tail=20 | grep -E "(Completed|Processing|Extracting)"
+```
+
+**Expected:** `INFO: Completed processing file X/X: unknown_source`
+
+### Test 3: RAG Queries
+
+Test different query modes:
+
+```bash
+# Naive mode (direct retrieval)
+curl -s -X POST http://localhost:9621/query \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What is AWS?", "mode": "naive"}' | jq .
+
+# Local mode (uses knowledge graph)
+curl -s -X POST http://localhost:9621/query \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What companies compete with AWS?", "mode": "local"}' | jq .
+
+# Hybrid mode (combines local + global)
+curl -s -X POST http://localhost:9621/query \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What is cloud computing?", "mode": "hybrid"}' | jq .
+```
+
+**Expected:** Each query should return a `response` with relevant information.
+
+### Test 4: Verify Data in DocumentDB
+
+Verify entities, relations, and documents are stored in DocumentDB:
+
+```bash
+python3 -c "
+from pymongo import MongoClient
+
+# Update with your DocumentDB connection details
+c = MongoClient('mongodb://<user>:<password>@<host>:10260/?authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true&directConnection=true')
+db = c['lightrag']
+
+print('=== COLLECTIONS ===')
+for col in sorted(db.list_collection_names()):
+    count = db[col].count_documents({})
+    print(f'  {col}: {count} docs')
+
+print('\n=== ENTITIES ===')
+for e in db['entity_chunks'].find():
+    print(f'  - {e.get(\"_id\", \"?\")}')
+
+print('\n=== RELATIONS ===')
+for r in db['relation_chunks'].find():
+    print(f'  - {r.get(\"_id\", \"?\")}')
+
+print('\n=== DOC STATUS ===')
+for d in db['doc_status'].find({}, {'_id': 1, 'status': 1}):
+    status = d.get('status', '?')
+    doc_id = str(d.get('_id', '?'))[:40]
+    print(f'  - {doc_id}... : {status}')
+
+c.close()
+"
+```
+
+**Expected output:**
+```
+=== COLLECTIONS ===
+  chunk_entity_relation: X docs
+  doc_status: X docs
+  entity_chunks: X docs
+  full_docs: X docs
+  ...
+
+=== ENTITIES ===
+  - AWS
+  - Microsoft Azure
+  - Google Cloud
+  ...
+
+=== RELATIONS ===
+  - AWS<SEP>Amazon
+  ...
+
+=== DOC STATUS ===
+  - doc-xxx... : processed
+  ...
+```
+
+### Test 5: WebUI Verification
+
+1. Open http://localhost:9621 in your browser
+2. **Documents tab**: Should show ingested documents with status (Completed/Failed)
+3. **Knowledge Graph tab**: Should display entity nodes (AWS, Azure, etc.) with connecting edges
+4. **Query tab**: Enter "What is AWS?" and select a mode — should return contextual answer
+
+### Test Summary Checklist
+
+| Test | Command/Action | Expected Result |
+|------|---------------|-----------------|
+| `_id` lookup | Python pymongo test | "SUCCESS: _id lookup works!" |
+| Document ingestion | POST /documents/text | `"status": "success"` |
+| No pruned errors | Check logs | No "pruned relation" errors |
+| Entity extraction | Check logs | "Completed processing file" |
+| RAG query | POST /query | Returns relevant `response` |
+| Data persistence | Python collection count | Collections have documents |
+| WebUI Documents | Browser | Shows document list with status |
+| WebUI Graph | Browser | Shows entity nodes and edges |
+
+### Common Issues
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| "pruned relation" error | DocumentDB < v0.110-0 | Upgrade to v0.110-0+ |
+| Document status: Failed | LLM timeout | Try shorter documents; check Ollama resources |
+| Empty query response | Document still processing | Wait 2-3 min; check logs for completion |
+| Graph shows no edges | LLM output format errors | Normal for some docs; relation extraction is LLM-dependent |
+
+## Known Issues
+
+### "Pruned Relation" Error on `_id` Lookups (Fixed in v0.110-0)
+
+**Status:** Fixed in DocumentDB v0.110-0 ([PR #459](https://github.com/documentdb/documentdb/pull/459))
+
+**Affected versions:** DocumentDB extension ≤ v0.109-0
+
+There is a bug in DocumentDB where queries using the `_id` index fail after any write operation:
+
+```
+trying to open a pruned relation, full error: {
+  'ok': 0.0, 
+  'code': 1, 
+  'codeName': 'SqlState(EXX000)', 
+  'errmsg': 'trying to open a pruned relation'
+}
+```
+
+**Root Cause:** In PostgreSQL 18, the custom planner's fast-path read plan did not correctly set `unprunableRelIds`, causing the `_id` index relation to be incorrectly marked as prunable. The fix ([commit e2c5520](https://github.com/documentdb/documentdb/commit/e2c552023f455b3abfa261439e7809f80afeeeec)) properly sets non-prunable RT indexes for PG 18.
+
+**What fails vs. what works:**
+
+| Operation | Result |
+|-----------|--------|
+| `insert_one({...})` | ✅ Works |
+| `find_one({})` (empty filter) | ✅ Works |
+| `find_one({'name': value})` | ✅ Works |
+| `count_documents({})` | ✅ Works |
+| `find_one({'_id': id})` after any write | ❌ **FAILS** |
+
+**Timeline:**
+| Event | Date |
+|-------|------|
+| Bug fix merged to main | Feb 25, 2026 |
+| v0.109-0 released (does NOT include fix) | Mar 9, 2026 |
+| v0.112.0 (verified fix) | Apr 21, 2026 |
+
+**Resolution:** Upgrade to DocumentDB extension v0.110-0 or later. Tested and verified working with v0.112.0.
+
+**Impact:** This prevents LightRAG document ingestion from working because the ingestion workflow reads back document status immediately after writing it using `find_one({'_id': inserted_id})`.
 
 ## Troubleshooting
 

--- a/documentdb-playground/lightrag/README.md
+++ b/documentdb-playground/lightrag/README.md
@@ -136,25 +136,18 @@ env:
 DocumentDB does not implement the MongoDB Atlas `$vectorSearch` aggregation
 operator that `MongoVectorDBStorage` requires.
 
-## DocumentDB Compatibility Patches
+## Expected Startup Warnings
 
-The `helm/lightrag` chart's `deployment.yaml` runs an init container
-(`patch-for-documentdb`) that no-ops three async methods in
-`lightrag/kg/mongo_impl.py` before the main container starts:
+LightRAG logs two non-fatal errors during startup against DocumentDB. They
+are safe to ignore:
 
-| Method                                    | Reason                                                                                                                |
-| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `create_and_migrate_indexes_if_not_exists`| Calls `createIndex` with collation (DocumentDB returns `not implemented yet`) and secondary indexes (hangs).          |
-| `create_search_index_if_not_exists`       | Calls `$listSearchIndexes` (Atlas-only). LightRAG already swallows the error; the patch silences the noisy log line.  |
-| `create_vector_index_if_not_exists`       | Creates Atlas `$vectorSearch` indexes — not relevant because we use `NanoVectorDBStorage`.                            |
+| Log line                                                         | Why it's harmless                                                                 |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `createIndex.collation is not implemented yet` (on `doc_status`) | DocumentDB doesn't support collation indexes; LightRAG continues without them.    |
+| `Pipeline stage name not recognized: $listSearchIndexes`         | Atlas-only API; LightRAG already falls back to regex search and logs as much.     |
 
-The patches are applied to both `/app/lightrag/` (dev install) and
-`/app/.venv/lib/python3.12/site-packages/lightrag/` (venv install) because the
-upstream image ships both copies, and the bytecode caches are cleared so the
-modified source is reloaded on import.
-
-LightRAG operates normally without these indexes. The trade-off is slower
-queries on very large datasets, which is acceptable for a playground.
+`MongoVectorDBStorage` would call Atlas `$vectorSearch`, but we don't use it
+(see [Storage backends](#storage-backends)).
 
 ## Verification
 
@@ -187,6 +180,31 @@ Open <http://localhost:9621> for the WebUI:
 - **Documents** — ingestion status
 - **Knowledge Graph** — extracted entities and relationships
 - **Query** — interactive RAG with `naive`, `local`, `global`, `hybrid` modes
+
+### Verify the storage backends
+
+Confirm that KV, graph, and doc-status data are actually living in DocumentDB,
+and that vectors are on the local PVC.
+
+```bash
+# 1. Check the env LightRAG actually loaded (chart writes to /app/.env, not container env)
+kubectl exec -n lightrag deploy/lightrag -- \
+    grep -E "LIGHTRAG_(KV|VECTOR|GRAPH|DOC_STATUS)_STORAGE|MONGO_DATABASE" /app/.env
+
+# 2. List collections in DocumentDB — should include full_docs, text_chunks,
+#    llm_response_cache (KV), entities/relationships (graph), doc_status.
+NS=documentdb-test
+CLUSTER=documentdb-cluster
+RAW=$(kubectl get documentdb "$CLUSTER" -n "$NS" -o jsonpath='{.status.connectionString}')
+URI=$(eval "echo \"$RAW\"" | sed -E 's/[?&]replicaSet=[^&]*//g')
+kubectl run mongo-test --rm -it --restart=Never -n lightrag --image=mongo:7 \
+    --command -- mongosh "$URI" \
+    --eval 'db.getSiblingDB("lightrag").getCollectionNames()'
+
+# 3. Confirm vectors are on the local PVC (NanoVectorDBStorage)
+kubectl exec -n lightrag deploy/lightrag -- ls -la /app/data/rag_storage/
+# Expected: vdb_chunks.json, vdb_entities.json, vdb_relationships.json
+```
 
 ## Troubleshooting
 

--- a/documentdb-playground/lightrag/documentdb.yaml
+++ b/documentdb-playground/lightrag/documentdb.yaml
@@ -1,0 +1,40 @@
+# Sample DocumentDB instance sized for the LightRAG playground.
+#
+# Apply with:
+#   kubectl create namespace documentdb-test
+#   kubectl apply -f documentdb.yaml
+#
+# Notes:
+# - LightRAG requires DocumentDB extension v0.110.0 or later for the `_id`
+#   lookup fix (https://github.com/documentdb/documentdb/pull/459).
+#   v0.110.0+ is the default in recent operator releases; pinning the images
+#   here makes the requirement explicit.
+# - Replace the password before using outside a throwaway dev cluster.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: docdb-credentials
+  namespace: documentdb-test
+type: Opaque
+stringData:
+  username: docdbadmin
+  password: "ChangeMe!ReplaceBeforeUsing"
+---
+apiVersion: documentdb.io/preview
+kind: DocumentDB
+metadata:
+  name: documentdb-cluster
+  namespace: documentdb-test
+spec:
+  nodeCount: 1
+  instancesPerNode: 1
+  documentDBImage: ghcr.io/documentdb/documentdb-kubernetes-operator/documentdb:0.110.0
+  gatewayImage: ghcr.io/documentdb/documentdb-kubernetes-operator/gateway:0.110.0
+  documentDbCredentialSecret: docdb-credentials
+  resource:
+    storage:
+      pvcSize: "10Gi"
+  exposeViaService:
+    serviceType: ClusterIP
+  sidecarInjectorPluginName: cnpg-i-sidecar-injector.documentdb.io

--- a/documentdb-playground/lightrag/helm/lightrag-values.yaml
+++ b/documentdb-playground/lightrag/helm/lightrag-values.yaml
@@ -1,0 +1,58 @@
+# LightRAG configuration for DocumentDB backend.
+# Update MONGO_URI with your DocumentDB connection string before deploying.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/hkuds/lightrag
+  tag: latest
+  imagePullSecrets: []
+
+updateStrategy:
+  type: Recreate
+
+service:
+  type: ClusterIP
+  port: 9621
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 1Gi
+
+persistence:
+  enabled: true
+  ragStorage:
+    size: 5Gi
+  inputs:
+    size: 2Gi
+
+env:
+  HOST: "0.0.0.0"
+  PORT: "9621"
+  WEBUI_TITLE: "LightRAG + DocumentDB"
+  WEBUI_DESCRIPTION: "Graph RAG backed by DocumentDB Kubernetes Operator"
+  # LLM - Ollama (in-cluster)
+  LLM_BINDING: ollama
+  LLM_MODEL: qwen2.5:3b
+  LLM_BINDING_HOST: "http://ollama.lightrag.svc.cluster.local:11434"
+  LLM_BINDING_API_KEY: ""
+  # Embedding - Ollama (in-cluster)
+  EMBEDDING_BINDING: ollama
+  EMBEDDING_MODEL: nomic-embed-text
+  EMBEDDING_DIM: "768"
+  EMBEDDING_BINDING_API_KEY: ""
+  # Storage - DocumentDB for KV/Graph/DocStatus, local for vectors
+  LIGHTRAG_KV_STORAGE: MongoKVStorage
+  LIGHTRAG_VECTOR_STORAGE: NanoVectorDBStorage
+  LIGHTRAG_GRAPH_STORAGE: MongoGraphStorage
+  LIGHTRAG_DOC_STATUS_STORAGE: MongoDocStatusStorage
+  # DocumentDB connection — update these values for your cluster
+  MONGO_URI: "mongodb://admin:MySecurePassword123@documentdb-service-my-cluster.documentdb-demo.svc.cluster.local:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
+  MONGO_DATABASE: "LightRAG"
+
+envFrom:
+  configmaps: []
+  secrets: []

--- a/documentdb-playground/lightrag/helm/lightrag-values.yaml
+++ b/documentdb-playground/lightrag/helm/lightrag-values.yaml
@@ -50,8 +50,8 @@ env:
   LIGHTRAG_GRAPH_STORAGE: MongoGraphStorage
   LIGHTRAG_DOC_STATUS_STORAGE: MongoDocStatusStorage
   # DocumentDB connection — update these values for your cluster
-  MONGO_URI: "mongodb://admin:MySecurePassword123@documentdb-service-my-cluster.documentdb-demo.svc.cluster.local:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
-  MONGO_DATABASE: "LightRAG"
+  MONGO_URI: "mongodb://docdbadmin:SecurePassword123!@documentdb-service-lightrag-test.documentdb-test.svc.cluster.local:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
+  MONGO_DATABASE: "lightrag"
 
 envFrom:
   configmaps: []

--- a/documentdb-playground/lightrag/helm/lightrag-values.yaml
+++ b/documentdb-playground/lightrag/helm/lightrag-values.yaml
@@ -1,5 +1,8 @@
 # LightRAG configuration for DocumentDB backend.
-# Update MONGO_URI with your DocumentDB connection string before deploying.
+#
+# MONGO_URI is the only field you typically need to edit. When deploying via
+# scripts/deploy.sh the URI is auto-populated from the DocumentDB resource's
+# status.connectionString, so the placeholder below is overridden.
 replicaCount: 1
 
 image:
@@ -16,11 +19,11 @@ service:
 
 resources:
   limits:
-    cpu: 1000m
-    memory: 2Gi
+    cpu: 2000m
+    memory: 4Gi
   requests:
     cpu: 500m
-    memory: 1Gi
+    memory: 2Gi
 
 persistence:
   enabled: true
@@ -39,6 +42,11 @@ env:
   LLM_MODEL: qwen2.5:3b
   LLM_BINDING_HOST: "http://ollama.lightrag.svc.cluster.local:11434"
   LLM_BINDING_API_KEY: ""
+  # Increase LLM/Embedding timeouts for slow CPU inference (defaults are 180s/30s)
+  LLM_TIMEOUT: "900"
+  EMBEDDING_TIMEOUT: "120"
+  # Reduce concurrent LLM calls to avoid overloading single-replica Ollama
+  MAX_ASYNC: "2"
   # Embedding - Ollama (in-cluster)
   EMBEDDING_BINDING: ollama
   EMBEDDING_MODEL: nomic-embed-text
@@ -49,8 +57,12 @@ env:
   LIGHTRAG_VECTOR_STORAGE: NanoVectorDBStorage
   LIGHTRAG_GRAPH_STORAGE: MongoGraphStorage
   LIGHTRAG_DOC_STATUS_STORAGE: MongoDocStatusStorage
-  # DocumentDB connection — update these values for your cluster
-  MONGO_URI: "mongodb://docdbadmin:SecurePassword123!@documentdb-service-lightrag-test.documentdb-test.svc.cluster.local:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
+  # DocumentDB connection — replace <user>, <password>, <service>, <namespace>
+  # with values from your cluster, or let scripts/deploy.sh populate this
+  # automatically from the DocumentDB resource's status.connectionString.
+  MONGO_URI: "mongodb://<user>:<password>@<documentdb-service>.<documentdb-namespace>.svc.cluster.local:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
+  # Must match the chart default (helm/lightrag/values.yaml). If you change
+  # this, change both — running with mismatched databases splits data silently.
   MONGO_DATABASE: "lightrag"
 
 envFrom:

--- a/documentdb-playground/lightrag/helm/lightrag/Chart.yaml
+++ b/documentdb-playground/lightrag/helm/lightrag/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: lightrag
+description: LightRAG graph-based RAG engine with DocumentDB backend
+type: application
+version: 0.1.0
+appVersion: "1.4.13"

--- a/documentdb-playground/lightrag/helm/lightrag/templates/NOTES.txt
+++ b/documentdb-playground/lightrag/helm/lightrag/templates/NOTES.txt
@@ -1,0 +1,20 @@
+LightRAG has been deployed with DocumentDB backend.
+
+1. Get the application URL:
+{{- if eq .Values.service.type "ClusterIP" }}
+  kubectl port-forward svc/{{ include "lightrag.fullname" . }} -n {{ .Release.Namespace }} 9621:{{ .Values.service.port }}
+  Then visit: http://localhost:9621
+{{- end }}
+
+2. Check health:
+  curl http://localhost:9621/health
+
+3. Insert a document:
+  curl -X POST http://localhost:9621/documents/text \
+    -H "Content-Type: application/json" \
+    -d '{"text": "Your text here"}'
+
+4. Query the knowledge graph:
+  curl -X POST http://localhost:9621/query \
+    -H "Content-Type: application/json" \
+    -d '{"query": "Your question", "mode": "hybrid"}'

--- a/documentdb-playground/lightrag/helm/lightrag/templates/_helpers.tpl
+++ b/documentdb-playground/lightrag/helm/lightrag/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{- define "lightrag.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "lightrag.fullname" -}}
+{{- default .Release.Name .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "lightrag.labels" -}}
+app.kubernetes.io/name: {{ include "lightrag.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "lightrag.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lightrag.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "lightrag.envContent" -}}
+{{- $first := true -}}
+{{- range $key, $val := .Values.env -}}
+{{- if not $first -}}{{- "\n" -}}{{- end -}}
+{{- $first = false -}}
+{{ $key }}={{ $val }}
+{{- end -}}
+{{- end -}}

--- a/documentdb-playground/lightrag/helm/lightrag/templates/deployment.yaml
+++ b/documentdb-playground/lightrag/helm/lightrag/templates/deployment.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lightrag.fullname" . }}
+  labels:
+    {{- include "lightrag.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lightrag.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include "lightrag.envContent" . | sha256sum }}
+      labels:
+        {{- include "lightrag.selectorLabels" . | nindent 8 }}
+    spec:
+      # Init container patches LightRAG's MongoDB storage layer for DocumentDB
+      # compatibility. DocumentDB does not support createIndex with collation,
+      # $listSearchIndexes, or secondary index creation (it hangs). The patch
+      # stubs out these calls so initialization completes cleanly.
+      initContainers:
+        - name: patch-for-documentdb
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ["/app/.venv/bin/python3", "-B", "-c"]
+          args:
+            - |
+              import os, glob
+
+              targets = [
+                  "/app/lightrag/kg/mongo_impl.py",
+                  "/app/.venv/lib/python3.12/site-packages/lightrag/kg/mongo_impl.py",
+              ]
+              for fp in targets:
+                  if not os.path.exists(fp):
+                      continue
+                  with open(fp) as f:
+                      content = f.read()
+                  if "Skipping index creation (DocumentDB)" in content:
+                      print(f"Already patched: {fp}")
+                      continue
+                  patched = content
+                  patched = patched.replace(
+                      "async def create_and_migrate_indexes_if_not_exists(self):",
+                      "async def create_and_migrate_indexes_if_not_exists(self):\n"
+                      "        logger.info(f'[{self.workspace}] Skipping index creation (DocumentDB)')\n"
+                      "        return\n"
+                      "    async def _orig_create_indexes(self):",
+                  )
+                  patched = patched.replace(
+                      "async def create_search_index_if_not_exists(self):",
+                      "async def create_search_index_if_not_exists(self):\n"
+                      "        logger.info(f'[{self.workspace}] Skipping search index (DocumentDB)')\n"
+                      "        return\n"
+                      "    async def _orig_create_search_index(self):",
+                  )
+                  patched = patched.replace(
+                      "async def create_vector_index_if_not_exists(self):",
+                      "async def create_vector_index_if_not_exists(self):\n"
+                      "        logger.info('Skipping vector index (DocumentDB)')\n"
+                      "        return\n"
+                      "    async def _orig_create_vector_index(self):",
+                  )
+                  with open(fp, "w") as f:
+                      f.write(patched)
+                  cache_dir = os.path.join(os.path.dirname(fp), "__pycache__")
+                  for cf in glob.glob(os.path.join(cache_dir, "mongo_impl*")):
+                      os.remove(cf)
+                  print(f"Patched: {fp}")
+              print("DocumentDB compatibility patches applied")
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c"]
+          args:
+            - exec lightrag-server
+          ports:
+            - name: http
+              containerPort: {{ .Values.env.PORT }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: rag-storage
+              mountPath: /app/data/rag_storage
+            - name: inputs
+              mountPath: /app/data/inputs
+            - name: env-file
+              mountPath: /app/.env
+              subPath: .env
+          {{- $envFrom := default (dict) .Values.envFrom }}
+          {{- $envFromEntries := list }}
+          {{- range (default (list) (index $envFrom "secrets")) }}
+          {{- $envFromEntries = append $envFromEntries (dict "secretRef" (dict "name" .name)) }}
+          {{- end }}
+          {{- range (default (list) (index $envFrom "configmaps")) }}
+          {{- $envFromEntries = append $envFromEntries (dict "configMapRef" (dict "name" .name)) }}
+          {{- end }}
+          {{- if gt (len $envFromEntries) 0 }}
+          envFrom:
+{{- toYaml $envFromEntries | nindent 12 }}
+          {{- end }}
+      {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: env-file
+          secret:
+            secretName: {{ include "lightrag.fullname" . }}-env
+        {{- if .Values.persistence.enabled }}
+        - name: rag-storage
+          persistentVolumeClaim:
+            claimName: {{ include "lightrag.fullname" . }}-rag-storage
+        - name: inputs
+          persistentVolumeClaim:
+            claimName: {{ include "lightrag.fullname" . }}-inputs
+        {{- else }}
+        - name: rag-storage
+          emptyDir: {}
+        - name: inputs
+          emptyDir: {}
+        {{- end }}
+  strategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}

--- a/documentdb-playground/lightrag/helm/lightrag/templates/deployment.yaml
+++ b/documentdb-playground/lightrag/helm/lightrag/templates/deployment.yaml
@@ -16,59 +16,6 @@ spec:
       labels:
         {{- include "lightrag.selectorLabels" . | nindent 8 }}
     spec:
-      # Init container patches LightRAG's MongoDB storage layer for DocumentDB
-      # compatibility. DocumentDB does not support createIndex with collation,
-      # $listSearchIndexes, or secondary index creation (it hangs). The patch
-      # stubs out these calls so initialization completes cleanly.
-      initContainers:
-        - name: patch-for-documentdb
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ["/app/.venv/bin/python3", "-B", "-c"]
-          args:
-            - |
-              import os, glob
-
-              targets = [
-                  "/app/lightrag/kg/mongo_impl.py",
-                  "/app/.venv/lib/python3.12/site-packages/lightrag/kg/mongo_impl.py",
-              ]
-              for fp in targets:
-                  if not os.path.exists(fp):
-                      continue
-                  with open(fp) as f:
-                      content = f.read()
-                  if "Skipping index creation (DocumentDB)" in content:
-                      print(f"Already patched: {fp}")
-                      continue
-                  patched = content
-                  patched = patched.replace(
-                      "async def create_and_migrate_indexes_if_not_exists(self):",
-                      "async def create_and_migrate_indexes_if_not_exists(self):\n"
-                      "        logger.info(f'[{self.workspace}] Skipping index creation (DocumentDB)')\n"
-                      "        return\n"
-                      "    async def _orig_create_indexes(self):",
-                  )
-                  patched = patched.replace(
-                      "async def create_search_index_if_not_exists(self):",
-                      "async def create_search_index_if_not_exists(self):\n"
-                      "        logger.info(f'[{self.workspace}] Skipping search index (DocumentDB)')\n"
-                      "        return\n"
-                      "    async def _orig_create_search_index(self):",
-                  )
-                  patched = patched.replace(
-                      "async def create_vector_index_if_not_exists(self):",
-                      "async def create_vector_index_if_not_exists(self):\n"
-                      "        logger.info('Skipping vector index (DocumentDB)')\n"
-                      "        return\n"
-                      "    async def _orig_create_vector_index(self):",
-                  )
-                  with open(fp, "w") as f:
-                      f.write(patched)
-                  cache_dir = os.path.join(os.path.dirname(fp), "__pycache__")
-                  for cf in glob.glob(os.path.join(cache_dir, "mongo_impl*")):
-                      os.remove(cf)
-                  print(f"Patched: {fp}")
-              print("DocumentDB compatibility patches applied")
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/documentdb-playground/lightrag/helm/lightrag/templates/pvc.yaml
+++ b/documentdb-playground/lightrag/helm/lightrag/templates/pvc.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "lightrag.fullname" . }}-rag-storage
+  labels:
+    {{- include "lightrag.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.ragStorage.size }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "lightrag.fullname" . }}-inputs
+  labels:
+    {{- include "lightrag.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.inputs.size }}
+{{- end }}

--- a/documentdb-playground/lightrag/helm/lightrag/templates/secret.yaml
+++ b/documentdb-playground/lightrag/helm/lightrag/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lightrag.fullname" . }}-env
+  labels:
+    {{- include "lightrag.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  .env: |-
+    {{- include "lightrag.envContent" . | nindent 4 }}

--- a/documentdb-playground/lightrag/helm/lightrag/templates/service.yaml
+++ b/documentdb-playground/lightrag/helm/lightrag/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lightrag.fullname" . }}
+  labels:
+    {{- include "lightrag.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.env.PORT }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lightrag.selectorLabels" . | nindent 4 }}

--- a/documentdb-playground/lightrag/helm/lightrag/values.yaml
+++ b/documentdb-playground/lightrag/helm/lightrag/values.yaml
@@ -1,0 +1,53 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/hkuds/lightrag
+  tag: latest
+  imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+updateStrategy:
+  type: Recreate
+
+service:
+  type: ClusterIP
+  port: 9621
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 1Gi
+
+persistence:
+  enabled: true
+  ragStorage:
+    size: 5Gi
+  inputs:
+    size: 2Gi
+
+env:
+  HOST: "0.0.0.0"
+  PORT: "9621"
+  LLM_BINDING: ollama
+  LLM_MODEL: qwen2.5:3b
+  LLM_BINDING_HOST: "http://ollama.lightrag.svc.cluster.local:11434"
+  LLM_BINDING_API_KEY: ""
+  EMBEDDING_BINDING: ollama
+  EMBEDDING_MODEL: nomic-embed-text
+  EMBEDDING_DIM: "768"
+  EMBEDDING_BINDING_API_KEY: ""
+  LIGHTRAG_KV_STORAGE: MongoKVStorage
+  LIGHTRAG_VECTOR_STORAGE: NanoVectorDBStorage
+  LIGHTRAG_GRAPH_STORAGE: MongoGraphStorage
+  LIGHTRAG_DOC_STATUS_STORAGE: MongoDocStatusStorage
+  MONGO_URI: ""
+  MONGO_DATABASE: "LightRAG"
+
+envFrom:
+  configmaps: []
+  secrets: []

--- a/documentdb-playground/lightrag/helm/lightrag/values.yaml
+++ b/documentdb-playground/lightrag/helm/lightrag/values.yaml
@@ -46,7 +46,7 @@ env:
   LIGHTRAG_GRAPH_STORAGE: MongoGraphStorage
   LIGHTRAG_DOC_STATUS_STORAGE: MongoDocStatusStorage
   MONGO_URI: ""
-  MONGO_DATABASE: "LightRAG"
+  MONGO_DATABASE: "lightrag"
 
 envFrom:
   configmaps: []

--- a/documentdb-playground/lightrag/helm/ollama.yaml
+++ b/documentdb-playground/lightrag/helm/ollama.yaml
@@ -1,0 +1,56 @@
+# Ollama deployment for LightRAG LLM and embedding inference.
+# After the pod is running, pull models with:
+#   OLLAMA_POD=$(kubectl get pod -l app=ollama -n lightrag -o jsonpath='{.items[0].metadata.name}')
+#   kubectl exec -n lightrag "$OLLAMA_POD" -- ollama pull nomic-embed-text
+#   kubectl exec -n lightrag "$OLLAMA_POD" -- ollama pull qwen2.5:3b
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lightrag
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  namespace: lightrag
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollama
+  template:
+    metadata:
+      labels:
+        app: ollama
+    spec:
+      containers:
+      - name: ollama
+        image: ollama/ollama:latest
+        ports:
+        - containerPort: 11434
+        resources:
+          requests:
+            cpu: 500m
+            memory: 3Gi
+          limits:
+            cpu: "4"
+            memory: 4Gi
+        volumeMounts:
+        - name: ollama-data
+          mountPath: /root/.ollama
+      volumes:
+      - name: ollama-data
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: lightrag
+spec:
+  selector:
+    app: ollama
+  ports:
+  - port: 11434
+    targetPort: 11434
+  type: ClusterIP

--- a/documentdb-playground/lightrag/helm/ollama.yaml
+++ b/documentdb-playground/lightrag/helm/ollama.yaml
@@ -8,6 +8,18 @@ kind: Namespace
 metadata:
   name: lightrag
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-models
+  namespace: lightrag
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,6 +27,8 @@ metadata:
   namespace: lightrag
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: ollama
@@ -31,16 +45,17 @@ spec:
         resources:
           requests:
             cpu: 500m
-            memory: 3Gi
+            memory: 4Gi
           limits:
             cpu: "4"
-            memory: 4Gi
+            memory: 8Gi
         volumeMounts:
         - name: ollama-data
           mountPath: /root/.ollama
       volumes:
       - name: ollama-data
-        emptyDir: {}
+        persistentVolumeClaim:
+          claimName: ollama-models
 ---
 apiVersion: v1
 kind: Service

--- a/documentdb-playground/lightrag/scripts/cleanup.sh
+++ b/documentdb-playground/lightrag/scripts/cleanup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Remove LightRAG and Ollama from the cluster.
+set -euo pipefail
+
+NAMESPACE="${LIGHTRAG_NAMESPACE:-lightrag}"
+
+echo "=== Cleaning up LightRAG deployment ==="
+
+echo "Uninstalling LightRAG Helm release..."
+helm uninstall lightrag -n "$NAMESPACE" 2>/dev/null || true
+
+echo "Deleting PVCs..."
+kubectl delete pvc -l app.kubernetes.io/name=lightrag -n "$NAMESPACE" 2>/dev/null || true
+
+echo "Deleting Ollama..."
+kubectl delete deployment ollama -n "$NAMESPACE" 2>/dev/null || true
+kubectl delete service ollama -n "$NAMESPACE" 2>/dev/null || true
+
+echo "Deleting namespace..."
+kubectl delete namespace "$NAMESPACE" 2>/dev/null || true
+
+echo "Cleanup complete."

--- a/documentdb-playground/lightrag/scripts/cleanup.sh
+++ b/documentdb-playground/lightrag/scripts/cleanup.sh
@@ -15,6 +15,10 @@ kubectl delete pvc -l app.kubernetes.io/name=lightrag -n "$NAMESPACE" 2>/dev/nul
 echo "Deleting Ollama..."
 kubectl delete deployment ollama -n "$NAMESPACE" 2>/dev/null || true
 kubectl delete service ollama -n "$NAMESPACE" 2>/dev/null || true
+# ollama-models PVC is not labeled app.kubernetes.io/name=lightrag, so the
+# label-selector delete above skips it. Delete it explicitly so a Ctrl-C
+# before the namespace delete does not orphan the PV.
+kubectl delete pvc ollama-models -n "$NAMESPACE" 2>/dev/null || true
 
 echo "Deleting namespace..."
 kubectl delete namespace "$NAMESPACE" 2>/dev/null || true

--- a/documentdb-playground/lightrag/scripts/deploy.sh
+++ b/documentdb-playground/lightrag/scripts/deploy.sh
@@ -29,24 +29,22 @@ kubectl exec -n "$NAMESPACE" "$OLLAMA_POD" -- ollama pull nomic-embed-text
 echo "Pulling qwen2.5:3b (LLM, ~1.9GB)..."
 kubectl exec -n "$NAMESPACE" "$OLLAMA_POD" -- ollama pull qwen2.5:3b
 
-# 3. Get DocumentDB connection details
+# 3. Get DocumentDB connection string from resource status
 echo ""
 echo "--- Step 3: DocumentDB connection ---"
-SVC_NAME="documentdb-service-${DOCUMENTDB_CLUSTER}"
-SVC_HOST="${SVC_NAME}.${DOCUMENTDB_NAMESPACE}.svc.cluster.local"
-# Try to extract credentials from the DocumentDB secret
-SECRET_NAME="${DOCUMENTDB_CLUSTER}-superuser"
-if kubectl get secret "$SECRET_NAME" -n "$DOCUMENTDB_NAMESPACE" &>/dev/null; then
-    DB_USER=$(kubectl get secret "$SECRET_NAME" -n "$DOCUMENTDB_NAMESPACE" -o jsonpath='{.data.username}' | base64 -d)
-    DB_PASS=$(kubectl get secret "$SECRET_NAME" -n "$DOCUMENTDB_NAMESPACE" -o jsonpath='{.data.password}' | base64 -d)
+RAW_CONN=$(kubectl get documentdb "$DOCUMENTDB_CLUSTER" -n "$DOCUMENTDB_NAMESPACE" \
+    -o jsonpath='{.status.connectionString}' 2>/dev/null) || true
+
+if [ -n "$RAW_CONN" ]; then
+    # The connection string contains embedded kubectl commands for credentials.
+    # eval resolves them into a usable URI.
+    MONGO_URI=$(eval echo "$RAW_CONN")
+    echo "Connection string retrieved from DocumentDB status."
 else
-    echo "Could not find secret $SECRET_NAME in namespace $DOCUMENTDB_NAMESPACE."
+    echo "Could not read status.connectionString from DocumentDB resource."
     echo "Please set MONGO_URI in $VALUES_FILE manually."
-    DB_USER="admin"
-    DB_PASS="CHANGEME"
+    MONGO_URI=""
 fi
-MONGO_URI="mongodb://${DB_USER}:${DB_PASS}@${SVC_HOST}:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
-echo "DocumentDB endpoint: ${SVC_HOST}:10260"
 
 # 4. Deploy LightRAG via Helm
 echo ""

--- a/documentdb-playground/lightrag/scripts/deploy.sh
+++ b/documentdb-playground/lightrag/scripts/deploy.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Deploy LightRAG with DocumentDB backend on a Kubernetes cluster.
+# Prerequisites: kubectl, helm, a running cluster with DocumentDB deployed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHART_DIR="$SCRIPT_DIR/../helm/lightrag"
+VALUES_FILE="$SCRIPT_DIR/../helm/lightrag-values.yaml"
+OLLAMA_MANIFEST="$SCRIPT_DIR/../helm/ollama.yaml"
+NAMESPACE="${LIGHTRAG_NAMESPACE:-lightrag}"
+DOCUMENTDB_NAMESPACE="${DOCUMENTDB_NAMESPACE:-documentdb-demo}"
+DOCUMENTDB_CLUSTER="${DOCUMENTDB_CLUSTER:-my-cluster}"
+
+echo "=== LightRAG + DocumentDB Deployment ==="
+
+# 1. Create namespace and deploy Ollama
+echo ""
+echo "--- Step 1: Deploy Ollama ---"
+kubectl apply -f "$OLLAMA_MANIFEST"
+echo "Waiting for Ollama pod to be ready..."
+kubectl wait --for=condition=Ready pod -l app=ollama -n "$NAMESPACE" --timeout=120s
+
+# 2. Pull models
+echo ""
+echo "--- Step 2: Pull LLM and embedding models ---"
+OLLAMA_POD=$(kubectl get pod -l app=ollama -n "$NAMESPACE" -o jsonpath='{.items[0].metadata.name}')
+echo "Pulling nomic-embed-text (embedding, ~274MB)..."
+kubectl exec -n "$NAMESPACE" "$OLLAMA_POD" -- ollama pull nomic-embed-text
+echo "Pulling qwen2.5:3b (LLM, ~1.9GB)..."
+kubectl exec -n "$NAMESPACE" "$OLLAMA_POD" -- ollama pull qwen2.5:3b
+
+# 3. Get DocumentDB connection details
+echo ""
+echo "--- Step 3: DocumentDB connection ---"
+SVC_NAME="documentdb-service-${DOCUMENTDB_CLUSTER}"
+SVC_HOST="${SVC_NAME}.${DOCUMENTDB_NAMESPACE}.svc.cluster.local"
+# Try to extract credentials from the DocumentDB secret
+SECRET_NAME="${DOCUMENTDB_CLUSTER}-superuser"
+if kubectl get secret "$SECRET_NAME" -n "$DOCUMENTDB_NAMESPACE" &>/dev/null; then
+    DB_USER=$(kubectl get secret "$SECRET_NAME" -n "$DOCUMENTDB_NAMESPACE" -o jsonpath='{.data.username}' | base64 -d)
+    DB_PASS=$(kubectl get secret "$SECRET_NAME" -n "$DOCUMENTDB_NAMESPACE" -o jsonpath='{.data.password}' | base64 -d)
+else
+    echo "Could not find secret $SECRET_NAME in namespace $DOCUMENTDB_NAMESPACE."
+    echo "Please set MONGO_URI in $VALUES_FILE manually."
+    DB_USER="admin"
+    DB_PASS="CHANGEME"
+fi
+MONGO_URI="mongodb://${DB_USER}:${DB_PASS}@${SVC_HOST}:10260/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsAllowInvalidCertificates=true"
+echo "DocumentDB endpoint: ${SVC_HOST}:10260"
+
+# 4. Deploy LightRAG via Helm
+echo ""
+echo "--- Step 4: Deploy LightRAG ---"
+helm upgrade --install lightrag "$CHART_DIR" \
+    -n "$NAMESPACE" \
+    -f "$VALUES_FILE" \
+    --set "env.MONGO_URI=$MONGO_URI" \
+    --wait --timeout 5m
+echo "Waiting for LightRAG pod to be ready..."
+kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=lightrag -n "$NAMESPACE" --timeout=300s
+
+echo ""
+echo "=== Deployment complete ==="
+echo ""
+echo "Access LightRAG:"
+echo "  kubectl port-forward svc/lightrag -n $NAMESPACE 9621:9621"
+echo "  open http://localhost:9621"
+echo ""
+echo "Insert a document:"
+echo "  curl -X POST http://localhost:9621/documents/text \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"text\": \"Your text here\"}'"
+echo ""
+echo "Query:"
+echo "  curl -X POST http://localhost:9621/query \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"query\": \"Your question\", \"mode\": \"hybrid\"}'"

--- a/documentdb-playground/lightrag/scripts/deploy.sh
+++ b/documentdb-playground/lightrag/scripts/deploy.sh
@@ -37,8 +37,17 @@ RAW_CONN=$(kubectl get documentdb "$DOCUMENTDB_CLUSTER" -n "$DOCUMENTDB_NAMESPAC
 
 if [ -n "$RAW_CONN" ]; then
     # The connection string contains embedded kubectl commands for credentials.
-    # eval resolves them into a usable URI.
-    MONGO_URI=$(eval echo "$RAW_CONN")
+    # eval resolves them into a usable URI. The inner quoting prevents & from
+    # being interpreted as a shell background operator.
+    MONGO_URI=$(eval "echo \"$RAW_CONN\"")
+
+    # Replace ClusterIP with DNS name for cross-namespace resolution.
+    SVC_IP=$(kubectl get svc "documentdb-service-${DOCUMENTDB_CLUSTER}" -n "$DOCUMENTDB_NAMESPACE"         -o jsonpath='{.spec.clusterIP}' 2>/dev/null) || true
+    if [ -n "$SVC_IP" ]; then
+        SVC_DNS="documentdb-service-${DOCUMENTDB_CLUSTER}.${DOCUMENTDB_NAMESPACE}.svc.cluster.local"
+        MONGO_URI=$(echo "$MONGO_URI" | sed "s/$SVC_IP/$SVC_DNS/g")
+    fi
+
     echo "Connection string retrieved from DocumentDB status."
 else
     echo "Could not read status.connectionString from DocumentDB resource."

--- a/documentdb-playground/lightrag/scripts/deploy.sh
+++ b/documentdb-playground/lightrag/scripts/deploy.sh
@@ -3,13 +3,16 @@
 # Prerequisites: kubectl, helm, a running cluster with DocumentDB deployed.
 set -euo pipefail
 
+command -v kubectl >/dev/null || { echo "kubectl is required" >&2; exit 1; }
+command -v helm >/dev/null || { echo "helm is required" >&2; exit 1; }
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CHART_DIR="$SCRIPT_DIR/../helm/lightrag"
 VALUES_FILE="$SCRIPT_DIR/../helm/lightrag-values.yaml"
 OLLAMA_MANIFEST="$SCRIPT_DIR/../helm/ollama.yaml"
 NAMESPACE="${LIGHTRAG_NAMESPACE:-lightrag}"
-DOCUMENTDB_NAMESPACE="${DOCUMENTDB_NAMESPACE:-documentdb-demo}"
-DOCUMENTDB_CLUSTER="${DOCUMENTDB_CLUSTER:-my-cluster}"
+DOCUMENTDB_NAMESPACE="${DOCUMENTDB_NAMESPACE:-documentdb-test}"
+DOCUMENTDB_CLUSTER="${DOCUMENTDB_CLUSTER:-documentdb-cluster}"
 
 echo "=== LightRAG + DocumentDB Deployment ==="
 
@@ -17,8 +20,8 @@ echo "=== LightRAG + DocumentDB Deployment ==="
 echo ""
 echo "--- Step 1: Deploy Ollama ---"
 kubectl apply -f "$OLLAMA_MANIFEST"
-echo "Waiting for Ollama pod to be ready..."
-kubectl wait --for=condition=Ready pod -l app=ollama -n "$NAMESPACE" --timeout=120s
+echo "Waiting for Ollama pod to be ready (first pull of ollama image can take a few minutes)..."
+kubectl wait --for=condition=Ready pod -l app=ollama -n "$NAMESPACE" --timeout=300s
 
 # 2. Pull models
 echo ""
@@ -36,9 +39,10 @@ RAW_CONN=$(kubectl get documentdb "$DOCUMENTDB_CLUSTER" -n "$DOCUMENTDB_NAMESPAC
     -o jsonpath='{.status.connectionString}' 2>/dev/null) || true
 
 if [ -n "$RAW_CONN" ]; then
-    # The connection string contains embedded kubectl commands for credentials.
-    # eval resolves them into a usable URI. The inner quoting prevents & from
-    # being interpreted as a shell background operator.
+    # The connection string contains embedded $(kubectl get secret ...)
+    # substitutions placed there by the DocumentDB operator. We rely on `eval`
+    # to resolve them. This trusts the operator-supplied field; do not point
+    # this script at an untrusted DocumentDB resource.
     MONGO_URI=$(eval "echo \"$RAW_CONN\"")
 
     # Replace ClusterIP with DNS name for cross-namespace resolution.
@@ -47,6 +51,15 @@ if [ -n "$RAW_CONN" ]; then
         SVC_DNS="documentdb-service-${DOCUMENTDB_CLUSTER}.${DOCUMENTDB_NAMESPACE}.svc.cluster.local"
         MONGO_URI=$(echo "$MONGO_URI" | sed "s/$SVC_IP/$SVC_DNS/g")
     fi
+
+    # The DocumentDB connection string sets both directConnection=true and
+    # replicaSet=rs0. pymongo treats these as conflicting: with directConnection
+    # it does not perform replica-set discovery, but the gateway does not
+    # advertise the replica-set name, so the driver fails with
+    # "client is configured to connect to a replica set named 'rs0' but this
+    # node belongs to a set named 'None'". Strip replicaSet for direct gateway
+    # connections.
+    MONGO_URI=$(echo "$MONGO_URI" | sed -E 's/[?&]replicaSet=[^&]*//g')
 
     echo "Connection string retrieved from DocumentDB status."
 else


### PR DESCRIPTION
### Summary
Adds a self-contained playground under `documentdb-playground/lightrag/` that deploys [LightRAG](https://github.com/HKUDS/LightRAG) — a graph-based RAG engine — backed by DocumentDB as its MongoDB-compatible storage layer, with Ollama for in-cluster LLM and embedding inference.

### What's included
- **Sample DocumentDB instance** (`documentdb.yaml`) sized for the playground, pinned to operator images `0.110.0` (required for the `_id` lookup fix).
- **Local Helm chart** (`helm/lightrag/`) with an init container that no-ops three `mongo_impl.py` index-creation methods that DocumentDB doesn't support (`createIndex` with collation, `$listSearchIndexes`, Atlas `$vectorSearch`). LightRAG runs unmodified otherwise.
- **Ollama deployment** (`helm/ollama.yaml`) with a 10 GiB PVC for model persistence, sized for `qwen2.5:3b` + `nomic-embed-text` on a Standard_D4-class node.
- **`scripts/deploy.sh` / `scripts/cleanup.sh`** — pulls the DocumentDB connection string from `status.connectionString`, resolves embedded credential lookups, swaps ClusterIP for in-cluster DNS, strips the conflicting `replicaSet=rs0` parameter, and `helm upgrade --install`s the chart.
- **`README.md`** — architecture diagram, quick start, OpenAI swap, slow-CPU tuning section, compatibility-patches table, verification, and troubleshooting for the three failure modes I hit during validation (replica-set conflict, Ollama OOM, `LLM_TIMEOUT`).

### Verification
End-to-end deploy on AKS (2× Standard_D4, k8s 1.35, DocumentDB operator 0.2.0, images 0.110.0):
- DocumentDB cluster healthy
- `helm install lightrag` succeeds (revision 3)
- Document insertion → entity extraction → graph build → query verified working through the WebUI
- `helm lint` clean

### Storage choices
| Store      | Backend                | Notes                                                  |
| ---------- | ---------------------- | ------------------------------------------------------ |
| KV         | `MongoKVStorage`       | Documents, chunks, entities                            |
| Graph      | `MongoGraphStorage`    | Knowledge graph nodes and edges                        |
| Doc status | `MongoDocStatusStorage`| Per-document processing state                          |
| Vectors    | `NanoVectorDBStorage`  | Local file (PVC) — DocumentDB has no `$vectorSearch`   |

### Scope
- Adds files under `documentdb-playground/lightrag/` only.
- No changes to the operator, CRDs, Helm chart, or CI workflows.
- The `helm/lightrag` chart is intentionally local-only — playground sample, not a published product chart.

### Checklist
- [x] `helm lint` passes
- [x] `bash -n` clean on both scripts
- [x] No secrets / personal identifiers in tree
- [x] DCO sign-off on all commits
- [x] Verified end-to-end on AKS