### PR TITLE
feat: allow using an existing Cloudnative PG operator

### DIFF
--- a/operator/documentdb-helm-chart/Chart.yaml
+++ b/operator/documentdb-helm-chart/Chart.yaml
@@ -9,3 +9,5 @@ dependencies:
   - name: cloudnative-pg
     version: "0.28.1"
     repository: "https://cloudnative-pg.github.io/charts/"
+    alias: cnpg
+    condition: cnpg.install

--- a/operator/documentdb-helm-chart/templates/01_namespace.yaml
+++ b/operator/documentdb-helm-chart/templates/01_namespace.yaml
@@ -1,7 +1,9 @@
+{{- if .Values.cnpg.install }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cnpg-system
+  name: {{ include "documentdb-chart.cnpgNamespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
     app.kubernetes.io/managed-by: "Helm"
+{{- end }}

--- a/operator/documentdb-helm-chart/templates/02_documentdb_sidecar_injector.yaml
+++ b/operator/documentdb-helm-chart/templates/02_documentdb_sidecar_injector.yaml
@@ -10,7 +10,7 @@ metadata:
     cnpg.io/pluginName: cnpg-i-sidecar-injector.documentdb.io
     app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
   name: sidecar-injector
-  namespace: cnpg-system
+  namespace: {{ include "documentdb-chart.cnpgNamespace" . }}
 spec:
   ports:
   - port: 9090
@@ -25,7 +25,7 @@ metadata:
   labels:
     app: sidecar-injector
   name: sidecar-injector
-  namespace: cnpg-system
+  namespace: {{ include "documentdb-chart.cnpgNamespace" . }}
 spec:
   replicas: 1
   selector:
@@ -74,7 +74,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: sidecarinjector-client
-  namespace: cnpg-system
+  namespace: {{ include "documentdb-chart.cnpgNamespace" . }}
 spec:
   commonName: sidecarinjector-client
   duration: 2160h
@@ -92,7 +92,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: sidecarinjector-server
-  namespace: cnpg-system
+  namespace: {{ include "documentdb-chart.cnpgNamespace" . }}
 spec:
   commonName: sidecar-injector
   dnsNames:
@@ -112,6 +112,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
-  namespace: cnpg-system
+  namespace: {{ include "documentdb-chart.cnpgNamespace" . }}
 spec:
   selfSigned: {}

--- a/operator/documentdb-helm-chart/templates/03_documentdb_wal_replica.yaml
+++ b/operator/documentdb-helm-chart/templates/03_documentdb_wal_replica.yaml
@@ -11,7 +11,7 @@ metadata:
     cnpg.io/pluginServerSecret: walreplica-server-tls
     cnpg.io/pluginPort: "9090"
   name: wal-replica
-  namespace: cnpg-system
+  namespace: {{ include "documentdb-chart.cnpgNamespace" . }}
 spec:
   ports:
   - port: 9090
@@ -26,7 +26,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: walreplica-client
-  namespace: cnpg-system
+  namespace: {{ include "documentdb-chart.cnpgNamespace" . }}
 spec:
   secretName: walreplica-client-tls
   commonName: "walreplica-client"
@@ -48,7 +48,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: walreplica-server
-  namespace: cnpg-system
+  namespace: {{ include "documentdb-chart.cnpgNamespace" . }}
 spec:
   secretName: walreplica-server-tls
   commonName: "wal-replica"
@@ -75,7 +75,7 @@ metadata:
   labels:
     app: wal-replica
   name: wal-replica
-  namespace: cnpg-system
+  namespace: {{ include "documentdb-chart.cnpgNamespace" . }}
 spec:
   replicas: 1
   selector:
@@ -90,7 +90,7 @@ spec:
     spec:
       serviceAccountName: wal-replica-manager
       containers:
-      - image: "{{ .Values.image.walreplica.repository }}:{{ .Values.image.walreplica.tag | default .Chart.AppVersion }}"  
+      - image: "{{ .Values.image.walreplica.repository }}:{{ .Values.image.walreplica.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.walreplica.pullPolicy }}"
         name: cnpg-i-wal-replica
         ports:
@@ -132,7 +132,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: wal-replica-manager
-  namespace: cnpg-system
+  namespace: {{ include "documentdb-chart.cnpgNamespace" . }}
 
 ---
 
@@ -171,7 +171,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: wal-replica-manager
-  namespace: cnpg-system
+  namespace: {{ include "documentdb-chart.cnpgNamespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
     app.kubernetes.io/managed-by: kustomize

--- a/operator/documentdb-helm-chart/templates/10_documentdb_webhook.yaml
+++ b/operator/documentdb-helm-chart/templates/10_documentdb_webhook.yaml
@@ -84,7 +84,7 @@ webhooks:
     # Fail-closed: reject requests when the webhook is unreachable.
     # Safe because readiness/startup probes keep the pod out of the
     # Service endpoints until the TLS cert is loaded (CNPG pattern).
-    failurePolicy: Fail
+    failurePolicy: {{ .Values.cnpg.webhookFailurePolicy | default "Fail" }}
     rules:
       - apiGroups:
           - documentdb.io

--- a/operator/documentdb-helm-chart/templates/_helpers.tpl
+++ b/operator/documentdb-helm-chart/templates/_helpers.tpl
@@ -1,3 +1,7 @@
 {{- define "documentdb-chart.name" -}}
 documentdb-operator
 {{- end -}}
+
+{{- define "documentdb-chart.cnpgNamespace" -}}
+{{- .Values.cnpg.namespaceOverride | default "cnpg-system" -}}
+{{- end -}}

--- a/operator/documentdb-helm-chart/values.yaml
+++ b/operator/documentdb-helm-chart/values.yaml
@@ -23,9 +23,9 @@ serviceAccount:
   automount: true
   annotations: {}
   name: "documentdb-operator"
-  
+
 # WAL Replica feature flag
-walReplica: false  # Set to true to deploy the WAL replica plugin
+walReplica: false # Set to true to deploy the WAL replica plugin
 
 image:
   documentdbk8soperator:
@@ -37,8 +37,10 @@ image:
   walreplica:
     repository: ghcr.io/documentdb/documentdb-kubernetes-operator/wal-replica
     pullPolicy: Always
-cloudnative-pg:
+cnpg:
+  install: true
   namespaceOverride: cnpg-system
+  webhookFailurePolicy: Fail
   additionalEnv:
     - name: ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES
       value: "true"


### PR DESCRIPTION
- flag for cnpg chart install
- use a template for cnpg namespace rather than hard-code
- various other potential failure ignores

No change to default behaviour