### PR TITLE
fix(helm): standardize labels and selectors with app.kubernetes.io/* (#381 C3)

### DIFF
--- a/operator/documentdb-helm-chart/templates/01_namespace.yaml
+++ b/operator/documentdb-helm-chart/templates/01_namespace.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   name: cnpg-system
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/name: {{ include "documentdb-operator.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/operator/documentdb-helm-chart/templates/02_documentdb_sidecar_injector.yaml
+++ b/operator/documentdb-helm-chart/templates/02_documentdb_sidecar_injector.yaml
@@ -6,9 +6,10 @@ metadata:
     cnpg.io/pluginPort: "9090"
     cnpg.io/pluginServerSecret: sidecarinjector-server-tls
   labels:
-    app: sidecar-injector
     cnpg.io/pluginName: cnpg-i-sidecar-injector.documentdb.io
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "sidecar-injector") | nindent 4 }}
+  # Name hardcoded: CNPG-I plugin Services in cnpg-system are shared infrastructure
+  # discovered by name; templating the name would require coordinated config in CNPG.
   name: sidecar-injector
   namespace: cnpg-system
 spec:
@@ -17,26 +18,24 @@ spec:
     protocol: TCP
     targetPort: 9090
   selector:
-    app: sidecar-injector
+    {{- include "documentdb-operator.selectorLabels" (dict "root" $ "component" "sidecar-injector") | nindent 4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: sidecar-injector
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "sidecar-injector") | nindent 4 }}
   name: sidecar-injector
   namespace: cnpg-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: sidecar-injector
-  strategy: {}
+      {{- include "documentdb-operator.selectorLabels" (dict "root" $ "component" "sidecar-injector") | nindent 6 }}
   template:
     metadata:
-      creationTimestamp: null
       labels:
-        app: sidecar-injector
+        {{- include "documentdb-operator.selectorLabels" (dict "root" $ "component" "sidecar-injector") | nindent 8 }}
     spec:
       containers:
       - args:

--- a/operator/documentdb-helm-chart/templates/03_documentdb_wal_replica.yaml
+++ b/operator/documentdb-helm-chart/templates/03_documentdb_wal_replica.yaml
@@ -3,13 +3,14 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: wal-replica
     cnpg.io/pluginName: cnpg-i-wal-replica.documentdb.io
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "wal-replica") | nindent 4 }}
   annotations:
     cnpg.io/pluginClientSecret: walreplica-client-tls
     cnpg.io/pluginServerSecret: walreplica-server-tls
     cnpg.io/pluginPort: "9090"
+  # Name hardcoded: CNPG-I plugin Services in cnpg-system are shared infrastructure
+  # discovered by name; templating the name would require coordinated config in CNPG.
   name: wal-replica
   namespace: cnpg-system
 spec:
@@ -18,7 +19,7 @@ spec:
     protocol: TCP
     targetPort: 9090
   selector:
-    app: wal-replica
+    {{- include "documentdb-operator.selectorLabels" (dict "root" $ "component" "wal-replica") | nindent 4 }}
 
 ---
 
@@ -73,20 +74,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: wal-replica
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "wal-replica") | nindent 4 }}
   name: wal-replica
   namespace: cnpg-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: wal-replica
-  strategy: {}
+      {{- include "documentdb-operator.selectorLabels" (dict "root" $ "component" "wal-replica") | nindent 6 }}
   template:
     metadata:
-      creationTimestamp: null
       labels:
-        app: wal-replica
+        {{- include "documentdb-operator.selectorLabels" (dict "root" $ "component" "wal-replica") | nindent 8 }}
     spec:
       serviceAccountName: wal-replica-manager
       containers:
@@ -122,8 +121,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: kustomize
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "wal-replica") | nindent 4 }}
   name: wal-replica-manager-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -141,7 +139,7 @@ kind: ClusterRole
 metadata:
   name: wal-replica-manager
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "wal-replica") | nindent 4 }}
 rules: # TODO trim this down to what's actually needed
 - apiGroups: ["apps"]
   resources: ["deployments"]
@@ -173,6 +171,5 @@ metadata:
   name: wal-replica-manager
   namespace: cnpg-system
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: kustomize
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "wal-replica") | nindent 4 }}
 {{- end }}

--- a/operator/documentdb-helm-chart/templates/04_serviceaccount.yaml
+++ b/operator/documentdb-helm-chart/templates/04_serviceaccount.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  name: {{ include "documentdb-operator.serviceAccountName" . }}
+  namespace: {{ include "documentdb-operator.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: "Helm"
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "operator") | nindent 4 }}

--- a/operator/documentdb-helm-chart/templates/05_clusterrole.yaml
+++ b/operator/documentdb-helm-chart/templates/05_clusterrole.yaml
@@ -3,8 +3,7 @@ kind: ClusterRole
 metadata:
   name: documentdb-operator-cluster-role
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: "Helm"
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "operator") | nindent 4 }}
 rules:
 - apiGroups: ["documentdb.io"] # documentdb.io permissions
   resources: ["dbs", "dbs/status", "dbs/finalizers"]

--- a/operator/documentdb-helm-chart/templates/07_clusterrolebinding.yaml
+++ b/operator/documentdb-helm-chart/templates/07_clusterrolebinding.yaml
@@ -3,12 +3,11 @@ kind: ClusterRoleBinding
 metadata:
   name: documentdb-operator-cluster-rolebinding
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: "Helm"
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "operator") | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name }}
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  name: {{ include "documentdb-operator.serviceAccountName" . }}
+  namespace: {{ include "documentdb-operator.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/operator/documentdb-helm-chart/templates/09_documentdb_operator.yaml
+++ b/operator/documentdb-helm-chart/templates/09_documentdb_operator.yaml
@@ -2,22 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: documentdb-operator
-  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  namespace: {{ include "documentdb-operator.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: "Helm"
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "operator") | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}
+      {{- include "documentdb-operator.selectorLabels" (dict "root" $ "component" "operator") | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}
+        {{- include "documentdb-operator.selectorLabels" (dict "root" $ "component" "operator") | nindent 8 }}
     spec:
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "documentdb-operator.serviceAccountName" . }}
       containers:
       - name: documentdb-operator
         image: "{{ .Values.image.documentdbk8soperator.repository }}:{{ .Values.image.documentdbk8soperator.tag | default .Chart.AppVersion }}"

--- a/operator/documentdb-helm-chart/templates/10_documentdb_webhook.yaml
+++ b/operator/documentdb-helm-chart/templates/10_documentdb_webhook.yaml
@@ -1,4 +1,4 @@
-{{- $ns := .Values.namespace | default .Release.Namespace -}}
+{{- $ns := include "documentdb-operator.namespace" . -}}
 # Self-signed Issuer for webhook TLS certificates in the operator namespace.
 # The sidecar injector uses a separate Issuer in cnpg-system; this one is for the operator.
 apiVersion: cert-manager.io/v1
@@ -7,8 +7,7 @@ metadata:
   name: documentdb-operator-selfsigned-issuer
   namespace: {{ $ns }}
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: "Helm"
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "operator") | nindent 4 }}
 spec:
   selfSigned: {}
 ---
@@ -19,8 +18,7 @@ metadata:
   name: documentdb-webhook-cert
   namespace: {{ $ns }}
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: "Helm"
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "operator") | nindent 4 }}
 spec:
   commonName: documentdb-webhook
   dnsNames:
@@ -38,38 +36,36 @@ spec:
     - server auth
 ---
 # Service fronting the operator's webhook server on port 9443.
-# NOTE: The service name is hardcoded because the operator currently assumes
-# a single installation per cluster. If multi-instance support is needed,
-# template the name using a fullname helper and update the
-# ValidatingWebhookConfiguration's clientConfig.service.name to match.
+# NOTE: The service name is hardcoded because the operator's ValidatingWebhookConfiguration
+# (also hardcoded below) registers this exact service name in clientConfig. CNPG uses the
+# same convention (`cnpg-webhook-service`) for the same reason. This means the chart is
+# effectively single-install-per-cluster — a second release in the same cluster would
+# overwrite the Service and the ValidatingWebhookConfiguration. Templating these requires
+# a coordinated change to make the operator binary read its webhook name from config.
 apiVersion: v1
 kind: Service
 metadata:
   name: documentdb-webhook-service
   namespace: {{ $ns }}
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: "Helm"
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "operator") | nindent 4 }}
 spec:
   ports:
     - port: 443
       protocol: TCP
       targetPort: 9443
   selector:
-    app: {{ .Release.Name }}
+    {{- include "documentdb-operator.selectorLabels" (dict "root" $ "component" "operator") | nindent 4 }}
 ---
 # ValidatingWebhookConfiguration for DocumentDB resources.
 # cert-manager injects the CA bundle automatically via the annotation.
-# NOTE: This is a cluster-scoped resource with a hardcoded name. Multiple
-# Helm releases would overwrite each other. If multi-instance support is
-# needed, template the name and the clientConfig.service references.
+# NOTE: Cluster-scoped resource with a hardcoded name — see Service comment above.
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: documentdb-validating-webhook
   labels:
-    app.kubernetes.io/name: {{ include "documentdb-chart.name" . }}
-    app.kubernetes.io/managed-by: "Helm"
+    {{- include "documentdb-operator.labels" (dict "root" $ "component" "operator") | nindent 4 }}
   annotations:
     cert-manager.io/inject-ca-from: {{ $ns }}/documentdb-webhook-cert
 webhooks:

--- a/operator/documentdb-helm-chart/templates/_helpers.tpl
+++ b/operator/documentdb-helm-chart/templates/_helpers.tpl
@@ -1,3 +1,63 @@
-{{- define "documentdb-chart.name" -}}
-documentdb-operator
+{{/*
+Chart name (overridable via .Values.nameOverride). Used as
+app.kubernetes.io/name across the chart.
+*/}}
+{{- define "documentdb-operator.name" -}}
+{{- default "documentdb-operator" .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Chart label value (name + version, sanitized).
+*/}}
+{{- define "documentdb-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Operator-namespace resolution: honor the chart's legacy .Values.namespace
+override and fall back to .Release.Namespace.
+*/}}
+{{- define "documentdb-operator.namespace" -}}
+{{- default .Release.Namespace .Values.namespace -}}
+{{- end -}}
+
+{{/*
+Common labels applied to every resource. Wraps selectorLabels so the two
+stay in sync.
+
+Usage:
+  {{- include "documentdb-operator.labels" (dict "root" $ "component" "operator") | nindent 4 }}
+*/}}
+{{- define "documentdb-operator.labels" -}}
+helm.sh/chart: {{ include "documentdb-operator.chart" .root }}
+{{ include "documentdb-operator.selectorLabels" . }}
+{{- if .root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels. Includes app.kubernetes.io/component so each Deployment in
+this chart (operator, sidecar-injector, wal-replica) gets a distinct,
+immutable selector. Previously the operator Deployment used
+`app: {{ .Release.Name }}`, which coupled the immutable selector to the
+release name.
+
+Usage:
+  {{- include "documentdb-operator.selectorLabels" (dict "root" $ "component" "operator") | nindent 6 }}
+*/}}
+{{- define "documentdb-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "documentdb-operator.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/*
+Service account name. Defaults to the stable name `documentdb-operator`.
+Override via .Values.serviceAccount.name if you need a fixed external name
+(e.g., an existing workload-identity binding).
+*/}}
+{{- define "documentdb-operator.serviceAccountName" -}}
+{{- default "documentdb-operator" .Values.serviceAccount.name -}}
 {{- end -}}

--- a/operator/documentdb-helm-chart/values.yaml
+++ b/operator/documentdb-helm-chart/values.yaml
@@ -22,7 +22,9 @@ serviceAccount:
   create: true
   automount: true
   annotations: {}
-  name: "documentdb-operator"
+  # Service account name. Defaults to `documentdb-operator`. Override only
+  # if you need a fixed external name (e.g., AKS workload-identity binding).
+  name: ""
   
 # WAL Replica feature flag
 walReplica: false  # Set to true to deploy the WAL replica plugin


### PR DESCRIPTION
## Summary

The chart''s three Deployments (operator, sidecar-injector, wal-replica) use ad-hoc selectors and don''t emit the standard `app.kubernetes.io/*` labels on pods. This PR fixes both with a new `_helpers.tpl` that follows the CNPG convention.

## Why this matters

The operator Deployment''s previous selector was:

```yaml
selector:
  matchLabels:
    app: {{ .Release.Name }}
```

Two bugs flowed from this:

1. **Renaming a release breaks `helm upgrade`**  `Deployment.spec.selector.matchLabels` is immutable; renaming a release changes the selector value; upgrade fails with `field is immutable`.
2. **Label-based pod lookup doesn''t work.** The chart never emitted `app.kubernetes.io/name`, `instance`, or `component` on pods, so `kubectl get pod -l app.kubernetes.io/...`, Lens, k9s, Prometheus relabel rules, and ArgoCD/Flux ownership matchers all fail to identify the operator''s pods.

The two cnpg-system plugins had the same gap (`app: sidecar-injector` / `app: wal-replica`).

## What changes

- New `templates/_helpers.tpl` defining `name`, `chart`, `namespace`, `labels`, `selectorLabels`, `serviceAccountName`. `selectorLabels` takes a `component` argument so each Deployment gets a distinct, immutable selector.
- All three Deployments and their fronting Services switched to the new helpers.
- All resources now carry the full `app.kubernetes.io/{name,instance,component,version,managed-by}` + `helm.sh/chart` set.
- Cleanups along the way (no behavior change):
  - Removed `creationTimestamp: null` / `strategy: {}` artifacts left from kustomize.
  - Replaced `app.kubernetes.io/managed-by: kustomize` / `"Helm"` literals with `.Release.Service`.

## What does NOT change

**Resource names are intentionally unchanged.** An earlier draft of this PR also templatized the ClusterRole / ClusterRoleBinding / ServiceAccount names with the CNPG-style `<release>-` prefix to enable multiple installs in one cluster. On review we dropped that: the operator is a **cluster-singleton** by design  its CRDs and `ValidatingWebhookConfiguration` are cluster-scoped, and CNPG itself accepts the same single-install limitation (they hardcode `cnpg-validating-webhook-configuration` / `cnpg-webhook-service`). Templating the cluster-scoped RBAC names would have:

- forced every existing install through an uninstall/reinstall migration
- not actually enabled multi-install (CRDs and webhook still collide)

So we keep stable names. The RBAC layer is upgrade-clean across this change.

##  Breaking change for existing installs (smaller scope than the previous draft)

Selectors are immutable, so `helm upgrade` from current `main` will fail with `field is immutable` on each of the three Deployments. The fix is to **delete only the Deployments**, then `helm upgrade`. RBAC, ServiceAccount, webhook Service, and ValidatingWebhookConfiguration are unaffected.

```bash
kubectl -n documentdb-operator delete deploy documentdb-operator
kubectl -n cnpg-system delete deploy sidecar-injector wal-replica   # if walReplica=true
helm upgrade documentdb-operator <chart> -n documentdb-operator
```

This is acceptable pre-GA (chart is in preview). User-managed `DocumentDB` CRs and the underlying CNPG `Cluster`s are unaffected (different controller scope).

## Local verification

- `helm lint` clean.
- `helm template` (default and `--set walReplica=true`) renders the **same resource names as on `main`** (zero rename); every Deployment selector resolves to:
  ```yaml
  app.kubernetes.io/name: documentdb-operator
  app.kubernetes.io/instance: <release>
  app.kubernetes.io/component: <operator|sidecar-injector|wal-replica>
  ```
- Fresh `helm install` on kind: operator, sidecar-injector, and CNPG operator pods reach Ready in <30s.
- Validating webhook still reachable: a `DocumentDB` CR with `spec.nodeCount: -1` is rejected with the expected schema validation error.
- `kubectl get pod -l app.kubernetes.io/component=operator` and `=sidecar-injector` resolve to the expected pods (confirms labels reach pod templates).

## Related

- Tracks **#381 C3** (selector standardization)
- **Not included** (and intentionally so): #381 C1 (templatizing cluster-scoped RBAC names). See discussion above for why.
