### PR TITLE
feat(helm): add pod security, resources, and scheduling knobs to chart

### DIFF
--- a/operator/documentdb-helm-chart/templates/02_documentdb_sidecar_injector.yaml
+++ b/operator/documentdb-helm-chart/templates/02_documentdb_sidecar_injector.yaml
@@ -31,13 +31,38 @@ spec:
   selector:
     matchLabels:
       app: sidecar-injector
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: sidecar-injector
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sidecarInjector.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.sidecarInjector.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sidecarInjector.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sidecarInjector.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sidecarInjector.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sidecarInjector.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args:
         - plugin
@@ -48,6 +73,10 @@ spec:
         image: "{{ .Values.image.sidecarinjector.repository }}:{{ .Values.image.sidecarinjector.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.sidecarinjector.pullPolicy }}"
         name: cnpg-i-sidecar-injector
+        {{- with .Values.sidecarInjector.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- if .Values.documentDbVersion }}
         - name: DOCUMENTDB_VERSION
@@ -56,7 +85,10 @@ spec:
         ports:
         - containerPort: 9090
           protocol: TCP
-        resources: {}
+        {{- with .Values.sidecarInjector.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /server
           name: server

--- a/operator/documentdb-helm-chart/templates/02_documentdb_sidecar_injector.yaml
+++ b/operator/documentdb-helm-chart/templates/02_documentdb_sidecar_injector.yaml
@@ -73,7 +73,7 @@ spec:
         image: "{{ .Values.image.sidecarinjector.repository }}:{{ .Values.image.sidecarinjector.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.sidecarinjector.pullPolicy }}"
         name: cnpg-i-sidecar-injector
-        {{- with .Values.sidecarInjector.securityContext }}
+        {{- with .Values.sidecarInjector.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/operator/documentdb-helm-chart/templates/03_documentdb_wal_replica.yaml
+++ b/operator/documentdb-helm-chart/templates/03_documentdb_wal_replica.yaml
@@ -81,18 +81,47 @@ spec:
   selector:
     matchLabels:
       app: wal-replica
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: wal-replica
     spec:
       serviceAccountName: wal-replica-manager
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.walReplicaPlugin.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.walReplicaPlugin.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.walReplicaPlugin.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.walReplicaPlugin.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.walReplicaPlugin.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.walReplicaPlugin.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: "{{ .Values.image.walreplica.repository }}:{{ .Values.image.walreplica.tag | default .Chart.AppVersion }}"  
         imagePullPolicy: "{{ .Values.image.walreplica.pullPolicy }}"
         name: cnpg-i-wal-replica
+        {{- with .Values.walReplicaPlugin.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 9090
           protocol: TCP
@@ -107,7 +136,10 @@ spec:
           name: server
         - mountPath: /client
           name: client
-        resources: {}
+        {{- with .Values.walReplicaPlugin.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: server
         secret:
@@ -123,7 +155,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: "Helm"
   name: wal-replica-manager-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -174,5 +206,5 @@ metadata:
   namespace: cnpg-system
   labels:
     app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: "Helm"
 {{- end }}

--- a/operator/documentdb-helm-chart/templates/03_documentdb_wal_replica.yaml
+++ b/operator/documentdb-helm-chart/templates/03_documentdb_wal_replica.yaml
@@ -118,7 +118,7 @@ spec:
       - image: "{{ .Values.image.walreplica.repository }}:{{ .Values.image.walreplica.tag | default .Chart.AppVersion }}"  
         imagePullPolicy: "{{ .Values.image.walreplica.pullPolicy }}"
         name: cnpg-i-wal-replica
-        {{- with .Values.walReplicaPlugin.securityContext }}
+        {{- with .Values.walReplicaPlugin.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/operator/documentdb-helm-chart/templates/09_documentdb_operator.yaml
+++ b/operator/documentdb-helm-chart/templates/09_documentdb_operator.yaml
@@ -18,10 +18,45 @@ spec:
         app: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: documentdb-operator
         image: "{{ .Values.image.documentdbk8soperator.repository }}:{{ .Values.image.documentdbk8soperator.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.documentdbk8soperator.pullPolicy }}"
+        {{- with .Values.operator.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.operator.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         args:
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
         ports:

--- a/operator/documentdb-helm-chart/templates/09_documentdb_operator.yaml
+++ b/operator/documentdb-helm-chart/templates/09_documentdb_operator.yaml
@@ -49,7 +49,7 @@ spec:
       - name: documentdb-operator
         image: "{{ .Values.image.documentdbk8soperator.repository }}:{{ .Values.image.documentdbk8soperator.tag | default .Chart.AppVersion }}"
         imagePullPolicy: "{{ .Values.image.documentdbk8soperator.pullPolicy }}"
-        {{- with .Values.operator.securityContext }}
+        {{- with .Values.operator.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/operator/documentdb-helm-chart/values.yaml
+++ b/operator/documentdb-helm-chart/values.yaml
@@ -27,16 +27,100 @@ serviceAccount:
 # WAL Replica feature flag
 walReplica: false  # Set to true to deploy the WAL replica plugin
 
+# Image pull secrets used by all operator components (operator, sidecar injector, wal-replica).
+# Each entry must be a Kubernetes Secret reference: [{ name: my-registry-secret }, ...]
+imagePullSecrets: []
+
 image:
   documentdbk8soperator:
     repository: ghcr.io/documentdb/documentdb-kubernetes-operator/operator
-    pullPolicy: Always
+    # Pinned image tags use IfNotPresent to avoid unnecessary registry pulls on pod restart.
+    pullPolicy: IfNotPresent
   sidecarinjector:
     repository: ghcr.io/documentdb/documentdb-kubernetes-operator/sidecar
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   walreplica:
     repository: ghcr.io/documentdb/documentdb-kubernetes-operator/wal-replica
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
+
+# Per-component pod-level configuration: resources, security contexts, and scheduling.
+# Defaults are conservative and aim to be compatible with Pod Security Admission's
+# `restricted` profile. Override any field per component as needed.
+operator:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  podSecurityContext:
+    runAsNonRoot: true
+    # The operator image (operator/src/Dockerfile) runs as the Alpine `manager`
+    # user, which is uid 100. We pin runAsUser explicitly so Kubernetes can
+    # verify the user is non-root without depending on the image's USER directive.
+    # If the operator Dockerfile is changed to use a different uid, update this
+    # value in lockstep with the appVersion bump.
+    runAsUser: 100
+    runAsGroup: 101
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  priorityClassName: ""
+
+sidecarInjector:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    runAsGroup: 10001
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  priorityClassName: ""
+
+walReplicaPlugin:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  podSecurityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  priorityClassName: ""
+
 cloudnative-pg:
   namespaceOverride: cnpg-system
   additionalEnv:

--- a/operator/documentdb-helm-chart/values.yaml
+++ b/operator/documentdb-helm-chart/values.yaml
@@ -112,6 +112,13 @@ walReplicaPlugin:
     seccompProfile:
       type: RuntimeDefault
   containerSecurityContext:
+    # Must match the USER directive in the wal-replica plugin image's
+    # Dockerfile. Pinned numerically (not by name) so kubelet's
+    # runAsNonRoot check can verify it without consulting /etc/passwd.
+    # Aligned with sidecarInjector (both are CNPG-I plugins); update in
+    # lockstep with the eventual wal-replica Dockerfile.
+    runAsUser: 10001
+    runAsGroup: 10001
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]

--- a/operator/documentdb-helm-chart/values.yaml
+++ b/operator/documentdb-helm-chart/values.yaml
@@ -47,13 +47,15 @@ image:
 # Defaults are conservative and aim to be compatible with Pod Security Admission's
 # `restricted` profile. Override any field per component as needed.
 operator:
+  # Requests-only by convention: scheduler reserves capacity for the
+  # operator, but no memory ceiling so a single operator can manage
+  # fleets of any size without OOMKill. Set limits explicitly if your
+  # environment requires Burstable→Guaranteed QoS or enforces
+  # LimitRange.
   resources:
     requests:
       cpu: 100m
       memory: 128Mi
-    limits:
-      cpu: 500m
-      memory: 512Mi
   podSecurityContext:
     runAsNonRoot: true
     seccompProfile:
@@ -76,13 +78,11 @@ operator:
   priorityClassName: ""
 
 sidecarInjector:
+  # See operator.resources comment — requests-only by convention.
   resources:
     requests:
       cpu: 50m
       memory: 64Mi
-    limits:
-      cpu: 200m
-      memory: 256Mi
   podSecurityContext:
     runAsNonRoot: true
     seccompProfile:
@@ -100,13 +100,11 @@ sidecarInjector:
   priorityClassName: ""
 
 walReplicaPlugin:
+  # See operator.resources comment — requests-only by convention.
   resources:
     requests:
       cpu: 50m
       memory: 64Mi
-    limits:
-      cpu: 200m
-      memory: 256Mi
   podSecurityContext:
     runAsNonRoot: true
     seccompProfile:

--- a/operator/documentdb-helm-chart/values.yaml
+++ b/operator/documentdb-helm-chart/values.yaml
@@ -29,6 +29,19 @@ walReplica: false  # Set to true to deploy the WAL replica plugin
 
 # Image pull secrets used by all operator components (operator, sidecar injector, wal-replica).
 # Each entry must be a Kubernetes Secret reference: [{ name: my-registry-secret }, ...]
+#
+# IMPORTANT: imagePullSecrets are namespace-scoped. This chart deploys pods into TWO
+# namespaces by default: the release namespace (operator) and `cnpg-system`
+# (sidecar-injector and, when enabled, wal-replica). If you use a private registry
+# you must create the same pull secret in BOTH namespaces (or in every namespace
+# referenced by your overrides). The chart does not create the secret for you;
+# create it out-of-band before `helm install`. Example:
+#   kubectl create secret docker-registry my-registry-secret \
+#     --docker-server=... --docker-username=... --docker-password=... \
+#     -n documentdb-operator
+#   kubectl create secret docker-registry my-registry-secret \
+#     --docker-server=... --docker-username=... --docker-password=... \
+#     -n cnpg-system
 imagePullSecrets: []
 
 image:

--- a/operator/documentdb-helm-chart/values.yaml
+++ b/operator/documentdb-helm-chart/values.yaml
@@ -56,6 +56,9 @@ operator:
       memory: 512Mi
   podSecurityContext:
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
     # The operator image (operator/src/Dockerfile) runs as the Alpine `manager`
     # user, which is uid 100. We pin runAsUser explicitly so Kubernetes can
     # verify the user is non-root without depending on the image's USER directive.
@@ -63,9 +66,6 @@ operator:
     # value in lockstep with the appVersion bump.
     runAsUser: 100
     runAsGroup: 101
-    seccompProfile:
-      type: RuntimeDefault
-  containerSecurityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
@@ -85,11 +85,11 @@ sidecarInjector:
       memory: 256Mi
   podSecurityContext:
     runAsNonRoot: true
-    runAsUser: 10001
-    runAsGroup: 10001
     seccompProfile:
       type: RuntimeDefault
   containerSecurityContext:
+    runAsUser: 10001
+    runAsGroup: 10001
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]

--- a/operator/documentdb-helm-chart/values.yaml
+++ b/operator/documentdb-helm-chart/values.yaml
@@ -65,7 +65,7 @@ operator:
     runAsGroup: 101
     seccompProfile:
       type: RuntimeDefault
-  securityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
@@ -89,7 +89,7 @@ sidecarInjector:
     runAsGroup: 10001
     seccompProfile:
       type: RuntimeDefault
-  securityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
@@ -111,7 +111,7 @@ walReplicaPlugin:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
-  securityContext:
+  containerSecurityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]


### PR DESCRIPTION
## Summary

Production-hardening pass on the operator Helm chart toward GA, addressing a subset of #381. All changes are **additive and non-breaking** for existing installs  no resource renames, no selector changes, no values-key renames. Those upgrade-breaking items (cluster-scoped name templating, label/selector standardization, walReplica restructuring) need a documented migration and are intentionally left for follow-up PRs.

## What this PR does

| Area | Change | Issue ref |
|---|---|---|
| Pod Security Admission | Add `podSecurityContext` (`runAsNonRoot`, `seccompProfile: RuntimeDefault`) and per-container `containerSecurityContext` (drop `ALL` caps, `allowPrivilegeEscalation: false`, pinned numeric `runAsUser`/`runAsGroup`) to all three deployments. Chart now passes PSA `restricted` out of the box. | M8 |
| Resources | Add CPU/memory `requests` (no `limits`  see commit `c6337d0`) on operator, sidecar-injector, wal-replica. Exposed via values for override. | C4 |
| Scheduling | Add `nodeSelector` / `tolerations` / `affinity` / `topologySpreadConstraints` / `priorityClassName` per component. | M5 |
| Private registries | Add top-level `imagePullSecrets`, plus documentation of the cross-namespace requirement. | M6 |
| Image pull | Default `image.*.pullPolicy: Always`  `IfNotPresent`. Pinned tags don't benefit from `Always`. | M7 |
| Cleanup | Remove Kustomize leftovers: `creationTimestamp: null`, `strategy: {}`, `resources: {}` from sidecar/wal-replica deployments. | M13 |
| Labels | Fix `app.kubernetes.io/managed-by: kustomize`  `Helm` in wal-replica RBAC. | M14 |

## Commits in this PR

| SHA | Subject |
|---|---|
| `ca5116e` | feat(helm): add pod security, resources, and scheduling knobs to chart |
| `306a9ec` | chore(helm): rename per-component `securityContext`  `containerSecurityContext` (matches CNPG operator chart, cert-manager, ingress-nginx, Bitnami common, prometheus-operator convention) |
| `04a5d35` | chore(helm): move `runAsUser`/`runAsGroup` from pod-level to container-level (identity belongs to the container that owns the image; pod-level keeps only policy fields  `runAsNonRoot`, `seccompProfile`) |
| `1c91137` | chore(helm): pin `walReplicaPlugin` `runAsUser`/`runAsGroup` to numeric UID `10001` so the chart declares the full identity contract for every component, even before the wal-replica image exists |
| `c6337d0` | chore(helm): drop CPU/memory `limits`, keep `requests` only (prevents operator OOMKill at scale; matches CNPG philosophy while still passing ResourceQuota admission) |
| `01ffd98` | docs(helm): document namespace-scoped pull-secret requirement (`imagePullSecrets` must be created in both `documentdb-operator` and `cnpg-system` namespaces  chart does not create the secret itself) |

> Note: SHAs above are pre-rebase. All commits are signed off with `Signed-off-by:` per DCO.

## A note on `runAsUser`

The operator's `runAsUser: 100` matches the Alpine `manager` uid in `operator/src/Dockerfile`. Sidecar's `runAsUser: 10001` matches its `USER 10001:10001` directive. The chart and the Dockerfiles are now coupled on these UIDs  if the Dockerfiles change, the chart values must change in lockstep with the `appVersion` bump. Long-term we should move both to distroless with the conventional UID `65532`  tracked in **#388 [GA blocker]**.

## What's explicitly NOT in this PR (and why)

- **C1  fullname helper + multi-install safety.** Renames cluster-scoped resources, which requires a migration plan (existing installs would orphan the old ClusterRole / ValidatingWebhookConfiguration).
- **C2  CRD upgrade story.** Needs a design decision (hooks vs separate CRD chart vs documented `kubectl apply`).
- **C3  selector/label standardization.** Selectors are immutable; can't be done in-place.
- **C5 / C6  RBAC audit + wal-replica TODO.** Needs a controller-code-aware review.
- **C7  CNPG version drift.** Already fixed by #376.
- **walReplica restructuring** (`walReplica: false`  `walReplica.enabled: false`). Values-key rename; needs a migration note.
- **`readOnlyRootFilesystem: true`** on the operator/plugin containers. Tracked in **#388** as a follow-up to the distroless base swap  it's essentially free on distroless (no shell/tools expect a writable rootfs) but risks CrashLoopBackOff on the current Alpine base.
- **Injected sidecar hardening** (gateway, otel-collector). Tracked in **#387 [GA blocker]**  needs a Go change in `cnpg-plugins/sidecar-injector/internal/lifecycle/lifecycle.go`.

Each of these is a reasonable standalone PR.

## Local verification

- `helm lint` clean.
- `helm template` + `kubectl apply --dry-run=client` succeeds with default values and with `walReplica=true`, also with `imagePullSecrets`, `nodeSelector`, and `tolerations` overrides.
- `helm upgrade --reset-values` on kind (chart revision 18) succeeds; operator and sidecar-injector pods roll out cleanly with the new security contexts.
- Live pod inspection confirms the final layout matches CNPG:
  - pod-level `securityContext`: `runAsNonRoot: true`, `seccompProfile: { type: RuntimeDefault }`
  - container-level `securityContext`: `runAsUser`, `runAsGroup`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`
  - container-level `resources`: `requests` only, no `limits`
- Validating webhook still reachable after upgrade (admission validation returns expected schema error on a malformed CR).
- `helm rollback` to previous revision succeeds (no broken upgrade state).

## Related

- Tracking issue: #381
- Follow-up GA blockers identified during this work: **#387** (injected sidecar PSA hardening), **#388** (distroless base + `readOnlyRootFilesystem`)
- Follow-up issue (BYO CNPG version compat): #380
- Recently merged (CNPG bump): #376
