### PR TITLE
feat(helm): add values schema and chart-testing lint (#381 M2, M3)

### DIFF
--- a/.github/configs/ct.yaml
+++ b/.github/configs/ct.yaml
@@ -1,0 +1,17 @@
+# chart-testing (ct) configuration for the DocumentDB operator Helm chart.
+# Used by the "Helm Chart Lint (chart-testing)" CI job to run `helm lint`,
+# values-schema validation (values.schema.json), and yaml/Chart.yaml linting.
+target-branch: main
+# Lint this chart explicitly rather than relying on git changed-detection, so
+# the job is deterministic regardless of which files a PR touches.
+charts:
+  - operator/documentdb-helm-chart
+# The chart has no maintainers field, and chart versioning is handled by the
+# release workflow rather than per-PR — disable both checks.
+validate-maintainers: false
+check-version-increment: false
+# Build the bundled CloudNative-PG dependency from its upstream repo.
+chart-repos:
+  - cloudnative-pg=https://cloudnative-pg.github.io/charts/
+helm-extra-args: --timeout 600s
+lint-conf: .github/configs/lintconf.yaml

--- a/.github/configs/lintconf.yaml
+++ b/.github/configs/lintconf.yaml
@@ -1,0 +1,44 @@
+# yamllint configuration used by chart-testing (ct lint).
+# Intentionally lenient: the goal is to catch structural YAML mistakes, not to
+# enforce a strict style on Helm templates and values files.
+rules:
+  braces:
+    level: error
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+  brackets:
+    level: error
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+  colons:
+    level: error
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    level: error
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: error
+    max: 2
+    max-start: 0
+    max-end: 1
+  hyphens:
+    level: error
+    max-spaces-after: 1
+  indentation:
+    level: error
+    spaces: consistent
+    indent-sequences: whatever
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  # CRLF line endings exist in some pre-existing chart files; normalizing them
+  # is out of scope for the lint setup. Don't fail the lint on newline style.
+  new-lines: disable
+  trailing-spaces: disable
+  truthy: disable

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -8,6 +8,8 @@ on:
       - 'operator/src/go.mod'
       - 'operator/src/go.sum'
       - 'operator/documentdb-helm-chart/**'
+      - '.github/workflows/test-unit.yml'
+      - '.github/configs/**'
   pull_request:
     branches: [main]
     paths:
@@ -15,6 +17,8 @@ on:
       - 'operator/src/go.mod'
       - 'operator/src/go.sum'
       - 'operator/documentdb-helm-chart/**'
+      - '.github/workflows/test-unit.yml'
+      - '.github/configs/**'
 
 permissions:
   contents: read
@@ -83,3 +87,38 @@ jobs:
         run: |
           echo "## Helm Chart Test Results" >> $GITHUB_STEP_SUMMARY
           echo "✅ Helm chart unit tests completed" >> $GITHUB_STEP_SUMMARY
+
+  helm-chart-lint:
+    name: Helm Chart Lint (chart-testing)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # chart-testing needs history to diff against the target branch.
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2
+
+      - name: Run chart-testing (lint)
+        # Lints the chart and validates values.yaml plus every ci/*-values.yaml
+        # combination against values.schema.json.
+        run: ct lint --config .github/configs/ct.yaml
+
+      - name: Lint Summary
+        if: always()
+        run: |
+          echo "## Helm Chart Lint Results" >> $GITHUB_STEP_SUMMARY
+          echo "✅ chart-testing lint (schema + yaml) completed" >> $GITHUB_STEP_SUMMARY

--- a/operator/documentdb-helm-chart/ci/custom-namespace-values.yaml
+++ b/operator/documentdb-helm-chart/ci/custom-namespace-values.yaml
@@ -1,0 +1,16 @@
+# ct lint test case: custom namespace plus image-pull secrets and scheduling
+# overrides. Exercises the optional `{{- with ... }}` blocks (imagePullSecrets,
+# nodeSelector, tolerations) and the namespace override across resources.
+certManager:
+  preflightCheck: false
+namespace: documentdb-custom
+imagePullSecrets:
+  - name: my-registry-secret
+operator:
+  nodeSelector:
+    disktype: ssd
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: documentdb
+      effect: NoSchedule

--- a/operator/documentdb-helm-chart/ci/default-values.yaml
+++ b/operator/documentdb-helm-chart/ci/default-values.yaml
@@ -1,0 +1,5 @@
+# ct lint test case: baseline render.
+# Preflight is disabled because CI lints/templates without a live cluster
+# (no cert-manager CRD present for API discovery).
+certManager:
+  preflightCheck: false

--- a/operator/documentdb-helm-chart/ci/walreplica-values.yaml
+++ b/operator/documentdb-helm-chart/ci/walreplica-values.yaml
@@ -1,0 +1,6 @@
+# ct lint test case: WAL replica plugin enabled.
+# Exercises the templates/03_documentdb_wal_replica.yaml render path that is
+# skipped by default (walReplica: false).
+certManager:
+  preflightCheck: false
+walReplica: true

--- a/operator/documentdb-helm-chart/values.schema.json
+++ b/operator/documentdb-helm-chart/values.schema.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DocumentDB Operator Helm chart values",
+  "description": "Schema for values.yaml. Validates user-supplied values at install/upgrade/template/lint time so typos and wrong types fail fast with an actionable message instead of at runtime.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "namespace": {
+      "description": "Namespace the operator is deployed into. Defaults to the Helm release namespace when unset.",
+      "type": "string"
+    },
+    "replicaCount": {
+      "description": "Number of operator replicas. The operator is a cluster singleton; keep at 1 unless leader election is configured.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "documentDbVersion": {
+      "description": "DocumentDB database image version (extension + gateway). Independent of Chart.appVersion. Empty falls back to the operator's compiled-in defaults.",
+      "type": "string"
+    },
+    "gatewayImagePullPolicy": {
+      "description": "Pull policy for the gateway sidecar container. Empty uses the Kubernetes default (IfNotPresent).",
+      "type": "string",
+      "enum": ["", "Always", "IfNotPresent", "Never"]
+    },
+    "documentDbImagePullPolicy": {
+      "description": "Pull policy for the DocumentDB extension ImageVolume. Empty uses Kubernetes default behavior.",
+      "type": "string",
+      "enum": ["", "Always", "IfNotPresent", "Never"]
+    },
+    "serviceAccount": {
+      "description": "Operator ServiceAccount configuration.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "description": "Whether to create the ServiceAccount.",
+          "type": "boolean"
+        },
+        "automount": {
+          "description": "Whether to automount the ServiceAccount API credentials.",
+          "type": "boolean"
+        },
+        "annotations": {
+          "description": "Annotations to add to the ServiceAccount.",
+          "type": "object"
+        },
+        "name": {
+          "description": "Name of the ServiceAccount to use.",
+          "type": "string"
+        }
+      }
+    },
+    "walReplica": {
+      "description": "Feature flag: deploy the WAL replica plugin when true.",
+      "type": "boolean"
+    },
+    "imagePullSecrets": {
+      "description": "Image pull secrets used by all operator components. Each entry is a Secret reference, e.g. [{ name: my-registry-secret }].",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "image": {
+      "description": "Container image repositories and pull policies for operator components.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "documentdbk8soperator": {
+          "$ref": "#/definitions/imageComponent"
+        },
+        "sidecarinjector": {
+          "$ref": "#/definitions/imageComponent"
+        },
+        "walreplica": {
+          "$ref": "#/definitions/imageComponent"
+        }
+      }
+    },
+    "certManager": {
+      "description": "cert-manager preflight configuration.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "preflightCheck": {
+          "description": "Fail the install with an actionable error when cert-manager is not present. Set false only for offline templating or out-of-band management.",
+          "type": "boolean"
+        }
+      }
+    },
+    "operator": {
+      "$ref": "#/definitions/componentConfig",
+      "description": "Pod-level configuration for the operator deployment."
+    },
+    "sidecarInjector": {
+      "$ref": "#/definitions/componentConfig",
+      "description": "Pod-level configuration for the sidecar-injector plugin deployment."
+    },
+    "walReplicaPlugin": {
+      "$ref": "#/definitions/componentConfig",
+      "description": "Pod-level configuration for the wal-replica plugin deployment."
+    },
+    "cloudnative-pg": {
+      "description": "Values passed through to the bundled CloudNative-PG subchart. Validated by the subchart's own schema.",
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "definitions": {
+    "imageComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "description": "Image repository.",
+          "type": "string"
+        },
+        "pullPolicy": {
+          "description": "Image pull policy.",
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": {
+          "description": "Image tag. Defaults to Chart.appVersion when unset.",
+          "type": "string"
+        }
+      }
+    },
+    "componentConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resources": {
+          "description": "Compute resource requests/limits for the container.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "podSecurityContext": {
+          "description": "Pod-level security context.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "containerSecurityContext": {
+          "description": "Container-level security context.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "nodeSelector": {
+          "description": "Node selector for scheduling.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "tolerations": {
+          "description": "Tolerations for scheduling.",
+          "type": "array"
+        },
+        "affinity": {
+          "description": "Affinity rules for scheduling.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "topologySpreadConstraints": {
+          "description": "Topology spread constraints for scheduling.",
+          "type": "array"
+        },
+        "priorityClassName": {
+          "description": "PriorityClass name for the pod.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
> Part of the GA-readiness chart audit (#381) — items **M2** and **M3**.

## What this PR does

Adds Helm values validation and chart-testing lint to the operator chart, aligning with upstream CloudNative-PG chart practice.

### M2 — `values.schema.json`

Adds a draft-07 JSON Schema for `values.yaml`. Helm automatically validates user-supplied values against it on `install` / `upgrade` / `template` / `lint`, so mistakes fail fast with an actionable message instead of becoming runtime errors. Examples now rejected up front:

- `--set replicaCount=one` → `got string, want integer`
- `--set image.documentdbk8soperator.pullPolicy=Sometimes` → `value must be one of 'Always', 'IfNotPresent', 'Never'`
- `--set replicaCont=2` (typo) → `additional properties 'replicaCont' not allowed`

The schema is strict at the root (typed keys, no unknown top-level properties) and lenient for Kubernetes-native nested structures (`resources`, security contexts, `affinity`) and the bundled `cloudnative-pg` subchart values.

### M3 — chart-testing lint in CI

Adds a **Helm Chart Lint (chart-testing)** job to `test-unit.yml` using the standard `helm/chart-testing` action — the same tool CNPG uses in its `lint.yml`. `ct lint` runs `helm lint`, **validates values against the schema (M2)**, and lints chart YAML/`Chart.yaml`.

- `.github/configs/ct.yaml` — chart-testing config (explicit chart path, CNPG dependency repo, maintainer/version checks disabled).
- `.github/configs/lintconf.yaml` — lenient yamllint config (structural checks only).
- `operator/documentdb-helm-chart/ci/*-values.yaml` — value combinations `ct lint` renders and schema-validates: baseline, `walReplica=true`, and a custom-namespace + `imagePullSecrets` + scheduling-overrides case.

## Why split from #384

Kept separate from the plugin-probes PR (#384) so each change reviews independently; M2's generated schema is a large additive file that would otherwise bury the probe change.

## Local verification

- `ct lint --config .github/configs/ct.yaml` passes for `values.yaml` and all three `ci/*-values.yaml` files.
- Schema rejects bad types, invalid enums, and unknown keys (verified via `helm template --set`).
- `helm lint` clean; `helm unittest` — 82 tests pass.

## Notes

- The pre-existing `values.yaml` uses CRLF line endings; normalizing that is out of scope, so the `new-lines` yamllint rule is disabled rather than reformatting the file in this PR.
- This PR is based on `main` and is independent of #384.

## Tracking

- #381 (GA chart audit, items M2 and M3)
