### PR TITLE
feat: add io_uring micro-benchmark playground

### DIFF
--- a/documentdb-playground/io-uring-benchmark/Dockerfile
+++ b/documentdb-playground/io-uring-benchmark/Dockerfile
@@ -1,0 +1,26 @@
+# Optional pre-baked image for the benchmark runner, so you don't clone + pip install
+# at pod startup on every run.
+#
+#   docker build -t <registry>/iouring-bench-runner:latest \
+#     --build-arg MICRO_BENCH_REF=main .
+#   docker push <registry>/iouring-bench-runner:latest
+#
+# Then set `image:` in manifests/benchmark-runner.yaml to your pushed image and replace
+# the bootstrap `args:` with: ["-c", "touch /tmp/ready && sleep infinity"].
+FROM python:3.12-slim
+
+ARG MICRO_BENCH_REPO=https://github.com/documentdb/micro-benchmarks.git
+ARG MICRO_BENCH_REF=main
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates build-essential procps \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN git clone "${MICRO_BENCH_REPO}" /opt/micro-benchmarks \
+ && cd /opt/micro-benchmarks \
+ && git checkout "${MICRO_BENCH_REF}" \
+ && pip install --no-cache-dir -r requirements.txt
+
+WORKDIR /opt/micro-benchmarks
+RUN mkdir -p /results
+CMD ["/bin/bash", "-c", "touch /tmp/ready && sleep infinity"]

--- a/documentdb-playground/io-uring-benchmark/README.md
+++ b/documentdb-playground/io-uring-benchmark/README.md
@@ -1,0 +1,215 @@
+# io_uring Micro-Benchmark Playground
+
+Measure the effect of PostgreSQL 18's asynchronous I/O backends — **`io_method = io_uring`**
+vs **`worker`** vs **`sync`** — on a DocumentDB cluster, using the
+[`documentdb/micro-benchmarks`](https://github.com/documentdb/micro-benchmarks) Locust
+read-query suite.
+
+DocumentDB runs on PostgreSQL 18 (via CloudNative-PG). PG18 introduced a pluggable
+asynchronous I/O subsystem; on Linux it can drive reads through **io_uring**, which
+batches and overlaps storage I/O to cut latency on scan-heavy read paths (sequential /
+bitmap heap scans, `VACUUM`, index builds). This playground turns that knob on a real
+DocumentDB cluster and quantifies it.
+
+---
+
+## TL;DR — proven feasibility
+
+A feasibility spike on a local kind cluster (kernel 6.12, `io_uring_disabled=0`) established:
+
+| Finding | Evidence |
+|---|---|
+| PG18 (`18-minimal-trixie`) ships io_uring support | `initdb` bootstrap postgres attempts `io_uring queue` setup |
+| The **only** blocker is container seccomp | With `RuntimeDefault`: `FATAL: could not setup io_uring queue: Operation not permitted` |
+| Relaxing seccomp turns it on | With `Unconfined`: PG18.3 starts, `SHOW io_method` → `io_uring`, `pg_stat_io` reads flow |
+| Enable path = operator PR #307 | `spec.postgres.parameters.io_method` is passed through to the CNPG Cluster |
+
+So two ingredients are required, and this playground ships both:
+
+1. **`io_method` passthrough** — `spec.postgres.parameters` on the DocumentDB CR (operator PR #307).
+2. **Relaxed seccomp** — the DocumentDB CR has no seccomp field and CNPG sets the postgres
+   container to `RuntimeDefault`, so we relax it with a **Kyverno mutate policy** (Unconfined
+   quick-start, or a hardened Localhost profile installed on the nodes).
+
+> **Where to run for headline numbers:** a managed cloud cluster (AKS/EKS) with a fast
+> NVMe / premium-SSD StorageClass. io_uring helps **real** storage I/O — on a laptop kind
+> cluster the storage layer is not representative, so treat local runs as smoke tests only.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart LR
+  subgraph cluster["Kubernetes cluster (AKS / EKS)"]
+    KV[Kyverno] -. mutate seccomp .-> PG
+    subgraph ns["namespace: iouring-bench"]
+      RUN[bench-runner pod<br/>Locust + micro-benchmarks] -->|MongoDB wire :10260| GW[(DocumentDB Gateway)]
+      GW --> PG["PostgreSQL 18<br/>io_method = sync|worker|io_uring"]
+      PG --> PVC[(fast SSD PVC)]
+    end
+  end
+  OP[DocumentDB operator] -->|spec.postgres.parameters| PG
+```
+
+The runner drives the gateway over the MongoDB wire protocol; the operator sets
+`io_method` from the CR; Kyverno relaxes seccomp so the io_uring variant can start.
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| Kubernetes 1.35+ | DocumentDB operator requires ImageVolume GA |
+| Node kernel ≥ 5.1, `io_uring_disabled=0` | Verified by `00-prereqs.sh`; modern AKS/EKS node images qualify |
+| Fast StorageClass | NVMe / premium SSD (AKS `managed-csi-premium`, EKS `gp3`/`io2`) for headline numbers |
+| DocumentDB operator **with `spec.postgres.parameters`** | i.e. a build that includes operator PR #307 |
+| `kubectl`, `helm`, `jq`, `python3` | Local CLIs |
+
+Bring your own cluster, or create one with the sibling playgrounds
+[`aks-setup/`](../aks-setup) or [`aws-setup/`](../aws-setup).
+
+---
+
+## Quick start
+
+```bash
+cd documentdb-playground/io-uring-benchmark
+
+# 0. Verify tooling + that nodes can run io_uring
+./scripts/00-prereqs.sh
+
+# 1. Install cert-manager + the DocumentDB operator (needs the PR #307 build)
+./scripts/10-deploy-operator.sh
+#    custom image:  OPERATOR_REPO=<repo> OPERATOR_TAG=<tag> ./scripts/10-deploy-operator.sh
+
+# 2. Relax seccomp for io_uring (Kyverno).  unconfined (default) or localhost
+./scripts/20-deploy-seccomp.sh
+#    hardened:  SECCOMP_MODE=localhost ./scripts/20-deploy-seccomp.sh
+
+# 3. Deploy the DocumentDB cluster (validates io_uring) + the benchmark runner
+STORAGE_CLASS=managed-csi-premium ./scripts/30-deploy-documentdb.sh
+
+# 4. Load the dataset once (size it to exceed RAM!)
+DOCUMENT_COUNT=10000000 ./scripts/40-load-data.sh
+
+# 5. Run the io_method x workload x selectivity x repeat matrix
+./scripts/50-run-matrix.sh
+
+# 6. Pull CSVs out and print the speedup table
+./scripts/60-collect.sh
+
+# 7. Tear down
+./scripts/99-teardown.sh            # namespace only
+./scripts/99-teardown.sh --operator # also remove Kyverno + operator
+```
+
+All knobs are environment variables with defaults in [`scripts/lib.sh`](scripts/lib.sh):
+`DOCUMENT_COUNT`, `IO_METHODS`, `WORKLOADS`, `SELECTIVITIES`, `REPEATS`, `RUN_TIME`,
+`QUERY_USERS`, `IO_WORKERS`, `SECCOMP_MODE`, `STORAGE_CLASS`.
+
+---
+
+## Methodology — making I/O observable
+
+io_uring only helps when reads actually hit **storage**. To get a meaningful signal:
+
+- **Dataset > RAM.** Size `DOCUMENT_COUNT` so the collection comfortably exceeds the pod
+  memory limit (`spec.resource.memory`, default `4Gi`) and the OS page cache, forcing reads
+  to disk. The default `10,000,000` docs is a starting point — scale it up for larger nodes.
+- **One independent variable.** Only `io_method` changes between runs. Image, CPU/memory,
+  StorageClass, dataset, and queries are held constant. `50-run-matrix.sh` switches
+  `io_method` in place (rolling restart, same PVC/data) so nothing else moves.
+- **Repeat and take the median.** `REPEATS` runs per cell; `analyze.py` reports the median
+  and the throughput speedup vs the `sync` baseline.
+- **Emphasize read-I/O-bound workloads.** `range_scalar` / `range_arr` (large bounded scans)
+  and low-selectivity points (large result sets) exercise the heap-read paths io_uring
+  accelerates. `index_build` (see below) is another strong signal.
+- **Corroborate with the engine.** Each cell snapshots PG18 `pg_stat_io`
+  (`*_pg_stat_io.csv`) with `track_io_timing=on`, so you can confirm reads/`read_time`
+  actually moved, not just client-side latency.
+
+For strict **cold-cache** numbers, restart the instance (or drop caches on the node)
+between cells; the default relies on the dataset exceeding RAM so most reads miss cache.
+
+### Index-build benchmark (optional)
+
+`index_build.py` measures index creation time directly:
+
+```bash
+POD=$(kubectl get pod -n iouring-bench -l app=bench-runner -o name | head -1)
+kubectl exec -n iouring-bench "$POD" -- bash -lc '
+  cd /opt/micro-benchmarks
+  URI="mongodb://$MONGO_USERNAME:$MONGO_PASSWORD@$GATEWAY_HOST:$GATEWAY_PORT/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true"
+  bash test/run_locust.sh --locustfile workloads/read_queries/index_build.py \
+    --uri "$URI" --users 1 --run-time 9999s --document-count 10000000 --index-fields=scalar_sel100'
+```
+
+Run it once per `io_method` (switch with a `kubectl patch` like `50-run-matrix.sh` does).
+
+---
+
+## Reading the results
+
+`60-collect.sh` copies raw CSVs to `results/raw/` and writes `results/summary.csv` +
+`results/summary.txt`. The summary has one row per (workload, selectivity) with each
+method's throughput (`rps`) and tail latency (`p95ms`, `p99ms`), plus the speedup of
+`worker` and `io_uring` relative to `sync`:
+
+```
+workload      selectivity  sync_rps  worker_rps  io_uring_rps  speedup_io_uring_vs_sync
+range_scalar  100          102.0     130.0       159.0         1.56x
+point_scalar  5k           50.0      —           75.0          1.50x
+```
+
+A `speedup_io_uring_vs_sync > 1.0` on the scan-heavy cells is the headline result.
+Cross-check against `*_pg_stat_io.csv` to confirm the gain came from faster reads.
+
+---
+
+## File reference
+
+| Path | Purpose |
+|---|---|
+| `manifests/documentdb-{sync,worker,io_uring}.yaml` | DocumentDB CR variants — differ only in `spec.postgres.parameters.io_method` |
+| `manifests/credentials.yaml` | Gateway credentials Secret (replace the password) |
+| `manifests/benchmark-runner.yaml` | Long-lived runner pod (clones micro-benchmarks, installs deps) |
+| `policy/kyverno-seccomp-unconfined.yaml` | Kyverno mutate → `Unconfined` on CNPG postgres pods (quick start) |
+| `policy/kyverno-seccomp-localhost.yaml` | Kyverno mutate → `Localhost profiles/postgres.json` (hardened) |
+| `seccomp/io_uring-seccompprofile.json` | Curated profile (CNPG default + io_uring syscalls), from CNPG PR #10446 |
+| `seccomp/deploy-seccomp-daemonset.yaml` + `kustomization.yaml` | Installs that profile on every node (`kubectl apply -k seccomp/`) |
+| `scripts/00..99-*.sh`, `scripts/lib.sh` | The run pipeline (prereqs → operator → seccomp → deploy → load → run → collect → teardown) |
+| `analyze.py` | Builds the median + speedup summary table from Locust CSVs |
+| `Dockerfile` | Optional pre-baked runner image |
+
+---
+
+## Why seccomp blocks io_uring (the gory detail)
+
+Modern container runtimes (containerd ≥ ~1.7) **removed** `io_uring_setup`, `io_uring_enter`,
+and `io_uring_register` from their default seccomp profile because io_uring has been a
+recurring kernel-exploit surface. So a container running with `seccompProfile: RuntimeDefault`
+— which is exactly what CloudNative-PG sets on the postgres container — gets `EPERM` the
+moment PostgreSQL tries to create its io_uring queue, and crash-loops:
+
+```
+FATAL:  could not setup io_uring queue: Operation not permitted
+HINT:   Check if io_uring is disabled via /proc/sys/kernel/io_uring_disabled.
+```
+
+The fix is to allow those three syscalls again. The **Localhost** profile here does exactly
+that and nothing more (preferred); **Unconfined** removes the sandbox entirely (simplest).
+Either way, the kernel-level `io_uring_disabled` sysctl must be `0` — `00-prereqs.sh` checks it.
+
+See CloudNative-PG [PR #10446](https://github.com/cloudnative-pg/cloudnative-pg/pull/10446)
+for the upstream profile and security discussion.
+
+---
+
+## Related
+
+- [PostgreSQL 18 asynchronous I/O](https://www.postgresql.org/docs/18/runtime-config-resource.html#GUC-IO-METHOD)
+- [`documentdb/micro-benchmarks`](https://github.com/documentdb/micro-benchmarks)
+- [PostgreSQL parameter tuning on DocumentDB](../../docs/operator-public-documentation/postgresql-tuning.md)
+- [CNPG security context / io_uring (PR #10446)](https://github.com/cloudnative-pg/cloudnative-pg/pull/10446)

--- a/documentdb-playground/io-uring-benchmark/analyze.py
+++ b/documentdb-playground/io-uring-benchmark/analyze.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Summarize io_uring micro-benchmark results.
+
+Reads Locust ``*_stats.csv`` files produced by 50-run-matrix.sh (one per
+io_method x workload x selectivity x repeat), takes the per-cell ``Aggregated``
+row, computes the median across repeats, and prints a comparison table with the
+throughput speedup of each io_method relative to ``sync``.
+
+Layout expected (any depth — we glob recursively):
+    <root>/.../<io_method>/<workload>_sel<sel>_r<rep>_stats.csv
+
+Usage:
+    python3 analyze.py <results-root> [--out summary.csv]
+"""
+import argparse
+import csv
+import glob
+import os
+import re
+import statistics
+import sys
+from collections import defaultdict
+
+CELL_RE = re.compile(r"(?P<wl>.+)_sel(?P<sel>[^_]+)_r(?P<rep>\d+)_stats\.csv$")
+SEL_ORDER = ["unique", "5", "10", "50", "100", "1k", "2k", "3k", "4k", "5k"]
+METHOD_ORDER = ["sync", "worker", "io_uring"]
+
+
+def _f(row, *keys):
+    """First parseable float among the given column names, else None."""
+    for k in keys:
+        if k in row and row[k] not in ("", "N/A", None):
+            try:
+                return float(row[k])
+            except ValueError:
+                pass
+    return None
+
+
+def parse_cell(path):
+    """Return (method, workload, selectivity, metrics) or None."""
+    m = CELL_RE.search(os.path.basename(path))
+    if not m:
+        return None
+    method = os.path.basename(os.path.dirname(path))
+    with open(path, newline="") as fh:
+        agg = None
+        for row in csv.DictReader(fh):
+            if row.get("Name") == "Aggregated":
+                agg = row
+                break
+        if agg is None:
+            return None
+    metrics = {
+        "rps": _f(agg, "Requests/s"),
+        "p50": _f(agg, "50%", "Median Response Time"),
+        "p95": _f(agg, "95%"),
+        "p99": _f(agg, "99%"),
+        "count": _f(agg, "Request Count"),
+    }
+    return method, m["wl"], m["sel"], metrics
+
+
+def median_or_none(vals):
+    vals = [v for v in vals if v is not None]
+    return statistics.median(vals) if vals else None
+
+
+def sel_key(sel):
+    return SEL_ORDER.index(sel) if sel in SEL_ORDER else len(SEL_ORDER)
+
+
+def method_key(method):
+    return METHOD_ORDER.index(method) if method in METHOD_ORDER else len(METHOD_ORDER)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("root", help="results root directory")
+    ap.add_argument("--out", default=None, help="write summary CSV here")
+    args = ap.parse_args()
+
+    files = glob.glob(os.path.join(args.root, "**", "*_stats.csv"), recursive=True)
+    # Skip locust's per-cell history files, keep only the summary stats files.
+    files = [f for f in files if not f.endswith("_stats_history.csv")]
+    if not files:
+        sys.exit(f"no *_stats.csv files found under {args.root}")
+
+    # (workload, sel, method) -> list of per-repeat metric dicts
+    cells = defaultdict(list)
+    for path in files:
+        parsed = parse_cell(path)
+        if parsed:
+            method, wl, sel, metrics = parsed
+            cells[(wl, sel, method)].append(metrics)
+
+    # (workload, sel, method) -> median metrics
+    agg = {}
+    for key, runs in cells.items():
+        agg[key] = {m: median_or_none([r[m] for r in runs]) for m in ("rps", "p50", "p95", "p99", "count")}
+
+    methods = sorted({k[2] for k in agg}, key=method_key)
+    combos = sorted({(k[0], k[1]) for k in agg}, key=lambda t: (t[0], sel_key(t[1])))
+
+    rows = []
+    header = ["workload", "selectivity"]
+    for mth in methods:
+        header += [f"{mth}_rps", f"{mth}_p95ms", f"{mth}_p99ms"]
+    header += [f"speedup_{mth}_vs_sync" for mth in methods if mth != "sync"]
+
+    for wl, sel in combos:
+        row = {"workload": wl, "selectivity": sel}
+        base = agg.get((wl, sel, "sync"), {}).get("rps")
+        for mth in methods:
+            md = agg.get((wl, sel, mth), {})
+            row[f"{mth}_rps"] = md.get("rps")
+            row[f"{mth}_p95ms"] = md.get("p95")
+            row[f"{mth}_p99ms"] = md.get("p99")
+        for mth in methods:
+            if mth == "sync":
+                continue
+            cur = agg.get((wl, sel, mth), {}).get("rps")
+            row[f"speedup_{mth}_vs_sync"] = (cur / base) if (cur and base) else None
+        rows.append(row)
+
+    def fmt(v, nd=1):
+        return "—" if v is None else f"{v:.{nd}f}"
+
+    widths = {h: max(len(h), 10) for h in header}
+    print("  ".join(h.ljust(widths[h]) for h in header))
+    print("  ".join("-" * widths[h] for h in header))
+    for row in rows:
+        cells_out = []
+        for h in header:
+            v = row.get(h)
+            if v is None:
+                cells_out.append("—".ljust(widths[h]))
+            elif h.startswith("speedup"):
+                cells_out.append((fmt(v, 2) + "x").ljust(widths[h]))
+            elif isinstance(v, float):
+                cells_out.append(fmt(v).ljust(widths[h]))
+            else:
+                cells_out.append(str(v).ljust(widths[h]))
+        print("  ".join(cells_out))
+
+    if args.out:
+        with open(args.out, "w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=header)
+            w.writeheader()
+            for row in rows:
+                w.writerow({k: ("" if row.get(k) is None else row.get(k)) for k in header})
+
+
+if __name__ == "__main__":
+    main()

--- a/documentdb-playground/io-uring-benchmark/manifests/benchmark-runner.yaml
+++ b/documentdb-playground/io-uring-benchmark/manifests/benchmark-runner.yaml
@@ -1,0 +1,88 @@
+# In-cluster benchmark runner for the DocumentDB micro-benchmarks Locust suite.
+#
+# A long-lived pod (not a one-shot Job) so scripts/50-run-matrix.sh can exec into it
+# once per (io_method x workload x selectivity) cell and collect CSVs, all over the
+# in-cluster pod network (no port-forward). It clones documentdb/micro-benchmarks and
+# pip-installs its requirements on first start, then idles.
+#
+# For repeated/CI use, pre-bake an image instead (see Dockerfile) and set `image:` below.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bench-runner
+  namespace: iouring-bench
+  labels:
+    app.kubernetes.io/part-of: io-uring-benchmark
+    app: bench-runner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bench-runner
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: bench-runner
+        app.kubernetes.io/part-of: io-uring-benchmark
+    spec:
+      containers:
+        - name: runner
+          image: python:3.12-slim
+          env:
+            - name: MICRO_BENCH_REPO
+              value: "https://github.com/documentdb/micro-benchmarks.git"
+            - name: MICRO_BENCH_REF
+              value: "main"
+            - name: GATEWAY_HOST
+              value: "documentdb-service-iouring-bench.iouring-bench.svc.cluster.local"
+            - name: GATEWAY_PORT
+              value: "10260"
+            - name: MONGO_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: iouring-bench-credentials
+                  key: username
+            - name: MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: iouring-bench-credentials
+                  key: password
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              echo "[bootstrap] installing OS deps..."
+              apt-get update >/tmp/apt.log 2>&1
+              apt-get install -y --no-install-recommends \
+                git ca-certificates build-essential procps >>/tmp/apt.log 2>&1
+              echo "[bootstrap] cloning ${MICRO_BENCH_REPO} @ ${MICRO_BENCH_REF}..."
+              git clone "${MICRO_BENCH_REPO}" /opt/micro-benchmarks
+              cd /opt/micro-benchmarks
+              git checkout "${MICRO_BENCH_REF}"
+              echo "[bootstrap] installing python deps..."
+              pip install --no-cache-dir -r requirements.txt >/tmp/pip.log 2>&1
+              mkdir -p /results
+              touch /tmp/ready
+              echo "[bootstrap] runner ready."
+              sleep infinity
+          readinessProbe:
+            exec:
+              command: ["cat", "/tmp/ready"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 60
+          resources:
+            requests:
+              cpu: "1"
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          volumeMounts:
+            - name: results
+              mountPath: /results
+      volumes:
+        - name: results
+          emptyDir: {}

--- a/documentdb-playground/io-uring-benchmark/manifests/credentials.yaml
+++ b/documentdb-playground/io-uring-benchmark/manifests/credentials.yaml
@@ -1,0 +1,13 @@
+# DocumentDB gateway credentials for the io_uring benchmark.
+#
+# WARNING: This is a throwaway password for a benchmark playground.
+#          Replace it (or generate one) before using anywhere real.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iouring-bench-credentials
+  namespace: iouring-bench
+type: Opaque
+stringData:
+  username: benchadmin
+  password: "ChangeMe!ReplaceBeforeUsing"

--- a/documentdb-playground/io-uring-benchmark/manifests/documentdb-iouring.yaml
+++ b/documentdb-playground/io-uring-benchmark/manifests/documentdb-iouring.yaml
@@ -1,0 +1,40 @@
+# DocumentDB variant: io_method = io_uring  (Linux io_uring async I/O)
+#
+# Asynchronous I/O via io_uring. This is the variant under test.
+#
+# REQUIREMENT: io_uring syscalls (io_uring_setup/enter/register) must NOT be blocked
+# by the container seccomp profile. CNPG runs the postgres container with
+# seccompProfile=RuntimeDefault, and modern containerd strips io_uring from
+# RuntimeDefault — postgres then CrashLoops with:
+#     FATAL: could not setup io_uring queue: Operation not permitted
+# The DocumentDB CR has no seccomp field, so relax it OUT OF BAND before deploying
+# this variant:  scripts/20-deploy-seccomp.sh  (Kyverno mutate, Localhost or Unconfined).
+#
+# Apply ONE variant at a time — see documentdb-sync.yaml for the full rationale.
+apiVersion: documentdb.io/preview
+kind: DocumentDB
+metadata:
+  name: iouring-bench
+  namespace: iouring-bench
+  labels:
+    app.kubernetes.io/part-of: io-uring-benchmark
+    io-uring-benchmark/io-method: io_uring
+spec:
+  nodeCount: 1
+  instancesPerNode: 1
+  documentDbCredentialSecret: iouring-bench-credentials
+  resource:
+    storage:
+      pvcSize: "50Gi"
+      # storageClass: managed-csi-premium
+      persistentVolumeReclaimPolicy: Delete
+    memory: "4Gi"
+    cpu: "2"
+  postgres:
+    parameters:
+      io_method: "io_uring"
+      track_io_timing: "on"
+  exposeViaService:
+    serviceType: ClusterIP
+  plugins:
+    sidecarInjectorName: cnpg-i-sidecar-injector.documentdb.io

--- a/documentdb-playground/io-uring-benchmark/manifests/documentdb-sync.yaml
+++ b/documentdb-playground/io-uring-benchmark/manifests/documentdb-sync.yaml
@@ -1,0 +1,44 @@
+# DocumentDB variant: io_method = sync  (BASELINE — synchronous I/O, no AIO)
+#
+# This is the control in the io_uring comparison. Apply ONE variant at a time to
+# the same name/namespace so the dataset, PVC, image, and resources stay constant
+# and io_method is the only independent variable.
+#
+# Notes
+# - spec.postgres.parameters.io_method is passed through to the CNPG Cluster's
+#   postgresql.parameters (operator PR #307). io_method is a postmaster-level GUC,
+#   so changing it triggers a CNPG rolling restart.
+# - spec.image.postgres defaults to ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+#   (PostgreSQL 18) which ships liburing; we leave it at the default here.
+# - Memory is intentionally constrained relative to the dataset so reads hit storage
+#   (io_uring only helps real I/O, not page-cache hits). Size the dataset in
+#   scripts/40-load-data.sh to exceed this.
+# - Set spec.resource.storage.storageClass to a fast (NVMe / premium SSD) class for
+#   headline numbers; omitted here to use the cluster default.
+apiVersion: documentdb.io/preview
+kind: DocumentDB
+metadata:
+  name: iouring-bench
+  namespace: iouring-bench
+  labels:
+    app.kubernetes.io/part-of: io-uring-benchmark
+    io-uring-benchmark/io-method: sync
+spec:
+  nodeCount: 1
+  instancesPerNode: 1
+  documentDbCredentialSecret: iouring-bench-credentials
+  resource:
+    storage:
+      pvcSize: "50Gi"
+      # storageClass: managed-csi-premium   # AKS premium SSD; set a fast class for real numbers
+      persistentVolumeReclaimPolicy: Delete
+    memory: "4Gi"
+    cpu: "2"
+  postgres:
+    parameters:
+      io_method: "sync"
+      track_io_timing: "on"
+  exposeViaService:
+    serviceType: ClusterIP
+  plugins:
+    sidecarInjectorName: cnpg-i-sidecar-injector.documentdb.io

--- a/documentdb-playground/io-uring-benchmark/manifests/documentdb-worker.yaml
+++ b/documentdb-playground/io-uring-benchmark/manifests/documentdb-worker.yaml
@@ -1,0 +1,34 @@
+# DocumentDB variant: io_method = worker  (PostgreSQL 18 DEFAULT async I/O)
+#
+# Asynchronous I/O via a pool of dedicated I/O worker processes (io_workers).
+# This is PG18's default and a useful middle point between sync and io_uring.
+#
+# Apply ONE variant at a time — see documentdb-sync.yaml for the full rationale.
+apiVersion: documentdb.io/preview
+kind: DocumentDB
+metadata:
+  name: iouring-bench
+  namespace: iouring-bench
+  labels:
+    app.kubernetes.io/part-of: io-uring-benchmark
+    io-uring-benchmark/io-method: worker
+spec:
+  nodeCount: 1
+  instancesPerNode: 1
+  documentDbCredentialSecret: iouring-bench-credentials
+  resource:
+    storage:
+      pvcSize: "50Gi"
+      # storageClass: managed-csi-premium
+      persistentVolumeReclaimPolicy: Delete
+    memory: "4Gi"
+    cpu: "2"
+  postgres:
+    parameters:
+      io_method: "worker"
+      io_workers: "3"
+      track_io_timing: "on"
+  exposeViaService:
+    serviceType: ClusterIP
+  plugins:
+    sidecarInjectorName: cnpg-i-sidecar-injector.documentdb.io

--- a/documentdb-playground/io-uring-benchmark/policy/kyverno-seccomp-localhost.yaml
+++ b/documentdb-playground/io-uring-benchmark/policy/kyverno-seccomp-localhost.yaml
@@ -1,0 +1,69 @@
+# Kyverno mutate policy — HARDENED (Localhost profile).
+#
+# Same targeting as the Unconfined variant, but points the postgres pods at a curated
+# Localhost seccomp profile that allows ONLY the extra io_uring syscalls on top of the
+# container runtime's default set. This keeps the seccomp sandbox in place.
+#
+# PREREQUISITE: the profile must already be on every node at
+#   /var/lib/kubelet/seccomp/profiles/postgres.json
+# Install it with the DaemonSet in this playground:
+#   kubectl apply -k seccomp/
+#
+# Requires Kyverno installed. Apply BEFORE deploying the DocumentDB CR. Use EITHER this
+# policy OR the Unconfined one, not both.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: io-uring-relax-seccomp-localhost
+  annotations:
+    policies.kyverno.io/title: Relax seccomp for io_uring (Localhost)
+    policies.kyverno.io/category: io-uring-benchmark
+spec:
+  rules:
+    - name: pod-seccomp-localhost
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+              namespaces: ["iouring-bench"]
+              selector:
+                matchExpressions:
+                  - key: cnpg.io/cluster
+                    operator: Exists
+      mutate:
+        patchStrategicMerge:
+          spec:
+            securityContext:
+              seccompProfile:
+                type: Localhost
+                localhostProfile: profiles/postgres.json
+    - name: container-seccomp-localhost
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+              namespaces: ["iouring-bench"]
+              selector:
+                matchExpressions:
+                  - key: cnpg.io/cluster
+                    operator: Exists
+      mutate:
+        foreach:
+          - list: "request.object.spec.containers"
+            patchStrategicMerge:
+              spec:
+                containers:
+                  - name: "{{ element.name }}"
+                    securityContext:
+                      seccompProfile:
+                        type: Localhost
+                        localhostProfile: profiles/postgres.json
+          - list: "request.object.spec.initContainers || `[]`"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  - name: "{{ element.name }}"
+                    securityContext:
+                      seccompProfile:
+                        type: Localhost
+                        localhostProfile: profiles/postgres.json

--- a/documentdb-playground/io-uring-benchmark/policy/kyverno-seccomp-unconfined.yaml
+++ b/documentdb-playground/io-uring-benchmark/policy/kyverno-seccomp-unconfined.yaml
@@ -1,0 +1,69 @@
+# Kyverno mutate policy — QUICK START (Unconfined).
+#
+# Relaxes the seccomp profile to Unconfined on every CNPG-managed postgres pod in the
+# iouring-bench namespace (both the initdb Job pods and the running instance pods,
+# matched by the cnpg.io/cluster label). This unblocks io_uring without shipping any
+# node-level profile.
+#
+# The DocumentDB operator does not expose a seccomp field and CNPG sets the postgres
+# CONTAINER's seccompProfile to RuntimeDefault, so we override at the pod level AND at
+# each container/initContainer (strategic-merge by container name).
+#
+# Unconfined removes the seccomp sandbox entirely — fine for a benchmark, but prefer the
+# Localhost variant (kyverno-seccomp-localhost.yaml + the seccomp DaemonSet) for anything
+# resembling production.
+#
+# Requires Kyverno installed in the cluster. Apply BEFORE deploying the DocumentDB CR.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: io-uring-relax-seccomp-unconfined
+  annotations:
+    policies.kyverno.io/title: Relax seccomp for io_uring (Unconfined)
+    policies.kyverno.io/category: io-uring-benchmark
+spec:
+  rules:
+    - name: pod-seccomp-unconfined
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+              namespaces: ["iouring-bench"]
+              selector:
+                matchExpressions:
+                  - key: cnpg.io/cluster
+                    operator: Exists
+      mutate:
+        patchStrategicMerge:
+          spec:
+            securityContext:
+              seccompProfile:
+                type: Unconfined
+    - name: container-seccomp-unconfined
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+              namespaces: ["iouring-bench"]
+              selector:
+                matchExpressions:
+                  - key: cnpg.io/cluster
+                    operator: Exists
+      mutate:
+        foreach:
+          - list: "request.object.spec.containers"
+            patchStrategicMerge:
+              spec:
+                containers:
+                  - name: "{{ element.name }}"
+                    securityContext:
+                      seccompProfile:
+                        type: Unconfined
+          - list: "request.object.spec.initContainers || `[]`"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  - name: "{{ element.name }}"
+                    securityContext:
+                      seccompProfile:
+                        type: Unconfined

--- a/documentdb-playground/io-uring-benchmark/scripts/00-prereqs.sh
+++ b/documentdb-playground/io-uring-benchmark/scripts/00-prereqs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# 00-prereqs.sh — verify tooling and that the cluster nodes can actually run io_uring.
+#
+# Checks:
+#   * required CLIs present
+#   * cluster reachable
+#   * node kernel >= 5.1 and /proc/sys/kernel/io_uring_disabled == 0
+#   * a fast (NVMe / premium SSD) StorageClass is available for headline numbers
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+require kubectl helm jq
+
+log "kubectl context: $(kubectl config current-context)"
+kubectl version -o json >/dev/null 2>&1 || die "cannot reach the cluster"
+
+log "checking node kernel + io_uring sysctl (ephemeral pod)..."
+OUT="$(kubectl run iouring-precheck --rm -i --restart=Never --image=busybox:1.36 --command -- \
+  sh -c 'echo KERNEL=$(uname -r); echo IO_URING_DISABLED=$(cat /proc/sys/kernel/io_uring_disabled 2>/dev/null || echo missing)' 2>/dev/null || true)"
+echo "$OUT" | grep -E 'KERNEL=|IO_URING_DISABLED=' || warn "could not read node kernel info"
+
+KVER="$(echo "$OUT" | sed -n 's/^KERNEL=//p' | cut -d- -f1)"
+DISABLED="$(echo "$OUT" | sed -n 's/^IO_URING_DISABLED=//p')"
+if [ -n "$KVER" ]; then
+  major="${KVER%%.*}"; rest="${KVER#*.}"; minor="${rest%%.*}"
+  if [ "$major" -lt 5 ] || { [ "$major" -eq 5 ] && [ "$minor" -lt 1 ]; }; then
+    warn "kernel $KVER may be too old for io_uring (need >= 5.1)"
+  else
+    log "kernel $KVER supports io_uring."
+  fi
+fi
+case "$DISABLED" in
+  0) log "io_uring is enabled on the node (io_uring_disabled=0)." ;;
+  missing) warn "io_uring_disabled sysctl not found; assuming enabled (older kernel)." ;;
+  *) warn "io_uring_disabled=$DISABLED — io_uring is DISABLED on this node. Re-enable it (sysctl kernel.io_uring_disabled=0) or io_uring will fail." ;;
+esac
+
+log "available StorageClasses:"
+kubectl get storageclass
+warn "For headline numbers, point spec.resource.storage.storageClass at a fast NVMe/premium-SSD class (e.g. AKS 'managed-csi-premium', EKS 'gp3'/io2)."
+
+log "prereq checks complete."

--- a/documentdb-playground/io-uring-benchmark/scripts/10-deploy-operator.sh
+++ b/documentdb-playground/io-uring-benchmark/scripts/10-deploy-operator.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# 10-deploy-operator.sh — install cert-manager and the DocumentDB operator.
+#
+# REQUIREMENT: the operator build must include spec.postgres.parameters passthrough
+# (operator PR #307). Released images >= the version containing #307 work out of the
+# box; to use a custom build set OPERATOR_REPO / OPERATOR_TAG.
+#
+# For a local kind cluster, prefer the repo's dev script instead:
+#   cd operator/src && DEPLOY=true DEPLOY_CLUSTER=true ./scripts/development/deploy.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+require kubectl helm
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+CHART_DIR="$REPO_ROOT/operator/documentdb-helm-chart"
+[ -d "$CHART_DIR" ] || die "operator helm chart not found at $CHART_DIR"
+
+OPERATOR_NS="${OPERATOR_NS:-documentdb-operator}"
+OPERATOR_REPO="${OPERATOR_REPO:-}"
+OPERATOR_TAG="${OPERATOR_TAG:-}"
+
+# --- cert-manager (required by the operator's webhooks + CNPG plugin certs) ---
+if kubectl get pods -n cert-manager 2>/dev/null | grep -q Running; then
+  log "cert-manager already running."
+else
+  log "installing cert-manager..."
+  helm repo add jetstack https://charts.jetstack.io --force-update
+  helm repo update
+  helm install cert-manager jetstack/cert-manager \
+    --namespace cert-manager --create-namespace --set installCRDs=true
+  kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance=cert-manager \
+    -n cert-manager --timeout=300s
+fi
+
+# --- DocumentDB operator (bundles CloudNative-PG as a chart dependency) ---
+log "building chart dependencies (CloudNative-PG)..."
+helm dependency build "$CHART_DIR" >/dev/null
+
+EXTRA=()
+[ -n "$OPERATOR_REPO" ] && EXTRA+=(--set "image.documentdbk8soperator.repository=$OPERATOR_REPO")
+[ -n "$OPERATOR_TAG" ]  && EXTRA+=(--set-string "image.documentdbk8soperator.tag=$OPERATOR_TAG")
+
+log "installing/upgrading documentdb-operator into namespace $OPERATOR_NS..."
+helm upgrade --install documentdb-operator "$CHART_DIR" \
+  --namespace "$OPERATOR_NS" --create-namespace \
+  "${EXTRA[@]}" --wait --timeout 10m
+
+log "waiting for operator rollout..."
+kubectl rollout status deploy -n "$OPERATOR_NS" --timeout=300s 2>/dev/null || true
+kubectl get pods -n "$OPERATOR_NS"
+log "operator install complete."
+warn "Confirm the operator supports spec.postgres.parameters:"
+warn "  kubectl explain documentdb.spec.postgres.parameters"

--- a/documentdb-playground/io-uring-benchmark/scripts/20-deploy-seccomp.sh
+++ b/documentdb-playground/io-uring-benchmark/scripts/20-deploy-seccomp.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# 20-deploy-seccomp.sh — relax seccomp on CNPG postgres pods so io_uring is allowed.
+#
+# The DocumentDB CR has no seccomp field and CNPG runs postgres with
+# seccompProfile=RuntimeDefault, which modern containerd strips io_uring from. We use a
+# Kyverno mutate policy to override seccomp on the CNPG-managed pods.
+#
+#   SECCOMP_MODE=unconfined (default)  -> Unconfined; no node profile needed (quick).
+#   SECCOMP_MODE=localhost             -> Localhost profiles/postgres.json; installs the
+#                                         curated io_uring profile on every node first.
+#
+# Run this BEFORE deploying the DocumentDB CR so the mutation applies at pod admission.
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+require kubectl helm
+PG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+kubectl get ns "$NS" >/dev/null 2>&1 || kubectl create namespace "$NS"
+
+# --- Kyverno ---
+if kubectl get pods -n kyverno 2>/dev/null | grep -q Running; then
+  log "Kyverno already running."
+else
+  log "installing Kyverno..."
+  helm repo add kyverno https://kyverno.github.io/kyverno/ --force-update
+  helm repo update
+  helm install kyverno kyverno/kyverno -n kyverno --create-namespace --wait --timeout 5m
+fi
+# Kyverno admission controller must be Ready before its policies take effect.
+kubectl wait --for=condition=Available deploy -n kyverno --all --timeout=300s 2>/dev/null || true
+
+case "$SECCOMP_MODE" in
+  localhost)
+    log "installing the io_uring Localhost seccomp profile on all nodes (DaemonSet)..."
+    kubectl apply -k "$PG_DIR/seccomp"
+    kubectl rollout status ds/io-uring-seccomp-installer -n kube-system --timeout=180s 2>/dev/null || true
+    log "applying Kyverno Localhost mutate policy..."
+    kubectl apply -f "$PG_DIR/policy/kyverno-seccomp-localhost.yaml"
+    kubectl delete -f "$PG_DIR/policy/kyverno-seccomp-unconfined.yaml" --ignore-not-found
+    ;;
+  unconfined)
+    log "applying Kyverno Unconfined mutate policy..."
+    kubectl apply -f "$PG_DIR/policy/kyverno-seccomp-unconfined.yaml"
+    kubectl delete -f "$PG_DIR/policy/kyverno-seccomp-localhost.yaml" --ignore-not-found
+    ;;
+  *) die "unknown SECCOMP_MODE='$SECCOMP_MODE' (expected: unconfined | localhost)" ;;
+esac
+
+log "seccomp solution (${SECCOMP_MODE}) deployed."
+warn "The policy mutates pods labeled cnpg.io/cluster in namespace '$NS' only."

--- a/documentdb-playground/io-uring-benchmark/scripts/30-deploy-documentdb.sh
+++ b/documentdb-playground/io-uring-benchmark/scripts/30-deploy-documentdb.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# 30-deploy-documentdb.sh — deploy the DocumentDB cluster + in-cluster benchmark runner.
+#
+# Deploys ONE io_method variant (INITIAL_METHOD, default io_uring so the seccomp path is
+# validated immediately), waits for health, verifies io_method, then starts the runner.
+#
+# Env: INITIAL_METHOD=io_uring|worker|sync   STORAGE_CLASS=<fast-class>
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+require kubectl
+PG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+INITIAL_METHOD="${INITIAL_METHOD:-io_uring}"
+MANIFEST="$PG_DIR/manifests/documentdb-${INITIAL_METHOD}.yaml"
+[ -f "$MANIFEST" ] || die "no manifest for INITIAL_METHOD='$INITIAL_METHOD'"
+
+kubectl get ns "$NS" >/dev/null 2>&1 || kubectl create namespace "$NS"
+
+log "applying gateway credentials..."
+kubectl apply -f "$PG_DIR/manifests/credentials.yaml"
+
+log "deploying DocumentDB '$NAME' (io_method=$INITIAL_METHOD)..."
+if [ -n "${STORAGE_CLASS:-}" ]; then
+  log "  using storageClass=$STORAGE_CLASS"
+  sed "s|# storageClass: managed-csi-premium.*|storageClass: ${STORAGE_CLASS}|" "$MANIFEST" | kubectl apply -f -
+else
+  kubectl apply -f "$MANIFEST"
+fi
+
+# Give the operator a moment to create the CNPG Cluster, then wait for health.
+sleep 15
+wait_cluster_ready 900
+
+GOT="$(current_io_method)"
+if [ "$GOT" = "$INITIAL_METHOD" ]; then
+  log "verified: io_method=$GOT is active in PostgreSQL."
+else
+  warn "expected io_method=$INITIAL_METHOD but postgres reports '$GOT'."
+fi
+log "postgres version: $(pgq 'SELECT version();' | head -1)"
+
+log "deploying benchmark runner..."
+kubectl apply -f "$PG_DIR/manifests/benchmark-runner.yaml"
+log "waiting for runner to clone micro-benchmarks + install deps (this can take a few minutes)..."
+kubectl rollout status deploy/bench-runner -n "$NS" --timeout=600s
+kubectl wait --for=condition=Ready pod -l app=bench-runner -n "$NS" --timeout=600s
+
+log "DocumentDB + runner ready. Next: ./40-load-data.sh"

--- a/documentdb-playground/io-uring-benchmark/scripts/40-load-data.sh
+++ b/documentdb-playground/io-uring-benchmark/scripts/40-load-data.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# 40-load-data.sh — load the dataset ONCE via the in-cluster runner.
+#
+# Runs documentdb/micro-benchmarks find_read_loader, which drops the collection, inserts
+# DOCUMENT_COUNT docs, then auto-quits. The io_method in effect during load does not
+# matter — the query phase is where io_uring is measured. Subsequent query runs auto-skip
+# loading when the collection already holds >= 95% of DOCUMENT_COUNT.
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+require kubectl
+POD="$(bench_pod)"; [ -n "$POD" ] || die "benchmark runner pod not found — run ./30-deploy-documentdb.sh"
+
+log "loading $DOCUMENT_COUNT documents (users=$LOAD_USERS, batch=$LOAD_BATCH_SIZE) — this can take a while..."
+kubectl exec -n "$NS" "$POD" -- bash -lc '
+set -euo pipefail
+cd /opt/micro-benchmarks
+URI="mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${GATEWAY_HOST}:${GATEWAY_PORT}/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true"
+bash test/run_locust.sh \
+  --locustfile workloads/read_queries/find_read_loader.py \
+  --uri "$URI" \
+  --users '"$LOAD_USERS"' --run-time 9999s \
+  --document-count '"$DOCUMENT_COUNT"' --load-batch-size '"$LOAD_BATCH_SIZE"'
+'
+log "data load complete. Next: ./50-run-matrix.sh"

--- a/documentdb-playground/io-uring-benchmark/scripts/50-run-matrix.sh
+++ b/documentdb-playground/io-uring-benchmark/scripts/50-run-matrix.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# 50-run-matrix.sh — run the io_method x workload x selectivity x repeat matrix.
+#
+# For each io_method: patch the CR + wait for the rolling restart, then run each read
+# workload at each selectivity REPEATS times. Locust CSVs and a pg_stat_io snapshot are
+# written inside the runner pod under /results/<method>/...; pull them out with
+# ./60-collect.sh.
+#
+# Tunables (see lib.sh): IO_METHODS, WORKLOADS, SELECTIVITIES, REPEATS, RUN_TIME,
+#   QUERY_USERS, DOCUMENT_COUNT, IO_WORKERS.
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+require kubectl
+POD="$(bench_pod)"; [ -n "$POD" ] || die "benchmark runner pod not found — run ./30-deploy-documentdb.sh"
+
+log "matrix: methods=[$IO_METHODS] workloads=[$WORKLOADS] selectivities=[$SELECTIVITIES] repeats=$REPEATS run-time=$RUN_TIME"
+
+for method in $IO_METHODS; do
+  switch_io_method "$method"
+  for wl in $WORKLOADS; do
+    for sel in $SELECTIVITIES; do
+      for rep in $(seq 1 "$REPEATS"); do
+        cell="${wl}_sel${sel}_r${rep}"
+        log ">>> ${method} / ${cell}"
+        reset_io_stats
+        skip_index=""; [ "$rep" -gt 1 ] && skip_index="--skip-index-setup"
+        kubectl exec -n "$NS" "$POD" -- bash -lc '
+          set -euo pipefail
+          cd /opt/micro-benchmarks
+          OUT="/results/'"$method"'"; mkdir -p "$OUT"
+          URI="mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${GATEWAY_HOST}:${GATEWAY_PORT}/?directConnection=true&authMechanism=SCRAM-SHA-256&tls=true&tlsInsecure=true"
+          bash test/run_locust.sh \
+            --locustfile workloads/read_queries/'"$wl"'.py \
+            --uri "$URI" \
+            --users '"$QUERY_USERS"' --run-time '"$RUN_TIME"' \
+            --document-count '"$DOCUMENT_COUNT"' \
+            --selectivity '"$sel"' \
+            --skip-data-load '"$skip_index"' \
+            --csv "$OUT/'"$cell"'"
+        ' || warn "cell ${method}/${cell} failed (continuing)"
+
+        # Capture the I/O accounting for this cell from PG18 pg_stat_io.
+        dump_io_stats > /tmp/iostat.csv 2>/dev/null || true
+        kubectl cp /tmp/iostat.csv "$NS/$POD:/results/$method/${cell}_pg_stat_io.csv" >/dev/null 2>&1 || true
+      done
+    done
+  done
+done
+
+log "matrix complete. Next: ./60-collect.sh"

--- a/documentdb-playground/io-uring-benchmark/scripts/60-collect.sh
+++ b/documentdb-playground/io-uring-benchmark/scripts/60-collect.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# 60-collect.sh — copy benchmark CSVs out of the runner pod and summarize them.
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+require kubectl
+POD="$(bench_pod)"; [ -n "$POD" ] || die "benchmark runner pod not found"
+PG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+DEST="$RESULTS_DIR/raw"
+mkdir -p "$DEST"
+log "copying /results from runner pod -> $DEST ..."
+kubectl cp "$NS/$POD:/results" "$DEST"
+
+log "summarizing..."
+if command -v python3 >/dev/null 2>&1; then
+  python3 "$PG_DIR/analyze.py" "$DEST" --out "$RESULTS_DIR/summary.csv" | tee "$RESULTS_DIR/summary.txt"
+  log "wrote $RESULTS_DIR/summary.csv and $RESULTS_DIR/summary.txt"
+else
+  warn "python3 not found locally; raw CSVs are in $DEST. Run analyze.py manually."
+fi

--- a/documentdb-playground/io-uring-benchmark/scripts/99-teardown.sh
+++ b/documentdb-playground/io-uring-benchmark/scripts/99-teardown.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# 99-teardown.sh — remove the benchmark. By default only the iouring-bench namespace.
+#
+# Flags:
+#   --all          also remove Kyverno policies + seccomp DaemonSet
+#   --operator     also uninstall the DocumentDB operator + Kyverno
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+require kubectl
+PG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+ALL=false; OPERATOR=false
+for a in "$@"; do
+  case "$a" in
+    --all) ALL=true ;;
+    --operator) ALL=true; OPERATOR=true ;;
+    *) die "unknown flag: $a" ;;
+  esac
+done
+
+log "deleting DocumentDB '$NAME' and namespace '$NS'..."
+kubectl delete documentdb "$NAME" -n "$NS" --ignore-not-found --wait=false 2>/dev/null || true
+kubectl delete namespace "$NS" --ignore-not-found
+
+if $ALL; then
+  log "removing Kyverno policies + seccomp profile installer..."
+  kubectl delete -f "$PG_DIR/policy/kyverno-seccomp-unconfined.yaml" --ignore-not-found
+  kubectl delete -f "$PG_DIR/policy/kyverno-seccomp-localhost.yaml" --ignore-not-found
+  kubectl delete -k "$PG_DIR/seccomp" --ignore-not-found 2>/dev/null || true
+fi
+
+if $OPERATOR; then
+  log "uninstalling Kyverno + DocumentDB operator..."
+  helm uninstall kyverno -n kyverno 2>/dev/null || true
+  helm uninstall documentdb-operator -n "${OPERATOR_NS:-documentdb-operator}" 2>/dev/null || true
+fi
+
+log "teardown complete."

--- a/documentdb-playground/io-uring-benchmark/scripts/lib.sh
+++ b/documentdb-playground/io-uring-benchmark/scripts/lib.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Shared helpers and configuration for the io_uring benchmark playground.
+# Source this from the numbered scripts:  source "$(dirname "$0")/lib.sh"
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# Configuration (override via environment)
+# --------------------------------------------------------------------------
+NS="${NS:-iouring-bench}"                       # namespace for the DocumentDB + runner
+NAME="${NAME:-iouring-bench}"                   # DocumentDB / CNPG cluster name
+GATEWAY_PORT="${GATEWAY_PORT:-10260}"
+DOCUMENT_COUNT="${DOCUMENT_COUNT:-10000000}"    # dataset size; MUST exceed RAM to expose I/O
+LOAD_USERS="${LOAD_USERS:-50}"
+LOAD_BATCH_SIZE="${LOAD_BATCH_SIZE:-100}"
+QUERY_USERS="${QUERY_USERS:-1}"
+RUN_TIME="${RUN_TIME:-180s}"                    # per query cell (must cover index build)
+REPEATS="${REPEATS:-3}"                         # repeats per cell
+IO_METHODS="${IO_METHODS:-sync worker io_uring}"
+WORKLOADS="${WORKLOADS:-range_scalar range_arr point_scalar point_arr}"
+SELECTIVITIES="${SELECTIVITIES:-100 1k 5k}"
+IO_WORKERS="${IO_WORKERS:-3}"
+SECCOMP_MODE="${SECCOMP_MODE:-unconfined}"      # unconfined | localhost
+RESULTS_DIR="${RESULTS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/results}"
+
+# --------------------------------------------------------------------------
+# Logging
+# --------------------------------------------------------------------------
+log()  { printf '\033[1;34m[io-uring]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[io-uring][warn]\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31m[io-uring][error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+require() {
+  for bin in "$@"; do
+    command -v "$bin" >/dev/null 2>&1 || die "required tool not found on PATH: $bin"
+  done
+}
+
+# --------------------------------------------------------------------------
+# Cluster helpers
+# --------------------------------------------------------------------------
+
+# Name of the CNPG primary postgres pod for our cluster.
+pg_primary_pod() {
+  kubectl get pods -n "$NS" \
+    -l "cnpg.io/cluster=$NAME,cnpg.io/instanceRole=primary" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+# Run psql inside the primary postgres container (trust auth over the local socket).
+pgq() {
+  local pod; pod="$(pg_primary_pod)"
+  [ -n "$pod" ] || die "no primary postgres pod found for cluster $NAME in $NS"
+  kubectl exec -n "$NS" "$pod" -c postgres -- psql -U postgres -tAc "$1"
+}
+
+# Current effective io_method inside postgres.
+current_io_method() { pgq "SHOW io_method;" | tr -d '[:space:]'; }
+
+# Name of the benchmark runner pod.
+bench_pod() {
+  kubectl get pods -n "$NS" -l app=bench-runner \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+# Wait until the DocumentDB-backed CNPG cluster reports a healthy primary.
+wait_cluster_ready() {
+  local timeout="${1:-600}" waited=0
+  log "waiting for CNPG cluster '$NAME' to become healthy (timeout ${timeout}s)..."
+  while :; do
+    local ready instances
+    ready="$(kubectl get cluster.postgresql.cnpg.io "$NAME" -n "$NS" -o jsonpath='{.status.readyInstances}' 2>/dev/null || true)"
+    instances="$(kubectl get cluster.postgresql.cnpg.io "$NAME" -n "$NS" -o jsonpath='{.spec.instances}' 2>/dev/null || true)"
+    if [ -n "$ready" ] && [ "$ready" = "$instances" ]; then
+      log "cluster healthy: ${ready}/${instances} instances ready."
+      return 0
+    fi
+    [ "$waited" -ge "$timeout" ] && die "timed out waiting for cluster '$NAME' (ready='$ready' want='$instances')"
+    sleep 5; waited=$((waited+5))
+  done
+}
+
+# Switch io_method on the live DocumentDB CR and wait for the rolling restart to apply.
+# Usage: switch_io_method <sync|worker|io_uring>
+switch_io_method() {
+  local method="$1"
+  log "switching io_method -> ${method} (patching DocumentDB/${NAME})..."
+  kubectl patch documentdb "$NAME" -n "$NS" --type merge -p \
+    "{\"spec\":{\"postgres\":{\"parameters\":{\"io_method\":\"${method}\",\"io_workers\":\"${IO_WORKERS}\",\"track_io_timing\":\"on\"}}}}"
+
+  # Give the operator + CNPG time to reconcile and roll the instance, then verify.
+  local timeout=420 waited=0
+  while :; do
+    sleep 10; waited=$((waited+10))
+    wait_cluster_ready 600 >/dev/null 2>&1 || true
+    local got; got="$(current_io_method 2>/dev/null || true)"
+    if [ "$got" = "$method" ]; then
+      log "io_method now active: ${got}"
+      return 0
+    fi
+    [ "$waited" -ge "$timeout" ] && die "timed out waiting for io_method=${method} (saw '${got}')"
+    log "  ...still '${got:-?}', waiting for restart (${waited}s)"
+  done
+}
+
+# Reset pg_stat_io so a fresh benchmark cell starts from zero counters.
+reset_io_stats() { pgq "SELECT pg_stat_reset_shared('io');" >/dev/null 2>&1 || true; }
+
+# Dump pg_stat_io (reads + read_time) to stdout as CSV.
+dump_io_stats() {
+  pgq "COPY (SELECT backend_type,object,context,reads,read_bytes,read_time,writes,write_time,extends FROM pg_stat_io WHERE reads>0 OR writes>0 ORDER BY reads DESC) TO STDOUT WITH CSV HEADER"
+}

--- a/documentdb-playground/io-uring-benchmark/seccomp/deploy-seccomp-daemonset.yaml
+++ b/documentdb-playground/io-uring-benchmark/seccomp/deploy-seccomp-daemonset.yaml
@@ -1,0 +1,65 @@
+# DaemonSet that installs the io_uring seccomp profile onto every node, at the
+# kubelet seccomp root so it can be referenced as a Localhost profile:
+#   /var/lib/kubelet/seccomp/profiles/postgres.json   ->   localhostProfile: profiles/postgres.json
+#
+# The profile content lives in the `io-uring-seccomp-profile` ConfigMap, generated
+# from seccomp/io_uring-seccompprofile.json by the kustomization in this directory
+# (kubectl apply -k seccomp/). It is the upstream CNPG RuntimeDefault-equivalent
+# profile PLUS the io_uring_{setup,enter,register} syscalls (CNPG PR #10446).
+#
+# Use this (Localhost) variant for a hardened, production-like posture. For a quick
+# proof, the Unconfined Kyverno policy needs no node-level profile at all.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: io-uring-seccomp-installer
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/part-of: io-uring-benchmark
+    app: io-uring-seccomp-installer
+spec:
+  selector:
+    matchLabels:
+      app: io-uring-seccomp-installer
+  template:
+    metadata:
+      labels:
+        app: io-uring-seccomp-installer
+        app.kubernetes.io/part-of: io-uring-benchmark
+    spec:
+      # The installer only writes a file to the host seccomp dir, then idles.
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - name: install-profile
+          image: busybox:1.36
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              install -D -m 0644 /profile/postgres.json /host-seccomp/profiles/postgres.json
+              echo "installed profiles/postgres.json on $(hostname)"
+          volumeMounts:
+            - name: profile
+              mountPath: /profile
+            - name: host-seccomp
+              mountPath: /host-seccomp
+      containers:
+        - name: pause
+          image: busybox:1.36
+          command: ["/bin/sh", "-c", "trap 'exit 0' TERM; while true; do sleep 3600 & wait $!; done"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+      volumes:
+        - name: profile
+          configMap:
+            name: io-uring-seccomp-profile
+        - name: host-seccomp
+          hostPath:
+            path: /var/lib/kubelet/seccomp
+            type: DirectoryOrCreate

--- a/documentdb-playground/io-uring-benchmark/seccomp/io_uring-seccompprofile.json
+++ b/documentdb-playground/io-uring-benchmark/seccomp/io_uring-seccompprofile.json
@@ -1,0 +1,798 @@
+{
+  "archMap": [
+    {
+      "architecture": "SCMP_ARCH_X86_64",
+      "subArchitectures": [
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_AARCH64",
+      "subArchitectures": [
+        "SCMP_ARCH_ARM"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_S390X",
+      "subArchitectures": [
+        "SCMP_ARCH_S390"
+      ]
+    }
+  ],
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "syscalls": [
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {},
+      "names": [
+        "accept",
+        "accept4",
+        "access",
+        "adjtimex",
+        "alarm",
+        "bind",
+        "brk",
+        "capget",
+        "capset",
+        "chdir",
+        "chmod",
+        "chown",
+        "chown32",
+        "clock_getres",
+        "clock_gettime",
+        "clock_nanosleep",
+        "close",
+        "connect",
+        "copy_file_range",
+        "creat",
+        "dup",
+        "dup2",
+        "dup3",
+        "epoll_create",
+        "epoll_create1",
+        "epoll_ctl",
+        "epoll_ctl_old",
+        "epoll_pwait",
+        "epoll_wait",
+        "epoll_wait_old",
+        "eventfd",
+        "eventfd2",
+        "execve",
+        "execveat",
+        "exit",
+        "exit_group",
+        "faccessat",
+        "fadvise64",
+        "fadvise64_64",
+        "fallocate",
+        "fanotify_mark",
+        "fchdir",
+        "fchmod",
+        "fchmodat",
+        "fchown",
+        "fchown32",
+        "fchownat",
+        "fcntl",
+        "fcntl64",
+        "fdatasync",
+        "fgetxattr",
+        "flistxattr",
+        "flock",
+        "fork",
+        "fremovexattr",
+        "fsetxattr",
+        "fstat",
+        "fstat64",
+        "fstatat64",
+        "fstatfs",
+        "fstatfs64",
+        "fsync",
+        "ftruncate",
+        "ftruncate64",
+        "futex",
+        "futimesat",
+        "getcpu",
+        "getcwd",
+        "getdents",
+        "getdents64",
+        "getegid",
+        "getegid32",
+        "geteuid",
+        "geteuid32",
+        "getgid",
+        "getgid32",
+        "getgroups",
+        "getgroups32",
+        "getitimer",
+        "getpeername",
+        "getpgid",
+        "getpgrp",
+        "getpid",
+        "getppid",
+        "getpriority",
+        "getrandom",
+        "getresgid",
+        "getresgid32",
+        "getresuid",
+        "getresuid32",
+        "getrlimit",
+        "get_robust_list",
+        "getrusage",
+        "getsid",
+        "getsockname",
+        "getsockopt",
+        "get_thread_area",
+        "gettid",
+        "gettimeofday",
+        "getuid",
+        "getuid32",
+        "getxattr",
+        "inotify_add_watch",
+        "inotify_init",
+        "inotify_init1",
+        "inotify_rm_watch",
+        "io_cancel",
+        "ioctl",
+        "io_destroy",
+        "io_getevents",
+        "io_pgetevents",
+        "ioprio_get",
+        "ioprio_set",
+        "io_setup",
+        "io_submit",
+        "io_uring_enter",
+        "io_uring_register",
+        "io_uring_setup",
+        "ipc",
+        "kill",
+        "lchown",
+        "lchown32",
+        "lgetxattr",
+        "link",
+        "linkat",
+        "listen",
+        "listxattr",
+        "llistxattr",
+        "_llseek",
+        "lremovexattr",
+        "lseek",
+        "lsetxattr",
+        "lstat",
+        "lstat64",
+        "madvise",
+        "memfd_create",
+        "mincore",
+        "mkdir",
+        "mkdirat",
+        "mknod",
+        "mknodat",
+        "mlock",
+        "mlock2",
+        "mlockall",
+        "mmap",
+        "mmap2",
+        "mprotect",
+        "mq_getsetattr",
+        "mq_notify",
+        "mq_open",
+        "mq_timedreceive",
+        "mq_timedsend",
+        "mq_unlink",
+        "mremap",
+        "msgctl",
+        "msgget",
+        "msgrcv",
+        "msgsnd",
+        "msync",
+        "munlock",
+        "munlockall",
+        "munmap",
+        "nanosleep",
+        "newfstatat",
+        "_newselect",
+        "open",
+        "openat",
+        "pause",
+        "pipe",
+        "pipe2",
+        "poll",
+        "ppoll",
+        "prctl",
+        "pread64",
+        "preadv",
+        "preadv2",
+        "prlimit64",
+        "pselect6",
+        "pwrite64",
+        "pwritev",
+        "pwritev2",
+        "read",
+        "readahead",
+        "readlink",
+        "readlinkat",
+        "readv",
+        "recv",
+        "recvfrom",
+        "recvmmsg",
+        "recvmsg",
+        "remap_file_pages",
+        "removexattr",
+        "rename",
+        "renameat",
+        "renameat2",
+        "restart_syscall",
+        "rmdir",
+        "rt_sigaction",
+        "rt_sigpending",
+        "rt_sigprocmask",
+        "rt_sigqueueinfo",
+        "rt_sigreturn",
+        "rt_sigsuspend",
+        "rt_sigtimedwait",
+        "rt_tgsigqueueinfo",
+        "sched_getaffinity",
+        "sched_getattr",
+        "sched_getparam",
+        "sched_get_priority_max",
+        "sched_get_priority_min",
+        "sched_getscheduler",
+        "sched_rr_get_interval",
+        "sched_setaffinity",
+        "sched_setattr",
+        "sched_setparam",
+        "sched_setscheduler",
+        "sched_yield",
+        "seccomp",
+        "select",
+        "semctl",
+        "semget",
+        "semop",
+        "semtimedop",
+        "send",
+        "sendfile",
+        "sendfile64",
+        "sendmmsg",
+        "sendmsg",
+        "sendto",
+        "setfsgid",
+        "setfsgid32",
+        "setfsuid",
+        "setfsuid32",
+        "setgid",
+        "setgid32",
+        "setgroups",
+        "setgroups32",
+        "setitimer",
+        "setpgid",
+        "setpriority",
+        "setregid",
+        "setregid32",
+        "setresgid",
+        "setresgid32",
+        "setresuid",
+        "setresuid32",
+        "setreuid",
+        "setreuid32",
+        "setrlimit",
+        "set_robust_list",
+        "setsid",
+        "setsockopt",
+        "set_thread_area",
+        "set_tid_address",
+        "setuid",
+        "setuid32",
+        "setxattr",
+        "shmat",
+        "shmctl",
+        "shmdt",
+        "shmget",
+        "shutdown",
+        "sigaltstack",
+        "signalfd",
+        "signalfd4",
+        "sigprocmask",
+        "sigreturn",
+        "socket",
+        "socketcall",
+        "socketpair",
+        "splice",
+        "stat",
+        "stat64",
+        "statfs",
+        "statfs64",
+        "statx",
+        "symlink",
+        "symlinkat",
+        "sync",
+        "sync_file_range",
+        "syncfs",
+        "sysinfo",
+        "tee",
+        "tgkill",
+        "time",
+        "timer_create",
+        "timer_delete",
+        "timerfd_create",
+        "timerfd_gettime",
+        "timerfd_settime",
+        "timer_getoverrun",
+        "timer_gettime",
+        "timer_settime",
+        "times",
+        "tkill",
+        "truncate",
+        "truncate64",
+        "ugetrlimit",
+        "umask",
+        "uname",
+        "unlink",
+        "unlinkat",
+        "utime",
+        "utimensat",
+        "utimes",
+        "vfork",
+        "vmsplice",
+        "wait4",
+        "waitid",
+        "waitpid",
+        "write",
+        "writev"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": null,
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "minKernel": "4.8"
+      },
+      "names": [
+        "ptrace"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "op": "SCMP_CMP_EQ",
+          "value": 0,
+          "valueTwo": 0
+        }
+      ],
+      "comment": "",
+      "excludes": {},
+      "includes": {},
+      "names": [
+        "personality"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "op": "SCMP_CMP_EQ",
+          "value": 8,
+          "valueTwo": 0
+        }
+      ],
+      "comment": "",
+      "excludes": {},
+      "includes": {},
+      "names": [
+        "personality"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "op": "SCMP_CMP_EQ",
+          "value": 131072,
+          "valueTwo": 0
+        }
+      ],
+      "comment": "",
+      "excludes": {},
+      "includes": {},
+      "names": [
+        "personality"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "op": "SCMP_CMP_EQ",
+          "value": 131080,
+          "valueTwo": 0
+        }
+      ],
+      "comment": "",
+      "excludes": {},
+      "includes": {},
+      "names": [
+        "personality"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "op": "SCMP_CMP_EQ",
+          "value": 4294967295,
+          "valueTwo": 0
+        }
+      ],
+      "comment": "",
+      "excludes": {},
+      "includes": {},
+      "names": [
+        "personality"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "arches": [
+          "ppc64le"
+        ]
+      },
+      "names": [
+        "sync_file_range2"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "arches": [
+          "arm",
+          "arm64"
+        ]
+      },
+      "names": [
+        "arm_fadvise64_64",
+        "arm_sync_file_range",
+        "sync_file_range2",
+        "breakpoint",
+        "cacheflush",
+        "set_tls"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32"
+        ]
+      },
+      "names": [
+        "arch_prctl"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32",
+          "x86"
+        ]
+      },
+      "names": [
+        "modify_ldt"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      },
+      "names": [
+        "s390_pci_mmio_read",
+        "s390_pci_mmio_write",
+        "s390_runtime_instr"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_DAC_READ_SEARCH"
+        ]
+      },
+      "names": [
+        "open_by_handle_at"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      },
+      "names": [
+        "bpf",
+        "clone",
+        "fanotify_init",
+        "lookup_dcookie",
+        "mount",
+        "name_to_handle_at",
+        "perf_event_open",
+        "quotactl",
+        "setdomainname",
+        "sethostname",
+        "setns",
+        "syslog",
+        "umount",
+        "umount2",
+        "unshare"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "op": "SCMP_CMP_MASKED_EQ",
+          "value": 2114060288,
+          "valueTwo": 0
+        }
+      ],
+      "comment": "",
+      "excludes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ],
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      },
+      "includes": {},
+      "names": [
+        "clone"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 1,
+          "op": "SCMP_CMP_MASKED_EQ",
+          "value": 2114060288,
+          "valueTwo": 0
+        }
+      ],
+      "comment": "s390 parameter ordering for clone is different",
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      },
+      "includes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      },
+      "names": [
+        "clone"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_SYS_BOOT"
+        ]
+      },
+      "names": [
+        "reboot"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_SYS_CHROOT"
+        ]
+      },
+      "names": [
+        "chroot"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_SYS_MODULE"
+        ]
+      },
+      "names": [
+        "delete_module",
+        "init_module",
+        "finit_module",
+        "query_module"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_SYS_PACCT"
+        ]
+      },
+      "names": [
+        "acct"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_SYS_PTRACE"
+        ]
+      },
+      "names": [
+        "kcmp",
+        "process_vm_readv",
+        "process_vm_writev",
+        "ptrace"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_SYS_RAWIO"
+        ]
+      },
+      "names": [
+        "iopl",
+        "ioperm"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_SYS_TIME"
+        ]
+      },
+      "names": [
+        "settimeofday",
+        "stime",
+        "clock_settime"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_SYS_TTY_CONFIG"
+        ]
+      },
+      "names": [
+        "vhangup"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_SYS_NICE"
+        ]
+      },
+      "names": [
+        "get_mempolicy",
+        "mbind",
+        "set_mempolicy"
+      ]
+    },
+    {
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "excludes": {},
+      "includes": {
+        "caps": [
+          "CAP_SYSLOG"
+        ]
+      },
+      "names": [
+        "syslog"
+      ]
+    }
+  ]
+}

--- a/documentdb-playground/io-uring-benchmark/seccomp/kustomization.yaml
+++ b/documentdb-playground/io-uring-benchmark/seccomp/kustomization.yaml
@@ -1,0 +1,19 @@
+# Apply with:  kubectl apply -k seccomp/
+#
+# Generates the io-uring-seccomp-profile ConfigMap from the JSON profile and
+# deploys the installer DaemonSet that writes it to each node's kubelet seccomp dir.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kube-system
+
+configMapGenerator:
+  - name: io-uring-seccomp-profile
+    files:
+      - postgres.json=io_uring-seccompprofile.json
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+resources:
+  - deploy-seccomp-daemonset.yaml


### PR DESCRIPTION
## What

Adds `documentdb-playground/io-uring-benchmark/` — a reproducible cloud (AKS/EKS) playground that measures **PostgreSQL 18 `io_method = io_uring` vs `worker` vs `sync`** on DocumentDB, driving the [`documentdb/micro-benchmarks`](https://github.com/documentdb/micro-benchmarks) Locust read-query suite.

## Why / proven feasibility

A spike on a local kind cluster (kernel 6.12, `io_uring_disabled=0`) established the full enable path:

| Finding | Evidence |
|---|---|
| PG18 `18-minimal-trixie` ships io_uring | `initdb` bootstrap postgres attempts io_uring queue setup |
| The only blocker is container seccomp | `RuntimeDefault` → `FATAL: could not setup io_uring queue: Operation not permitted` |
| Relaxing seccomp turns it on | `Unconfined` → PG18.3 starts, `SHOW io_method` = `io_uring`, `pg_stat_io` reads flow |

CNPG natively exposes `spec.seccompProfile`, but the DocumentDB CR has no seccomp field, so the playground relaxes seccomp on the CNPG postgres pods via a **Kyverno mutate policy**.

## Contents

- **CR variants** `manifests/documentdb-{sync,worker,io_uring}.yaml` — differ only in `spec.postgres.parameters.io_method`.
- **seccomp** — Kyverno policies (`Unconfined` quick-start + hardened `Localhost`), the curated CNPG io_uring profile (from [CNPG #10446](https://github.com/cloudnative-pg/cloudnative-pg/pull/10446)), and a node-installer DaemonSet.
- **harness** — an in-cluster Locust runner + an `00…99` script pipeline + `analyze.py` (median + speedup-vs-`sync` table).
- **README** — proven feasibility, the seccomp deep-dive, and an I/O-bound methodology (dataset > RAM, one variable, repeats + median, `pg_stat_io` corroboration).

## How to run

```bash
cd documentdb-playground/io-uring-benchmark
./scripts/00-prereqs.sh && ./scripts/10-deploy-operator.sh && ./scripts/20-deploy-seccomp.sh
STORAGE_CLASS=<fast-ssd> ./scripts/30-deploy-documentdb.sh
DOCUMENT_COUNT=10000000 ./scripts/40-load-data.sh
./scripts/50-run-matrix.sh && ./scripts/60-collect.sh
```

## Notes

- **Depends on** operator support for `spec.postgres.parameters` (#307). The README's link to `postgresql-tuning.md` resolves once #307 lands.
- Headline numbers are intended to come from a managed cloud cluster with fast NVMe/premium-SSD storage; local kind is a smoke test only (storage is not representative).
- Draft until #307 merges and a cloud run populates `results/`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>