### PR TITLE
fix: bump CloudNative-PG to chart 0.28.1 / app 1.29.1 (CVE-2026-44477)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ The DocumentDB Kubernetes Operator is a Kubernetes operator that manages Documen
 | Component | Version | Notes |
 |-----------|---------|-------|
 | Kubernetes | 1.30+ | Based on k8s.io/api v0.34.2 |
-| CloudNative-PG | 1.28.0 | Helm chart uses CNPG chart 0.27.0 |
+| CloudNative-PG | 1.29.1 | Helm chart uses CNPG chart 0.28.1 |
 | cert-manager | 1.19.2 | Required for TLS certificate management |
 | controller-runtime | 0.22.4 | Kubebuilder framework |
 | Go | 1.25.0 | See `operator/src/go.mod` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Security
+- **Bumped CloudNative-PG dependency from chart 0.27.0 (app 1.28.0) to 0.28.1 (app 1.29.1)** to pick up the fix for [CVE-2026-44477 / GHSA-423p-g724-fr39](https://github.com/cloudnative-pg/cloudnative-pg/security/advisories/GHSA-423p-g724-fr39): a privilege-escalation vulnerability in the CNPG metrics exporter that could allow a low-privilege PostgreSQL user to escalate to superuser and execute arbitrary commands in the database pod. Operators upgrading via `helm upgrade` will get the patched CNPG operator automatically.
+
 ### Major Features
 - **Gateway OTLP metrics in the per-pod sidecar**: when `spec.monitoring.enabled=true`, the OTel Collector sidecar now exposes an OTLP/gRPC receiver on `127.0.0.1:4317` and the documentdb-gateway is configured (via `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_METRICS_ENABLED`) to push its `db_client_*` metrics there. The sidecar's existing prometheus exporter re-exports them alongside the existing `documentdb.postgres.up` sqlquery output, with per-pod attribution added by the collector's resource processor. No new CRD fields; this turns on automatically wherever monitoring was already enabled.
 - **Two-Phase Extension Upgrade**: New `spec.schemaVersion` field separates binary upgrades (`spec.documentDBVersion`) from irreversible schema migrations (`ALTER EXTENSION UPDATE`). The default behavior gives you a rollback-safe window — update the binary first, validate, then finalize the schema. Set `schemaVersion: "auto"` for single-step upgrades in development environments. See the [upgrade guide](docs/operator-public-documentation/preview/operations/upgrades.md) for details.

--- a/operator/documentdb-helm-chart/Chart.yaml
+++ b/operator/documentdb-helm-chart/Chart.yaml
@@ -7,5 +7,5 @@ description: A Helm chart for deploying the DocumentDB operator
 appVersion: "0.2.0"
 dependencies:
   - name: cloudnative-pg
-    version: "0.27.0"
+    version: "0.28.1"
     repository: "https://cloudnative-pg.github.io/charts/"


### PR DESCRIPTION
## Summary
Bumps the bundled CloudNative-PG Helm dependency from chart **0.27.0** (CNPG **1.28.0**) to chart **0.28.1** (CNPG **1.29.1**) to pick up the security fix for [CVE-2026-44477 / GHSA-423p-g724-fr39](https://github.com/cloudnative-pg/cloudnative-pg/security/advisories/GHSA-423p-g724-fr39).

## CVE details
A privilege-escalation flaw in the CNPG metrics exporter: the exporter previously connected to PostgreSQL as the superuser and only demoted via `SET ROLE`, leaving session-level superuser powers available. A low-privilege database user could chain this to escalate to PostgreSQL superuser and execute arbitrary OS commands inside the database pod.

Fixed in CNPG 1.29.1 (and backport 1.28.3) by:
- Running the exporter as a dedicated `cnpg_metrics_exporter` role with only `pg_monitor` privileges
- Schema-qualifying catalog references in default monitoring queries
- Picking up upstream CVE fixes in `jackc/pgx` and the Go runtime

Since we ship CNPG as a Helm sub-chart, every user installing our operator currently inherits the vulnerable version, so this needs to ship in our next release.

## Changes
- `operator/documentdb-helm-chart/Chart.yaml`: `cloudnative-pg` dependency `0.27.0`  `0.28.1`
- `AGENTS.md`: update version compatibility matrix (CNPG `1.28.0`  `1.29.1`, chart `0.27.0`  `0.28.1`)
- `CHANGELOG.md`: `[Unreleased]`  `Security` entry

`Chart.lock` and `charts/*.tgz` are gitignored (regenerated by `helm dependency update`); verified locally that the lock resolves to `0.28.1`.

## Validation TODO before merge
- [ ] CI: `test-build-and-package`, `test-integration`, `test-E2E`, `test-backup-and-restore`
- [ ] Smoke-test `helm install` / `helm upgrade` against a Kind cluster to confirm CNPG CRDs and our pinned CRDs in `operator/documentdb-helm-chart/crds/` still reconcile
- [ ] Audit any custom monitoring queries we ship  the new `cnpg_metrics_exporter` role may need explicit GRANTs (per CNPG 1.29.1 release notes)

## References
- https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v1.29.1
- https://github.com/cloudnative-pg/cloudnative-pg/security/advisories/GHSA-423p-g724-fr39
- https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/Chart.yaml
