### PR TITLE
feat(helm): apply CRDs on helm upgrade via pre-upgrade Job

### DIFF
--- a/operator/documentdb-helm-chart/templates/00_crd_upgrade.yaml
+++ b/operator/documentdb-helm-chart/templates/00_crd_upgrade.yaml
@@ -1,0 +1,169 @@
+{{/*
+CRD upgrade Job
+===============
+
+Helm 3 installs files from the chart's crds/ directory on the first
+install but never touches them on subsequent helm upgrade calls. That
+means schema bumps shipped in a new chart version don't reach the
+cluster, leading to "unknown field" errors on CRs and silent feature
+breakage.
+
+This template wires up a pre-install / pre-upgrade hook Job that runs
+`kubectl apply` against the CRDs embedded in the chart. On a fresh
+install, the Job runs after Helm's own crds/ processing and is a no-op.
+On every helm upgrade, the Job applies the new chart's CRD schemas.
+
+CRD removal on `helm uninstall` is intentionally NOT done here: removing
+CRDs cascades-deletes every DocumentDB / Backup / ScheduledBackup CR in
+the cluster, which is a data-loss footgun. Users wanting that behavior
+should `kubectl delete crd` explicitly.
+
+Set `crdUpgradeJob.enabled=false` to skip the Job (e.g., GitOps setups
+that manage CRDs separately via a sync wave).
+*/}}
+{{- if .Values.crdUpgradeJob.enabled -}}
+{{- $crdFiles := .Files.Glob "crds/*.yaml" -}}
+{{- if $crdFiles -}}
+{{- $ns := .Values.namespace | default .Release.Namespace -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: documentdb-crd-payload
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
+    app.kubernetes.io/component: crd-upgrade
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-15"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+data:
+{{- range $path, $bytes := $crdFiles }}
+  {{ base $path }}: |
+{{ $.Files.Get $path | indent 4 }}
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: documentdb-crd-upgrade
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
+    app.kubernetes.io/component: crd-upgrade
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-15"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: documentdb-crd-upgrade
+  labels:
+    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
+    app.kubernetes.io/component: crd-upgrade
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-15"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: documentdb-crd-upgrade
+  labels:
+    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
+    app.kubernetes.io/component: crd-upgrade
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-15"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+subjects:
+- kind: ServiceAccount
+  name: documentdb-crd-upgrade
+  namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: documentdb-crd-upgrade
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: documentdb-crd-upgrade
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
+    app.kubernetes.io/component: crd-upgrade
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.crdUpgradeJob.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.crdUpgradeJob.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
+        app.kubernetes.io/component: crd-upgrade
+    spec:
+      restartPolicy: Never
+      serviceAccountName: documentdb-crd-upgrade
+      {{- with .Values.crdUpgradeJob.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: kubectl
+        image: "{{ .Values.crdUpgradeJob.image.repository }}:{{ .Values.crdUpgradeJob.image.tag }}"
+        imagePullPolicy: {{ .Values.crdUpgradeJob.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          readOnlyRootFilesystem: true
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          set -eu
+          for f in /crds/*.yaml; do
+            echo "Applying $f"
+            kubectl apply --server-side --force-conflicts -f "$f"
+          done
+          echo "All CRDs applied."
+        volumeMounts:
+        - name: crds
+          mountPath: /crds
+        - name: tmp
+          mountPath: /tmp
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+      volumes:
+      - name: crds
+        configMap:
+          name: documentdb-crd-payload
+      - name: tmp
+        emptyDir: {}
+{{- end }}
+{{- end }}

--- a/operator/documentdb-helm-chart/values.yaml
+++ b/operator/documentdb-helm-chart/values.yaml
@@ -37,6 +37,22 @@ image:
   walreplica:
     repository: ghcr.io/documentdb/documentdb-kubernetes-operator/wal-replica
     pullPolicy: Always
+# Job that applies the chart's CRDs on every install/upgrade. See
+# templates/00_crd_upgrade.yaml for the rationale (Helm 3 does not upgrade
+# files in crds/ on `helm upgrade`).
+crdUpgradeJob:
+  enabled: true
+  image:
+    # Image must include both kubectl and a POSIX shell. alpine/k8s is a
+    # widely used, multi-arch image with both. Pin the tag to a version
+    # matching the cluster's control plane minor where possible.
+    repository: alpine/k8s
+    tag: "1.30.5"
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 120
+
 cloudnative-pg:
   namespaceOverride: cnpg-system
   additionalEnv:


### PR DESCRIPTION
## Summary

Adds a pre-install / pre-upgrade hook `Job` that applies the chart's CRDs against the cluster, so chart upgrades that bump CRD schemas don't silently leave the old schema in place.

## Why

Helm 3 installs files from a chart's `crds/` directory **only** on the first `helm install` and then refuses to touch them on subsequent `helm upgrade` calls (see [Helm docs: Limitations of CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations)). Today, bumping the chart with a schema change ships the new CRD in `crds/` but the live cluster keeps the old one  users hit silent `unknown field` errors on CRs and assume the operator is broken.

## What

- New template `templates/00_crd_upgrade.yaml` renders, as `pre-install` + `pre-upgrade` hooks (weight -15 / -10):
  - `ConfigMap` containing all CRDs from `crds/*.yaml` via `.Files.Glob`
  - `ServiceAccount` + `ClusterRole` + `ClusterRoleBinding` scoped to CRD `get/list/create/patch/update`
  - `Job` that loops over the CRDs and runs `kubectl apply --server-side --force-conflicts`
- All resources use `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded` so they clean themselves up.
- Gated by a new values block `crdUpgradeJob.{enabled,image,imagePullSecrets,backoffLimit,ttlSecondsAfterFinished}`, default `enabled: true`.
- The chart keeps the existing `crds/` directory so fresh installs still bootstrap CRDs the standard Helm way; the Job is then a no-op on first install and the upgrade fix on subsequent runs.

## Deliberately out of scope

- **CRD deletion on uninstall.** Removing a CRD cascades-deletes every `DocumentDB` / `Backup` / `ScheduledBackup` CR in the cluster  a data-loss footgun. Users who want that behavior should `kubectl delete crd` explicitly.

## Test

- `helm lint` 
- `helm template` renders 4 hook-annotated resources 
- Live `helm upgrade` on local kind:
  - Job ran, applied all 3 CRDs server-side 
  - `kubectl get crd dbs.documentdb.io -o jsonpath='{.metadata.managedFields[*].manager}'` reports `helm kubectl kube-apiserver`  the new `kubectl` manager confirms the Job patched the CRD 
  - Hook resources cleaned up via `hook-succeeded` delete policy 

## Notes for reviewers

- Image: `alpine/k8s:1.30.5` (multi-arch, has shell + kubectl). Override via `crdUpgradeJob.image` if you mirror images internally.
- Pin the tag to your control-plane minor where possible.

Refs #381
