### PR TITLE
feat: block DocumentDB creation when ImageVolume is unavailable (#431)

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -77,10 +77,14 @@ inputs:
     description: 'Kubernetes version for Kind cluster (e.g., v1.35.0, v1.34.0)'
     required: false
     default: 'v1.35.0'
-  enable-image-volume-gate:
-    description: 'Enable the Kubernetes ImageVolume feature gate on the kind cluster (apiserver + kubelet). Needed to exercise the operator on K8s < 1.35, where the gate is beta/off-by-default.'
+  kind-feature-gates:
+    description: 'Comma-separated list of Kubernetes feature gates to enable on the kind cluster (apiserver + kubelet), e.g. "ImageVolume" or "ImageVolume,SomeOtherGate". Useful for exercising beta/off-by-default features. Empty means use cluster defaults.'
     required: false
-    default: 'false'
+    default: ''
+  deploy-documentdb:
+    description: 'Whether the action should deploy a DocumentDB and wait for it to become Healthy as part of setup. Set to "false" to provision only the cluster + operator and let the caller create its own resources (e.g. to assert a webhook rejection).'
+    required: false
+    default: 'true'
   released-chart-version:
     description: 'Install operator from the public GHCR OCI Helm chart instead of built artifacts. Use "latest" to resolve the highest stable SemVer tag published to GHCR, or pass an explicit version (e.g. "0.2.0") for reproducible installs (recommended).'
     required: false
@@ -221,25 +225,29 @@ runs:
         mongosh --version
         echo "✓ mongosh installed successfully for ${{ inputs.architecture }}"
 
-    - name: Generate kind config (ImageVolume feature gate)
+    - name: Generate kind config (feature gates)
       id: kind-config
-      if: inputs.enable-image-volume-gate == 'true'
+      if: inputs.kind-feature-gates != ''
       shell: bash
       run: |
-        # The ImageVolume feature is beta/off-by-default before Kubernetes
-        # 1.35. To exercise the operator on 1.33/1.34 we must turn the gate on
-        # for every control-plane and node component. A top-level featureGates
-        # block in the kind config applies to the apiserver, controller-manager,
-        # scheduler, and kubelet.
-        CONFIG_PATH="${RUNNER_TEMP}/kind-imagevolume-config.yaml"
-        cat > "$CONFIG_PATH" <<'EOF'
-        kind: Cluster
-        apiVersion: kind.x-k8s.io/v1alpha4
-        featureGates:
-          ImageVolume: true
-        EOF
+        # Enable the requested feature gates on every control-plane and node
+        # component. A top-level featureGates block in the kind config applies
+        # to the apiserver, controller-manager, scheduler, and kubelet -- which
+        # is what beta/off-by-default features (e.g. ImageVolume before its 1.35
+        # GA) require to be exercised end-to-end.
+        CONFIG_PATH="${RUNNER_TEMP}/kind-feature-gates-config.yaml"
+        {
+          echo "kind: Cluster"
+          echo "apiVersion: kind.x-k8s.io/v1alpha4"
+          echo "featureGates:"
+          IFS=',' read -ra GATES <<< "${{ inputs.kind-feature-gates }}"
+          for gate in "${GATES[@]}"; do
+            gate="$(echo "$gate" | xargs)"  # trim whitespace
+            [ -n "$gate" ] && echo "  ${gate}: true"
+          done
+        } > "$CONFIG_PATH"
         echo "path=$CONFIG_PATH" >> "$GITHUB_OUTPUT"
-        echo "Generated kind config enabling the ImageVolume feature gate:"
+        echo "Generated kind config enabling feature gates: ${{ inputs.kind-feature-gates }}"
         cat "$CONFIG_PATH"
 
     - name: Create kind cluster
@@ -748,6 +756,7 @@ runs:
         echo "✓ DocumentDB credentials secret created successfully"
 
     - name: Deploy DocumentDB cluster
+      if: inputs.deploy-documentdb == 'true'
       shell: bash
       run: |
         echo "Deploying DocumentDB cluster on ${{ inputs.architecture }} architecture..."

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -78,7 +78,7 @@ inputs:
     required: false
     default: 'v1.35.0'
   kind-feature-gates:
-    description: 'Comma-separated list of Kubernetes feature gates to enable on the kind cluster (apiserver + kubelet), e.g. "ImageVolume" or "ImageVolume,SomeOtherGate". Useful for exercising beta/off-by-default features. Empty means use cluster defaults.'
+    description: 'Comma-separated list of Kubernetes feature gates to set on the kind cluster (apiserver + kubelet). Each entry is "Name" (defaults to true) or "Name=true"/"Name=false", e.g. "ImageVolume" or "ImageVolume=false". Empty means use cluster defaults.'
     required: false
     default: ''
   deploy-documentdb:
@@ -230,24 +230,29 @@ runs:
       if: inputs.kind-feature-gates != ''
       shell: bash
       run: |
-        # Enable the requested feature gates on every control-plane and node
+        # Set the requested feature gates on every control-plane and node
         # component. A top-level featureGates block in the kind config applies
         # to the apiserver, controller-manager, scheduler, and kubelet -- which
-        # is what beta/off-by-default features (e.g. ImageVolume before its 1.35
-        # GA) require to be exercised end-to-end.
+        # is what beta features (e.g. ImageVolume before its 1.35 GA) require to
+        # deterministically enable ("Name=true") or disable ("Name=false"),
+        # independent of the version's default.
         CONFIG_PATH="${RUNNER_TEMP}/kind-feature-gates-config.yaml"
         {
           echo "kind: Cluster"
           echo "apiVersion: kind.x-k8s.io/v1alpha4"
           echo "featureGates:"
           IFS=',' read -ra GATES <<< "${{ inputs.kind-feature-gates }}"
-          for gate in "${GATES[@]}"; do
-            gate="$(echo "$gate" | xargs)"  # trim whitespace
-            [ -n "$gate" ] && echo "  ${gate}: true"
+          for entry in "${GATES[@]}"; do
+            entry="$(echo "$entry" | xargs)"  # trim whitespace
+            [ -z "$entry" ] && continue
+            name="${entry%%=*}"
+            value="true"
+            [ "$entry" != "$name" ] && value="${entry#*=}"
+            echo "  ${name}: ${value}"
           done
         } > "$CONFIG_PATH"
         echo "path=$CONFIG_PATH" >> "$GITHUB_OUTPUT"
-        echo "Generated kind config enabling feature gates: ${{ inputs.kind-feature-gates }}"
+        echo "Generated kind config setting feature gates: ${{ inputs.kind-feature-gates }}"
         cat "$CONFIG_PATH"
 
     - name: Create kind cluster

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -77,6 +77,10 @@ inputs:
     description: 'Kubernetes version for Kind cluster (e.g., v1.35.0, v1.34.0)'
     required: false
     default: 'v1.35.0'
+  enable-image-volume-gate:
+    description: 'Enable the Kubernetes ImageVolume feature gate on the kind cluster (apiserver + kubelet). Needed to exercise the operator on K8s < 1.35, where the gate is beta/off-by-default.'
+    required: false
+    default: 'false'
   released-chart-version:
     description: 'Install operator from the public GHCR OCI Helm chart instead of built artifacts. Use "latest" to resolve the highest stable SemVer tag published to GHCR, or pass an explicit version (e.g. "0.2.0") for reproducible installs (recommended).'
     required: false
@@ -217,12 +221,34 @@ runs:
         mongosh --version
         echo "✓ mongosh installed successfully for ${{ inputs.architecture }}"
 
+    - name: Generate kind config (ImageVolume feature gate)
+      id: kind-config
+      if: inputs.enable-image-volume-gate == 'true'
+      shell: bash
+      run: |
+        # The ImageVolume feature is beta/off-by-default before Kubernetes
+        # 1.35. To exercise the operator on 1.33/1.34 we must turn the gate on
+        # for every control-plane and node component. A top-level featureGates
+        # block in the kind config applies to the apiserver, controller-manager,
+        # scheduler, and kubelet.
+        CONFIG_PATH="${RUNNER_TEMP}/kind-imagevolume-config.yaml"
+        cat > "$CONFIG_PATH" <<'EOF'
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        featureGates:
+          ImageVolume: true
+        EOF
+        echo "path=$CONFIG_PATH" >> "$GITHUB_OUTPUT"
+        echo "Generated kind config enabling the ImageVolume feature gate:"
+        cat "$CONFIG_PATH"
+
     - name: Create kind cluster
       uses: helm/kind-action@v1.12.0
       with:
         version: v0.31.0
         node_image: kindest/node:${{ inputs.kubernetes-version }}
         cluster_name: documentdb-${{ inputs.test-type }}-${{ inputs.architecture }}-${{ inputs.test-scenario-name }}
+        config: ${{ steps.kind-config.outputs.path }}
 
     - name: Resolve DocumentDB and Gateway image references
       shell: bash

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -344,3 +344,94 @@ jobs:
             /tmp/cluster-logs/
           if-no-files-found: ignore
           retention-days: 14
+
+  # ---------------------------------------------------------------------------
+  # ImageVolume preflight (positive path, K8s < 1.35).
+  #
+  # Proves the operator works on Kubernetes versions BELOW the 1.35 GA of the
+  # ImageVolume feature, provided the feature gate is enabled. On these
+  # clusters the webhook's capability probe must ADMIT the DocumentDB, and the
+  # extension image must actually MOUNT at runtime (containerd >= 2.1, shipped
+  # in kind's 1.33/1.34 node images) for the cluster to reach Healthy.
+  #
+  # No Ginkgo specs run here on purpose: the composite action already deploys a
+  # DocumentDB and waits for Healthy as part of setup, so a green setup IS the
+  # end-to-end assertion. If the gate were off or the runtime too old, setup
+  # would fail. The gate-OFF / blocked path is covered by the webhook unit
+  # tests (operator/src/internal/webhook), not by CI.
+  # ---------------------------------------------------------------------------
+  imagevolume-preflight:
+    name: ImageVolume preflight (k8s ${{ matrix.kubernetes_version }})
+    needs: [build]
+    if: always() && needs.build.result == 'success'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        # Lowest supported versions where ImageVolume is still beta/off by
+        # default; the composite action turns the gate on for both.
+        kubernetes_version: [v1.33.7, v1.34.3]
+    env:
+      IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
+      EXT_IMAGE_TAG: ${{ needs.build.outputs.ext_image_tag }}
+      CHART_VERSION: ${{ needs.build.outputs.chart_version || '0.1.0' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download platform images artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-platform-images
+          path: ./artifacts/build-platform-images
+
+      - name: Download helm chart artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-helm-chart-amd64
+          path: ./artifacts/build-helm-chart-amd64
+
+      - name: Setup test environment (ImageVolume gate enabled)
+        uses: ./.github/actions/setup-test-environment
+        with:
+          test-type: 'e2e'
+          architecture: 'amd64'
+          runner: 'ubuntu-22.04'
+          test-scenario-name: imagevolume
+          node-count: '1'
+          instances-per-node: '1'
+          cert-manager-namespace: ${{ env.CERT_MANAGER_NS }}
+          operator-namespace: ${{ env.OPERATOR_NS }}
+          db-namespace: ${{ env.DB_NS }}
+          db-cluster-name: ${{ env.DB_NAME }}
+          db-username: ${{ env.DB_USERNAME }}
+          db-password: ${{ env.DB_PASSWORD }}
+          db-port: ${{ env.DB_PORT }}
+          image-tag: ${{ env.IMAGE_TAG }}
+          documentdb-image-tag: ${{ env.EXT_IMAGE_TAG }}
+          chart-version: ${{ env.CHART_VERSION }}
+          use-external-images: 'false'
+          kubernetes-version: ${{ matrix.kubernetes_version }}
+          enable-image-volume-gate: 'true'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository-owner: ${{ github.repository_owner }}
+
+      - name: Collect cluster diagnostics
+        if: failure()
+        uses: ./.github/actions/collect-logs
+        with:
+          architecture: amd64
+          operator-namespace: ${{ env.OPERATOR_NS }}
+          db-namespace: ${{ env.DB_NS }}
+          db-name: ${{ env.DB_NAME }}
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: imagevolume-preflight-logs-${{ matrix.kubernetes_version }}-${{ github.run_attempt }}
+          path: |
+            /tmp/cluster-logs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -413,7 +413,7 @@ jobs:
           chart-version: ${{ env.CHART_VERSION }}
           use-external-images: 'false'
           kubernetes-version: ${{ matrix.kubernetes_version }}
-          enable-image-volume-gate: 'true'
+          kind-feature-gates: 'ImageVolume'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository-owner: ${{ github.repository_owner }}
 
@@ -431,6 +431,133 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: imagevolume-preflight-logs-${{ matrix.kubernetes_version }}-${{ github.run_attempt }}
+          path: |
+            /tmp/cluster-logs/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ---------------------------------------------------------------------------
+  # ImageVolume block check (negative path).
+  #
+  # The mirror image of imagevolume-preflight: a Kubernetes 1.33 cluster with
+  # the ImageVolume gate LEFT OFF (its default on 1.33). Here the operator's
+  # admission webhook must REJECT DocumentDB creation with an actionable
+  # ImageVolume error instead of letting pods hang. The composite action
+  # provisions the cluster + operator only (deploy-documentdb: false); the
+  # workflow then applies a DocumentDB and asserts the apply fails with an
+  # ImageVolume message. This proves the fail-fast guarantee end-to-end on a
+  # real cluster, complementing the webhook unit tests.
+  # ---------------------------------------------------------------------------
+  imagevolume-block:
+    name: ImageVolume block (k8s v1.33.7, gate off)
+    needs: [build]
+    if: always() && needs.build.result == 'success'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    env:
+      IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
+      EXT_IMAGE_TAG: ${{ needs.build.outputs.ext_image_tag }}
+      CHART_VERSION: ${{ needs.build.outputs.chart_version || '0.1.0' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download platform images artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-platform-images
+          path: ./artifacts/build-platform-images
+
+      - name: Download helm chart artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-helm-chart-amd64
+          path: ./artifacts/build-helm-chart-amd64
+
+      - name: Setup test environment (operator only, no DocumentDB)
+        uses: ./.github/actions/setup-test-environment
+        with:
+          test-type: 'e2e'
+          architecture: 'amd64'
+          runner: 'ubuntu-22.04'
+          test-scenario-name: imagevolume-block
+          node-count: '1'
+          instances-per-node: '1'
+          cert-manager-namespace: ${{ env.CERT_MANAGER_NS }}
+          operator-namespace: ${{ env.OPERATOR_NS }}
+          db-namespace: ${{ env.DB_NS }}
+          db-cluster-name: ${{ env.DB_NAME }}
+          db-username: ${{ env.DB_USERNAME }}
+          db-password: ${{ env.DB_PASSWORD }}
+          db-port: ${{ env.DB_PORT }}
+          image-tag: ${{ env.IMAGE_TAG }}
+          documentdb-image-tag: ${{ env.EXT_IMAGE_TAG }}
+          chart-version: ${{ env.CHART_VERSION }}
+          use-external-images: 'false'
+          kubernetes-version: v1.33.7
+          deploy-documentdb: 'false'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository-owner: ${{ github.repository_owner }}
+
+      - name: Assert DocumentDB creation is blocked (ImageVolume unavailable)
+        shell: bash
+        run: |
+          echo "Negative test: with the ImageVolume gate off on k8s 1.33, the"
+          echo "operator's admission webhook must REJECT DocumentDB creation."
+
+          # The validating webhook runs its ImageVolume capability probe first
+          # and returns 403 Forbidden before any spec validation, so this apply
+          # is expected to FAIL with a message mentioning ImageVolume.
+          set +e
+          APPLY_OUTPUT="$(cat <<EOF | kubectl apply -f - 2>&1
+          apiVersion: documentdb.io/preview
+          kind: DocumentDB
+          metadata:
+            name: ${{ env.DB_NAME }}
+            namespace: ${{ env.DB_NS }}
+          spec:
+            nodeCount: 1
+            instancesPerNode: 1
+            resource:
+              storage:
+                pvcSize: 5Gi
+                storageClass: csi-hostpath-sc
+            exposeViaService:
+              serviceType: ClusterIP
+          EOF
+          )"
+          APPLY_RC=$?
+          set -e
+
+          echo "kubectl apply exit code: ${APPLY_RC}"
+          echo "kubectl apply output:"
+          echo "${APPLY_OUTPUT}"
+
+          if [ "${APPLY_RC}" -eq 0 ]; then
+            echo "❌ Expected DocumentDB creation to be rejected, but it was admitted."
+            kubectl delete documentdb ${{ env.DB_NAME }} -n ${{ env.DB_NS }} --ignore-not-found
+            exit 1
+          fi
+          if ! echo "${APPLY_OUTPUT}" | grep -qi "ImageVolume"; then
+            echo "❌ Rejected, but not for the expected ImageVolume reason."
+            exit 1
+          fi
+          echo "✓ DocumentDB creation was correctly blocked with an ImageVolume error."
+
+      - name: Collect cluster diagnostics
+        if: failure()
+        uses: ./.github/actions/collect-logs
+        with:
+          architecture: amd64
+          operator-namespace: ${{ env.OPERATOR_NS }}
+          db-namespace: ${{ env.DB_NS }}
+          db-name: ${{ env.DB_NAME }}
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: imagevolume-block-logs-${{ github.run_attempt }}
           path: |
             /tmp/cluster-logs/
           if-no-files-found: ignore

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -440,16 +440,19 @@ jobs:
   # ImageVolume block check (negative path).
   #
   # The mirror image of imagevolume-preflight: a Kubernetes 1.33 cluster with
-  # the ImageVolume gate LEFT OFF (its default on 1.33). Here the operator's
-  # admission webhook must REJECT DocumentDB creation with an actionable
-  # ImageVolume error instead of letting pods hang. The composite action
-  # provisions the cluster + operator only (deploy-documentdb: false); the
-  # workflow then applies a DocumentDB and asserts the apply fails with an
-  # ImageVolume message. This proves the fail-fast guarantee end-to-end on a
-  # real cluster, complementing the webhook unit tests.
+  # the ImageVolume gate EXPLICITLY DISABLED (kind-feature-gates:
+  # 'ImageVolume=false'). We force it off rather than relying on the version
+  # default because ImageVolume's real-world default in 1.33/1.34 is
+  # inconsistent across node images. Here the operator's admission webhook must
+  # REJECT DocumentDB creation with an actionable ImageVolume error instead of
+  # letting pods hang. The composite action provisions the cluster + operator
+  # only (deploy-documentdb: false); the workflow then applies a DocumentDB and
+  # asserts the apply fails with an ImageVolume message. This proves the
+  # fail-fast guarantee end-to-end on a real cluster, complementing the webhook
+  # unit tests.
   # ---------------------------------------------------------------------------
   imagevolume-block:
-    name: ImageVolume block (k8s v1.33.7, gate off)
+    name: ImageVolume block (k8s v1.33.7, gate disabled)
     needs: [build]
     if: always() && needs.build.result == 'success'
     runs-on: ubuntu-22.04
@@ -495,6 +498,7 @@ jobs:
           chart-version: ${{ env.CHART_VERSION }}
           use-external-images: 'false'
           kubernetes-version: v1.33.7
+          kind-feature-gates: 'ImageVolume=false'
           deploy-documentdb: 'false'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository-owner: ${{ github.repository_owner }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Major Features
+- **Fail-fast ImageVolume capability check**: The operator now depends on the Kubernetes [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature to mount the DocumentDB extension into PostgreSQL pods. Instead of gating on a Kubernetes version number, the validating webhook performs a capability probe (a server-side dry-run) when a `DocumentDB` is created and **rejects the resource with an actionable error if ImageVolume is unavailable**, so you find out immediately instead of waiting for pods that never become ready. ImageVolume is GA (on by default) in Kubernetes **1.35+**; on **1.33/1.34** it is beta and must be enabled via the `ImageVolume` feature gate on a containerd/CRI-O runtime. The Helm chart's `kubeVersion` floor is relaxed to `>= 1.33.0-0` accordingly. See [Before you start](docs/operator-public-documentation/preview/getting-started/before-you-start.md).
+
 ## [0.3.0] - 2026-07-15
 
 ### Security

--- a/docs/operator-public-documentation/preview/faq.md
+++ b/docs/operator-public-documentation/preview/faq.md
@@ -21,7 +21,7 @@ DocumentDB uses PostgreSQL as its underlying storage engine. The DocumentDB Gate
 
 ### Which Kubernetes distributions are supported?
 
-The operator works on any conformant Kubernetes distribution (version 1.35 or later). It has been tested on:
+The operator works on any conformant Kubernetes distribution (version 1.35 or later, or 1.33/1.34 with the ImageVolume feature gate enabled). It has been tested on:
 
 - **Azure Kubernetes Service (AKS)**
 - **Amazon Elastic Kubernetes Service (EKS)**
@@ -40,7 +40,7 @@ See the [API Reference](api-reference.md) for auto-generated documentation of al
 
 ### What are the minimum Kubernetes version requirements?
 
-Kubernetes **1.35 or later** is required. The operator uses the [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature, which became generally available in Kubernetes 1.35.
+The operator depends on the [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature to mount the DocumentDB extension. That feature is GA (on by default) in **Kubernetes 1.35+**, which is the recommended baseline. On **1.33 or 1.34** the feature is beta and off by default, so it works only if you enable the `ImageVolume` feature gate on the kube-apiserver and every kubelet (self-managed clusters only) with a container runtime that supports image volumes (containerd ≥ 2.1 or CRI-O ≥ 1.33). When the feature is unavailable, the operator's admission webhook rejects `DocumentDB` creation with an actionable error rather than letting pods hang.
 
 ### Do I need to install CloudNativePG separately?
 

--- a/docs/operator-public-documentation/preview/getting-started/before-you-start.md
+++ b/docs/operator-public-documentation/preview/getting-started/before-you-start.md
@@ -20,7 +20,7 @@ Before installing the DocumentDB Kubernetes Operator, ensure you have the follow
 | Component | Minimum Version | Purpose | Installation Guide |
 |-----------|-----------------|---------|-------------------|
 | **Kubernetes cluster** | 1.35+ (or 1.33/1.34 with the ImageVolume gate enabled) | Container orchestration platform | See [Cluster Options](#kubernetes-cluster-options) |
-| **kubectl** | 1.33+ | Kubernetes command-line tool | [Install kubectl](https://kubernetes.io/docs/tasks/tools/) |
+| **kubectl** | 1.34+ | Kubernetes command-line tool (supported within ±1 minor of the cluster; 1.34+ covers the 1.35 baseline) | [Install kubectl](https://kubernetes.io/docs/tasks/tools/) |
 | **Helm** | 3.x | Package manager for Kubernetes | [Install Helm](https://helm.sh/docs/intro/install/) |
 | **cert-manager** | 1.19+ | TLS certificate management | [Install cert-manager](https://cert-manager.io/docs/installation/) |
 

--- a/docs/operator-public-documentation/preview/getting-started/before-you-start.md
+++ b/docs/operator-public-documentation/preview/getting-started/before-you-start.md
@@ -19,13 +19,18 @@ Before installing the DocumentDB Kubernetes Operator, ensure you have the follow
 
 | Component | Minimum Version | Purpose | Installation Guide |
 |-----------|-----------------|---------|-------------------|
-| **Kubernetes cluster** | 1.35+ | Container orchestration platform | See [Cluster Options](#kubernetes-cluster-options) |
-| **kubectl** | 1.35+ | Kubernetes command-line tool | [Install kubectl](https://kubernetes.io/docs/tasks/tools/) |
+| **Kubernetes cluster** | 1.35+ (or 1.33/1.34 with the ImageVolume gate enabled) | Container orchestration platform | See [Cluster Options](#kubernetes-cluster-options) |
+| **kubectl** | 1.33+ | Kubernetes command-line tool | [Install kubectl](https://kubernetes.io/docs/tasks/tools/) |
 | **Helm** | 3.x | Package manager for Kubernetes | [Install Helm](https://helm.sh/docs/intro/install/) |
 | **cert-manager** | 1.19+ | TLS certificate management | [Install cert-manager](https://cert-manager.io/docs/installation/) |
 
-!!! warning "Kubernetes 1.35+ with containerd or CRI-O Required"
-    The operator requires Kubernetes 1.35 or later because it uses the [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature (GA in Kubernetes 1.35) to mount the DocumentDB extension into PostgreSQL pods. The cluster must use a **containerd** or **CRI-O** container runtime — Docker does not support ImageVolumes.
+!!! warning "The ImageVolume feature and a containerd or CRI-O runtime are required"
+    The operator uses the [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature to mount the DocumentDB extension into PostgreSQL pods, so the feature **must be available on your cluster**. It is GA (on by default) in **Kubernetes 1.35+** — the recommended baseline. The cluster must use a **containerd** or **CRI-O** container runtime; Docker does not support ImageVolumes.
+
+    When you create a `DocumentDB`, the operator's admission webhook probes for ImageVolume support and **rejects the resource with an actionable error if the feature is unavailable**, so you find out immediately instead of waiting for pods that never become ready.
+
+!!! note "Advanced: running on Kubernetes 1.33 or 1.34"
+    ImageVolume is a beta feature that is **off by default** on Kubernetes 1.33 and 1.34. On a self-managed cluster you can still run the operator there by enabling the `ImageVolume` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) on **both** the kube-apiserver and every kubelet, and ensuring the node's container runtime supports image volumes (**containerd ≥ 2.1** or **CRI-O ≥ 1.33**). Managed offerings (AKS/EKS/GKE) generally do not let you toggle apiserver/kubelet feature gates, so use 1.35+ there.
 
 ### Optional components
 
@@ -38,7 +43,7 @@ Before installing the DocumentDB Kubernetes Operator, ensure you have the follow
 
 ### Kubernetes cluster options
 
-The operator runs on any conformant Kubernetes distribution (1.35+). Choose based on your environment:
+The operator runs on any conformant Kubernetes distribution (1.35+, or 1.33/1.34 with the ImageVolume feature gate enabled). Choose based on your environment:
 
 === "Local Development"
 

--- a/docs/operator-public-documentation/preview/getting-started/before-you-start.md
+++ b/docs/operator-public-documentation/preview/getting-started/before-you-start.md
@@ -25,12 +25,7 @@ Before installing the DocumentDB Kubernetes Operator, ensure you have the follow
 | **cert-manager** | 1.19+ | TLS certificate management | [Install cert-manager](https://cert-manager.io/docs/installation/) |
 
 !!! warning "The ImageVolume feature and a containerd or CRI-O runtime are required"
-    The operator uses the [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature to mount the DocumentDB extension into PostgreSQL pods, so the feature **must be available on your cluster**. It is GA (on by default) in **Kubernetes 1.35+** — the recommended baseline. The cluster must use a **containerd** or **CRI-O** container runtime; Docker does not support ImageVolumes.
-
-    When you create a `DocumentDB`, the operator's admission webhook probes for ImageVolume support and **rejects the resource with an actionable error if the feature is unavailable**, so you find out immediately instead of waiting for pods that never become ready.
-
-!!! note "Advanced: running on Kubernetes 1.33 or 1.34"
-    ImageVolume is a beta feature that is **off by default** on Kubernetes 1.33 and 1.34. On a self-managed cluster you can still run the operator there by enabling the `ImageVolume` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) on **both** the kube-apiserver and every kubelet, and ensuring the node's container runtime supports image volumes (**containerd ≥ 2.1** or **CRI-O ≥ 1.33**). Managed offerings (AKS/EKS/GKE) generally do not let you toggle apiserver/kubelet feature gates, so use 1.35+ there.
+    The operator mounts the DocumentDB extension into PostgreSQL pods via the [ImageVolume](https://kubernetes.io/docs/concepts/storage/volumes/#image) feature, so it **must be available on your cluster**, running on a **containerd** or **CRI-O** runtime (Docker is not supported). ImageVolume is GA (on by default) in **Kubernetes 1.35+**; on **1.33/1.34** it is beta and works only if you enable the `ImageVolume` feature gate on the apiserver and kubelets (self-managed clusters; containerd ≥ 2.1 or CRI-O ≥ 1.33). If the feature is unavailable, the operator's admission webhook rejects `DocumentDB` creation with an actionable error instead of leaving pods stuck.
 
 ### Optional components
 

--- a/operator/documentdb-helm-chart/Chart.yaml
+++ b/operator/documentdb-helm-chart/Chart.yaml
@@ -5,7 +5,8 @@ description: A Helm chart for deploying the DocumentDB operator
 # The operator requires the Kubernetes ImageVolume feature (GA in 1.35, beta and
 # opt-in via feature gate in 1.33/1.34). The operator's validating webhook performs
 # a capability probe at DocumentDB creation time rather than gating on version, so
-# the chart only requires 1.33+ (older releases lack ImageVolume entirely).
+# the chart only requires 1.33+ (on 1.31/1.32 ImageVolume was alpha and not usable
+# with these operator images).
 kubeVersion: ">= 1.33.0-0"
 # appVersion controls the default image tag for operator, sidecar, and wal-replica images.
 # Database image versions (documentdb extension + gateway) are controlled by documentDbVersion in values.yaml.

--- a/operator/documentdb-helm-chart/Chart.yaml
+++ b/operator/documentdb-helm-chart/Chart.yaml
@@ -2,8 +2,11 @@ apiVersion: v2
 name: documentdb-operator
 version: 0.3.0
 description: A Helm chart for deploying the DocumentDB operator
-# The operator requires Kubernetes 1.35+ for ImageVolume GA support.
-kubeVersion: ">= 1.35.0-0"
+# The operator requires the Kubernetes ImageVolume feature (GA in 1.35, beta and
+# opt-in via feature gate in 1.33/1.34). The operator's validating webhook performs
+# a capability probe at DocumentDB creation time rather than gating on version, so
+# the chart only requires 1.33+ (older releases lack ImageVolume entirely).
+kubeVersion: ">= 1.33.0-0"
 # appVersion controls the default image tag for operator, sidecar, and wal-replica images.
 # Database image versions (documentdb extension + gateway) are controlled by documentDbVersion in values.yaml.
 appVersion: "0.3.0"

--- a/operator/src/internal/controller/documentdb_controller.go
+++ b/operator/src/internal/controller/documentdb_controller.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -519,17 +518,11 @@ func documentDBServicePredicate() predicate.Predicate {
 // SetupWithManager sets up the controller with the Manager.
 func (r *DocumentDBReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.Clientset == nil {
-		return fmt.Errorf("Clientset must be configured: required for Kubernetes version detection and SQL execution")
+		return fmt.Errorf("Clientset must be configured: required for SQL execution against the CNPG primary")
 	}
 
 	if r.SQLExecutor == nil {
 		r.SQLExecutor = r.executeSQLCommand
-	}
-
-	// Verify the cluster meets the minimum Kubernetes version requirement.
-	// ImageVolume (GA in K8s 1.35) is required for mounting the DocumentDB extension image.
-	if err := r.validateK8sVersion(); err != nil {
-		return err
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -540,43 +533,6 @@ func (r *DocumentDBReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&cnpgv1.Subscription{}).
 		Named("documentdb-controller").
 		Complete(r)
-}
-
-// validateK8sVersion checks that the Kubernetes cluster version is at least 1.35.
-// The operator requires ImageVolume (GA in K8s 1.35) to mount the DocumentDB extension image.
-// Callers must ensure Clientset is non-nil before calling this method.
-func (r *DocumentDBReconciler) validateK8sVersion() error {
-	serverVersion, err := r.Clientset.Discovery().ServerVersion()
-	if err != nil {
-		return fmt.Errorf("failed to detect Kubernetes version: %w", err)
-	}
-
-	majorStr := strings.TrimRight(serverVersion.Major, "+")
-	major, err := strconv.Atoi(majorStr)
-	if err != nil {
-		return fmt.Errorf("failed to parse Kubernetes major version %q: %w", serverVersion.Major, err)
-	}
-
-	// Future major versions (>1) are assumed to support ImageVolume.
-	if major > 1 {
-		return nil
-	}
-
-	minorStr := strings.TrimRight(serverVersion.Minor, "+")
-	minor, err := strconv.Atoi(minorStr)
-	if err != nil {
-		return fmt.Errorf("failed to parse Kubernetes minor version %q: %w", serverVersion.Minor, err)
-	}
-
-	if minor < util.MinK8sMinorVersion {
-		return fmt.Errorf(
-			"kubernetes version %s.%s is not supported: the DocumentDB operator requires Kubernetes 1.%d+ "+
-				"for ImageVolume support (GA in K8s 1.%d). Please upgrade your cluster",
-			serverVersion.Major, serverVersion.Minor, util.MinK8sMinorVersion, util.MinK8sMinorVersion,
-		)
-	}
-
-	return nil
 }
 
 // COPIED FROM https://github.com/cloudnative-pg/cloudnative-pg/blob/release-1.25/internal/cmd/plugin/promote/promote.go

--- a/operator/src/internal/controller/documentdb_controller_test.go
+++ b/operator/src/internal/controller/documentdb_controller_test.go
@@ -18,10 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/version"
-	fakediscovery "k8s.io/client-go/discovery/fake"
 	kubefake "k8s.io/client-go/kubernetes/fake"
-	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -2808,21 +2805,6 @@ var _ = Describe("DocumentDB Controller", func() {
 			output, _ := reconciler.SQLExecutor(context.Background(), nil, "")
 			Expect(output).To(Equal("custom"))
 		})
-
-		It("should return error when K8s version validation fails", func() {
-			clientset := kubefake.NewSimpleClientset()
-			fakeDisc, ok := clientset.Discovery().(*fakediscovery.FakeDiscovery)
-			Expect(ok).To(BeTrue())
-			fakeDisc.FakedServerVersion = &version.Info{Major: "1", Minor: "34"}
-
-			reconciler := &DocumentDBReconciler{
-				Clientset: clientset,
-			}
-
-			err := reconciler.SetupWithManager(nil)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("not supported"))
-		})
 	})
 
 	Describe("Reconcile", func() {
@@ -3017,99 +2999,6 @@ var _ = Describe("DocumentDB Controller", func() {
 			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: documentDBName, Namespace: documentDBNamespace}, updatedCluster)).To(Succeed())
 			Expect(updatedCluster.Spec.Plugins[0].Parameters["gatewayTLSSecret"]).To(Equal("new-tls-secret"))
 			Expect(updatedCluster.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
-		})
-	})
-
-	Describe("validateK8sVersion", func() {
-		It("should return nil for K8s >= 1.35", func() {
-			clientset := kubefake.NewSimpleClientset()
-			fakeDisc, ok := clientset.Discovery().(*fakediscovery.FakeDiscovery)
-			Expect(ok).To(BeTrue())
-			fakeDisc.FakedServerVersion = &version.Info{Major: "1", Minor: "35"}
-
-			reconciler := &DocumentDBReconciler{Clientset: clientset}
-			Expect(reconciler.validateK8sVersion()).To(Succeed())
-		})
-
-		It("should return error for K8s < 1.35", func() {
-			clientset := kubefake.NewSimpleClientset()
-			fakeDisc, ok := clientset.Discovery().(*fakediscovery.FakeDiscovery)
-			Expect(ok).To(BeTrue())
-			fakeDisc.FakedServerVersion = &version.Info{Major: "1", Minor: "34"}
-
-			reconciler := &DocumentDBReconciler{Clientset: clientset}
-			err := reconciler.validateK8sVersion()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("not supported"))
-			Expect(err.Error()).To(ContainSubstring("1.35"))
-		})
-
-		It("should return nil for K8s 1.36+", func() {
-			clientset := kubefake.NewSimpleClientset()
-			fakeDisc, ok := clientset.Discovery().(*fakediscovery.FakeDiscovery)
-			Expect(ok).To(BeTrue())
-			fakeDisc.FakedServerVersion = &version.Info{Major: "1", Minor: "36"}
-
-			reconciler := &DocumentDBReconciler{Clientset: clientset}
-			Expect(reconciler.validateK8sVersion()).To(Succeed())
-		})
-
-		It("should return nil for future major versions (e.g. K8s 2.0)", func() {
-			clientset := kubefake.NewSimpleClientset()
-			fakeDisc, ok := clientset.Discovery().(*fakediscovery.FakeDiscovery)
-			Expect(ok).To(BeTrue())
-			fakeDisc.FakedServerVersion = &version.Info{Major: "2", Minor: "0"}
-
-			reconciler := &DocumentDBReconciler{Clientset: clientset}
-			Expect(reconciler.validateK8sVersion()).To(Succeed())
-		})
-
-		It("should handle minor version with + suffix", func() {
-			clientset := kubefake.NewSimpleClientset()
-			fakeDisc, ok := clientset.Discovery().(*fakediscovery.FakeDiscovery)
-			Expect(ok).To(BeTrue())
-			fakeDisc.FakedServerVersion = &version.Info{Major: "1", Minor: "35+"}
-
-			reconciler := &DocumentDBReconciler{Clientset: clientset}
-			Expect(reconciler.validateK8sVersion()).To(Succeed())
-		})
-
-		It("should return error when ServerVersion fails", func() {
-			clientset := kubefake.NewSimpleClientset()
-			fakeDisc, ok := clientset.Discovery().(*fakediscovery.FakeDiscovery)
-			Expect(ok).To(BeTrue())
-			fakeDisc.PrependReactor("*", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
-				return true, nil, fmt.Errorf("connection refused")
-			})
-
-			reconciler := &DocumentDBReconciler{Clientset: clientset}
-			err := reconciler.validateK8sVersion()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to detect"))
-		})
-
-		It("should return error when minor version is not a number", func() {
-			clientset := kubefake.NewSimpleClientset()
-			fakeDisc, ok := clientset.Discovery().(*fakediscovery.FakeDiscovery)
-			Expect(ok).To(BeTrue())
-			fakeDisc.FakedServerVersion = &version.Info{Major: "1", Minor: "abc"}
-
-			reconciler := &DocumentDBReconciler{Clientset: clientset}
-			err := reconciler.validateK8sVersion()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to parse"))
-		})
-
-		It("should return error when major version is not a number", func() {
-			clientset := kubefake.NewSimpleClientset()
-			fakeDisc, ok := clientset.Discovery().(*fakediscovery.FakeDiscovery)
-			Expect(ok).To(BeTrue())
-			fakeDisc.FakedServerVersion = &version.Info{Major: "abc", Minor: "35"}
-
-			reconciler := &DocumentDBReconciler{Clientset: clientset}
-			err := reconciler.validateK8sVersion()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to parse Kubernetes major version"))
 		})
 	})
 

--- a/operator/src/internal/utils/constants.go
+++ b/operator/src/internal/utils/constants.go
@@ -32,10 +32,6 @@ const (
 	DOCUMENTDB_EXTENSION_IMAGE_REPO = "ghcr.io/documentdb/documentdb-kubernetes-operator/documentdb"
 	GATEWAY_IMAGE_REPO              = "ghcr.io/documentdb/documentdb-kubernetes-operator/gateway"
 
-	// MinK8sMinorVersion is the minimum required Kubernetes minor version.
-	// The operator requires K8s 1.35+ for ImageVolume GA support.
-	MinK8sMinorVersion = 35
-
 	// DEFAULT_DOCUMENTDB_IMAGE is the extension image used in ImageVolume mode.
 	DEFAULT_DOCUMENTDB_IMAGE = DOCUMENTDB_EXTENSION_IMAGE_REPO + ":0.110.0"
 	// NOTE: Keep in sync with operator/cnpg-plugins/sidecar-injector/internal/config/config.go:applyDefaults()

--- a/operator/src/internal/webhook/documentdb_webhook.go
+++ b/operator/src/internal/webhook/documentdb_webhook.go
@@ -47,8 +47,18 @@ func (v *DocumentDBValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:webhook:path=/validate-documentdb-io-preview-documentdb,mutating=false,failurePolicy=fail,sideEffects=None,groups=documentdb.io,resources=dbs,verbs=create;update,versions=preview,name=vdocumentdb.kb.io,admissionReviewVersions=v1
 
 // ValidateCreate validates a DocumentDB resource on creation.
-func (v *DocumentDBValidator) ValidateCreate(_ context.Context, documentdb *dbpreview.DocumentDB) (admission.Warnings, error) {
+func (v *DocumentDBValidator) ValidateCreate(ctx context.Context, documentdb *dbpreview.DocumentDB) (admission.Warnings, error) {
 	documentdbLog.Info("Validation for DocumentDB upon creation", "name", documentdb.Name, "namespace", documentdb.Namespace)
+
+	// Cluster-capability preflight: block creation up-front when the cluster
+	// does not support the ImageVolume feature the operator relies on to mount
+	// the DocumentDB extension. Runs only on create because it reflects a
+	// cluster-wide capability, not a per-spec property.
+	if err := v.ensureImageVolumeSupported(ctx, documentdb.Namespace); err != nil {
+		return nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "documentdb.io", Resource: "dbs"},
+			documentdb.Name, err)
+	}
 
 	allErrs := v.validate(documentdb)
 	if len(allErrs) == 0 {

--- a/operator/src/internal/webhook/documentdb_webhook_test.go
+++ b/operator/src/internal/webhook/documentdb_webhook_test.go
@@ -242,7 +242,12 @@ var _ = Describe("ValidateCreate admission handler", func() {
 	var v *DocumentDBValidator
 
 	BeforeEach(func() {
-		v = &DocumentDBValidator{}
+		// ValidateCreate now runs the ImageVolume capability probe, which
+		// issues dry-run Pod creates. Back the validator with a client that
+		// models a cluster where ImageVolume is supported so these specs
+		// exercise the spec-level validation path.
+		imageVolumeConfirmed.Store(false)
+		v = newValidatorWithCreate(nil, acceptAll)
 	})
 
 	It("allows a valid DocumentDB resource", func() {
@@ -256,6 +261,14 @@ var _ = Describe("ValidateCreate admission handler", func() {
 		db := newTestDocumentDB("0.110.0", "0.112.0", "")
 		_, err := v.ValidateCreate(context.Background(), db)
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("blocks creation when the cluster lacks ImageVolume support", func() {
+		v = newValidatorWithCreate(nil, rejectImageVolume)
+		db := newTestDocumentDB("0.112.0", "", "")
+		_, err := v.ValidateCreate(context.Background(), db)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("ImageVolume feature is not enabled"))
 	})
 })
 

--- a/operator/src/internal/webhook/imagevolume.go
+++ b/operator/src/internal/webhook/imagevolume.go
@@ -60,9 +60,9 @@ func (v *DocumentDBValidator) ensureImageVolumeSupported(ctx context.Context, na
 		"the Kubernetes ImageVolume feature is not enabled on this cluster, but it is required by the DocumentDB " +
 			"operator to mount the DocumentDB extension into PostgreSQL pods. ImageVolume is GA (on by default) in " +
 			"Kubernetes 1.35+. On Kubernetes 1.33/1.34 you may enable the ImageVolume feature gate on both the " +
-			"kube-apiserver and every kubelet, and ensure the container runtime supports it (containerd >= 2.1 or " +
-			"CRI-O >= 1.33). Managed offerings (AKS/EKS/GKE) generally cannot enable this before it ships on by " +
-			"default. See https://kubernetes.io/docs/concepts/storage/volumes/#image",
+			"kube-apiserver and every kubelet; the container runtime must also support it (containerd >= 2.1 or " +
+			"CRI-O >= 1.33), which this preflight cannot verify. " +
+			"See https://kubernetes.io/docs/concepts/storage/volumes/#image",
 	)
 }
 

--- a/operator/src/internal/webhook/imagevolume.go
+++ b/operator/src/internal/webhook/imagevolume.go
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// imageVolumeProbeImage is a syntactically valid image reference used only for
+// the dry-run capability probe. It is never pulled or scheduled because every
+// probe Pod is submitted with client.DryRunAll.
+const imageVolumeProbeImage = "registry.k8s.io/pause:3.10"
+
+// imageVolumeProbeVolumeName is the volume/mount name shared by both probe Pods.
+const imageVolumeProbeVolumeName = "probe"
+
+// imageVolumeConfirmed caches a positive detection of ImageVolume support.
+//
+// Only positive results are cached: once the cluster is known to support
+// ImageVolume, subsequent creates skip the probe entirely (steady-state
+// latency ~0). A negative or inconclusive result is never cached, so if an
+// administrator enables the feature gate later the next create re-probes and
+// succeeds without restarting the operator.
+var imageVolumeConfirmed atomic.Bool
+
+// ensureImageVolumeSupported blocks DocumentDB creation when the cluster does
+// not support the Kubernetes ImageVolume feature (feature gate off, or a
+// runtime/version that lacks it). The operator mounts the DocumentDB extension
+// into the PostgreSQL pod via a corev1.ImageVolumeSource, so without this
+// feature the cluster can never become ready.
+//
+// The check is intentionally fail-open: it blocks only when it can positively
+// prove the feature is unavailable. If the cluster environment prevents a
+// conclusive answer (e.g. Pod Security Admission or a ResourceQuota rejects the
+// baseline probe Pod), creation is allowed and the reconcile loop surfaces any
+// real failure later.
+func (v *DocumentDBValidator) ensureImageVolumeSupported(ctx context.Context, namespace string) error {
+	if imageVolumeConfirmed.Load() {
+		return nil
+	}
+
+	supported, conclusive := v.probeImageVolume(ctx, namespace)
+	if !conclusive {
+		// Could not determine support; do not block on an inconclusive probe.
+		return nil
+	}
+	if supported {
+		imageVolumeConfirmed.Store(true)
+		return nil
+	}
+
+	return fmt.Errorf(
+		"the Kubernetes ImageVolume feature is not enabled on this cluster, but it is required by the DocumentDB " +
+			"operator to mount the DocumentDB extension into PostgreSQL pods. ImageVolume is GA (on by default) in " +
+			"Kubernetes 1.35+. On Kubernetes 1.33/1.34 you may enable the ImageVolume feature gate on both the " +
+			"kube-apiserver and every kubelet, and ensure the container runtime supports it (containerd >= 2.1 or " +
+			"CRI-O >= 1.33). Managed offerings (AKS/EKS/GKE) generally cannot enable this before it ships on by " +
+			"default. See https://kubernetes.io/docs/concepts/storage/volumes/#image",
+	)
+}
+
+// probeImageVolume performs a differential server-side dry-run to detect
+// ImageVolume support without relying on error-string matching.
+//
+// It submits two dry-run Pods that are identical except for a single volume:
+//   - baseline: an emptyDir volume (always a valid volume source), and
+//   - image:    an ImageVolumeSource volume.
+//
+// Interpretation:
+//   - baseline rejected           -> the environment blocks pod creation
+//     entirely (PSA, quota, other webhooks); inconclusive.
+//   - baseline ok, image ok       -> ImageVolume is supported.
+//   - baseline ok, image rejected -> the image volume is the sole difference,
+//     so ImageVolume is unsupported.
+//
+// The second return value reports whether the result is conclusive.
+func (v *DocumentDBValidator) probeImageVolume(ctx context.Context, namespace string) (supported bool, conclusive bool) {
+	if err := v.dryRunProbePod(ctx, namespace, baselineProbeVolume()); err != nil {
+		documentdbLog.Info("ImageVolume preflight inconclusive: baseline probe pod rejected", "error", err.Error())
+		return false, false
+	}
+
+	if err := v.dryRunProbePod(ctx, namespace, imageProbeVolume()); err != nil {
+		documentdbLog.Info("ImageVolume preflight: image-volume probe pod rejected while baseline passed; feature unavailable", "error", err.Error())
+		return false, true
+	}
+
+	return true, true
+}
+
+// dryRunProbePod submits a minimal Pod carrying the given probe volume as a
+// server-side dry-run (never persisted) and returns the API server's verdict.
+func (v *DocumentDBValidator) dryRunProbePod(ctx context.Context, namespace string, volume corev1.Volume) error {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "documentdb-imagevolume-preflight-",
+			Namespace:    namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "probe",
+				Image: imageVolumeProbeImage,
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      imageVolumeProbeVolumeName,
+					MountPath: "/probe",
+				}},
+			}},
+			Volumes: []corev1.Volume{volume},
+		},
+	}
+	return v.Create(ctx, pod, client.DryRunAll)
+}
+
+// baselineProbeVolume returns an emptyDir volume, which every Kubernetes
+// version accepts. It establishes whether the environment permits creating the
+// probe Pod at all.
+func baselineProbeVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: imageVolumeProbeVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
+// imageProbeVolume returns an ImageVolumeSource volume, the feature under test.
+func imageProbeVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: imageVolumeProbeVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Image: &corev1.ImageVolumeSource{
+				Reference:  imageVolumeProbeImage,
+				PullPolicy: corev1.PullIfNotPresent,
+			},
+		},
+	}
+}

--- a/operator/src/internal/webhook/imagevolume.go
+++ b/operator/src/internal/webhook/imagevolume.go
@@ -93,13 +93,13 @@ func (v *DocumentDBValidator) ensureImageVolumeSupported(ctx context.Context, na
 // The second return value reports whether the result is conclusive.
 func (v *DocumentDBValidator) probeImageVolume(ctx context.Context, namespace string) (supported bool, conclusive bool) {
 	if _, err := v.dryRunProbePod(ctx, namespace, baselineProbeVolume()); err != nil {
-		documentdbLog.Info("ImageVolume preflight inconclusive: baseline probe pod rejected", "error", err.Error())
+		documentdbLog.Info("ImageVolume preflight inconclusive: baseline probe pod rejected", "error", err)
 		return false, false
 	}
 
 	returned, err := v.dryRunProbePod(ctx, namespace, imageProbeVolume())
 	if err != nil {
-		documentdbLog.Info("ImageVolume preflight: image-volume probe pod rejected while baseline passed; feature unavailable", "error", err.Error())
+		documentdbLog.Info("ImageVolume preflight: image-volume probe pod rejected while baseline passed; feature unavailable", "error", err)
 		return false, true
 	}
 

--- a/operator/src/internal/webhook/imagevolume.go
+++ b/operator/src/internal/webhook/imagevolume.go
@@ -74,30 +74,62 @@ func (v *DocumentDBValidator) ensureImageVolumeSupported(ctx context.Context, na
 //   - image:    an ImageVolumeSource volume.
 //
 // Interpretation:
-//   - baseline rejected           -> the environment blocks pod creation
+//   - baseline rejected             -> the environment blocks pod creation
 //     entirely (PSA, quota, other webhooks); inconclusive.
-//   - baseline ok, image ok       -> ImageVolume is supported.
-//   - baseline ok, image rejected -> the image volume is the sole difference,
+//   - baseline ok, image rejected   -> the image volume is the sole difference,
 //     so ImageVolume is unsupported.
+//   - baseline ok, image accepted but the ImageVolumeSource was pruned from the
+//     returned Pod -> the feature gate is off, so the API server silently drops
+//     the disabled field instead of rejecting it; ImageVolume is unsupported.
+//   - baseline ok, image accepted and the ImageVolumeSource survived -> the
+//     feature is supported.
+//
+// The pruning case is the important one: on Kubernetes 1.33/1.34 with the
+// ImageVolume beta gate OFF, a dry-run create does NOT fail; the API server
+// admits the Pod and simply strips the unknown/disabled volume source. Relying
+// on a create error alone therefore false-positives as "supported". We close
+// that gap by inspecting the returned object for field retention.
 //
 // The second return value reports whether the result is conclusive.
 func (v *DocumentDBValidator) probeImageVolume(ctx context.Context, namespace string) (supported bool, conclusive bool) {
-	if err := v.dryRunProbePod(ctx, namespace, baselineProbeVolume()); err != nil {
+	if _, err := v.dryRunProbePod(ctx, namespace, baselineProbeVolume()); err != nil {
 		documentdbLog.Info("ImageVolume preflight inconclusive: baseline probe pod rejected", "error", err.Error())
 		return false, false
 	}
 
-	if err := v.dryRunProbePod(ctx, namespace, imageProbeVolume()); err != nil {
+	returned, err := v.dryRunProbePod(ctx, namespace, imageProbeVolume())
+	if err != nil {
 		documentdbLog.Info("ImageVolume preflight: image-volume probe pod rejected while baseline passed; feature unavailable", "error", err.Error())
+		return false, true
+	}
+
+	if !hasImageVolume(returned) {
+		documentdbLog.Info("ImageVolume preflight: image-volume probe pod admitted but the ImageVolumeSource was pruned from the returned spec; feature gate is off, feature unavailable")
 		return false, true
 	}
 
 	return true, true
 }
 
+// hasImageVolume reports whether the server-returned Pod still carries the probe
+// volume as an ImageVolumeSource. When the ImageVolume feature gate is off the
+// API server prunes the field, so its absence means the feature is unavailable.
+func hasImageVolume(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Name == imageVolumeProbeVolumeName {
+			return vol.Image != nil
+		}
+	}
+	return false
+}
+
 // dryRunProbePod submits a minimal Pod carrying the given probe volume as a
-// server-side dry-run (never persisted) and returns the API server's verdict.
-func (v *DocumentDBValidator) dryRunProbePod(ctx context.Context, namespace string, volume corev1.Volume) error {
+// server-side dry-run (never persisted) and returns the Pod as processed by the
+// API server (with defaulting and field pruning applied) alongside its verdict.
+func (v *DocumentDBValidator) dryRunProbePod(ctx context.Context, namespace string, volume corev1.Volume) (*corev1.Pod, error) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "documentdb-imagevolume-preflight-",
@@ -115,7 +147,8 @@ func (v *DocumentDBValidator) dryRunProbePod(ctx context.Context, namespace stri
 			Volumes: []corev1.Volume{volume},
 		},
 	}
-	return v.Create(ctx, pod, client.DryRunAll)
+	err := v.Create(ctx, pod, client.DryRunAll)
+	return pod, err
 }
 
 // baselineProbeVolume returns an emptyDir volume, which every Kubernetes

--- a/operator/src/internal/webhook/imagevolume_test.go
+++ b/operator/src/internal/webhook/imagevolume_test.go
@@ -80,6 +80,23 @@ func rejectAll(_ client.Object) error {
 	return fmt.Errorf("pods \"probe\" is forbidden: violates PodSecurity \"restricted:latest\"")
 }
 
+// pruneImageVolume models a Kubernetes 1.33/1.34 API server with the ImageVolume
+// beta gate OFF: the Pod is admitted (no error), but the API server silently
+// strips the disabled ImageVolumeSource from the stored/returned spec. This is
+// the failure mode that a plain error check misses.
+func pruneImageVolume(obj client.Object) error {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].VolumeSource.Image != nil {
+			pod.Spec.Volumes[i].VolumeSource.Image = nil
+		}
+	}
+	return nil
+}
+
 var _ = Describe("ImageVolume capability probe", func() {
 	BeforeEach(func() {
 		// The positive-result cache is a package global; reset it so specs
@@ -102,6 +119,13 @@ var _ = Describe("ImageVolume capability probe", func() {
 			Expect(supported).To(BeFalse())
 		})
 
+		It("reports unsupported when the image volume is admitted but pruned (gate off)", func() {
+			v := newValidatorWithCreate(nil, pruneImageVolume)
+			supported, conclusive := v.probeImageVolume(context.Background(), "default")
+			Expect(conclusive).To(BeTrue())
+			Expect(supported).To(BeFalse())
+		})
+
 		It("is inconclusive when the baseline Pod is rejected", func() {
 			v := newValidatorWithCreate(nil, rejectAll)
 			supported, conclusive := v.probeImageVolume(context.Background(), "default")
@@ -119,6 +143,14 @@ var _ = Describe("ImageVolume capability probe", func() {
 
 		It("blocks creation with an actionable error when unsupported", func() {
 			v := newValidatorWithCreate(nil, rejectImageVolume)
+			err := v.ensureImageVolumeSupported(context.Background(), "default")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ImageVolume feature is not enabled"))
+			Expect(imageVolumeConfirmed.Load()).To(BeFalse())
+		})
+
+		It("blocks creation when the image volume is admitted but pruned (gate off)", func() {
+			v := newValidatorWithCreate(nil, pruneImageVolume)
 			err := v.ensureImageVolumeSupported(context.Background(), "default")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("ImageVolume feature is not enabled"))

--- a/operator/src/internal/webhook/imagevolume_test.go
+++ b/operator/src/internal/webhook/imagevolume_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// podHasImageVolume reports whether any of the Pod's volumes uses an
+// ImageVolumeSource — the field a gate-off API server rejects.
+func podHasImageVolume(obj client.Object) bool {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return false
+	}
+	for _, vol := range pod.Spec.Volumes {
+		if vol.VolumeSource.Image != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// probeScheme returns a scheme that knows about core/v1 Pods.
+func probeScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+// newValidatorWithCreate builds a DocumentDBValidator backed by a fake client
+// whose Create behaviour is supplied by createFn — modelling how a particular
+// API server responds to the probe Pods. createCount, when non-nil, is
+// incremented on every intercepted Create so tests can assert whether the
+// probe ran at all.
+func newValidatorWithCreate(createCount *int32, createFn func(obj client.Object) error) *DocumentDBValidator {
+	c := fake.NewClientBuilder().
+		WithScheme(probeScheme()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+				if createCount != nil {
+					atomic.AddInt32(createCount, 1)
+				}
+				return createFn(obj)
+			},
+		}).
+		Build()
+	return &DocumentDBValidator{Client: c}
+}
+
+// acceptAll models an API server with ImageVolume enabled: every probe Pod is
+// admitted.
+func acceptAll(_ client.Object) error { return nil }
+
+// rejectImageVolume models an API server with the ImageVolume gate OFF: the
+// baseline (emptyDir) probe is admitted, but any Pod carrying an image volume
+// is rejected.
+func rejectImageVolume(obj client.Object) error {
+	if podHasImageVolume(obj) {
+		return fmt.Errorf("Pod \"probe\" is invalid: spec.volumes[0].image: Forbidden: image volumes are disabled by feature-gate")
+	}
+	return nil
+}
+
+// rejectAll models an environment (PSA, ResourceQuota, another webhook) that
+// blocks the baseline probe Pod, making the result inconclusive.
+func rejectAll(_ client.Object) error {
+	return fmt.Errorf("pods \"probe\" is forbidden: violates PodSecurity \"restricted:latest\"")
+}
+
+var _ = Describe("ImageVolume capability probe", func() {
+	BeforeEach(func() {
+		// The positive-result cache is a package global; reset it so specs
+		// don't leak state into one another.
+		imageVolumeConfirmed.Store(false)
+	})
+
+	Describe("probeImageVolume", func() {
+		It("reports supported when both probe Pods are admitted", func() {
+			v := newValidatorWithCreate(nil, acceptAll)
+			supported, conclusive := v.probeImageVolume(context.Background(), "default")
+			Expect(conclusive).To(BeTrue())
+			Expect(supported).To(BeTrue())
+		})
+
+		It("reports unsupported when only the image-volume Pod is rejected", func() {
+			v := newValidatorWithCreate(nil, rejectImageVolume)
+			supported, conclusive := v.probeImageVolume(context.Background(), "default")
+			Expect(conclusive).To(BeTrue())
+			Expect(supported).To(BeFalse())
+		})
+
+		It("is inconclusive when the baseline Pod is rejected", func() {
+			v := newValidatorWithCreate(nil, rejectAll)
+			supported, conclusive := v.probeImageVolume(context.Background(), "default")
+			Expect(conclusive).To(BeFalse())
+			Expect(supported).To(BeFalse())
+		})
+	})
+
+	Describe("ensureImageVolumeSupported", func() {
+		It("allows creation and caches the positive result when supported", func() {
+			v := newValidatorWithCreate(nil, acceptAll)
+			Expect(v.ensureImageVolumeSupported(context.Background(), "default")).To(Succeed())
+			Expect(imageVolumeConfirmed.Load()).To(BeTrue())
+		})
+
+		It("blocks creation with an actionable error when unsupported", func() {
+			v := newValidatorWithCreate(nil, rejectImageVolume)
+			err := v.ensureImageVolumeSupported(context.Background(), "default")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ImageVolume feature is not enabled"))
+			Expect(imageVolumeConfirmed.Load()).To(BeFalse())
+		})
+
+		It("fails open (allows creation) on an inconclusive probe without caching", func() {
+			v := newValidatorWithCreate(nil, rejectAll)
+			Expect(v.ensureImageVolumeSupported(context.Background(), "default")).To(Succeed())
+			Expect(imageVolumeConfirmed.Load()).To(BeFalse())
+		})
+
+		It("short-circuits without probing once the positive result is cached", func() {
+			var creates int32
+			// This client would reject the image-volume probe, so a call that
+			// actually probed would error — proving the cache short-circuit.
+			v := newValidatorWithCreate(&creates, rejectImageVolume)
+			imageVolumeConfirmed.Store(true)
+
+			Expect(v.ensureImageVolumeSupported(context.Background(), "default")).To(Succeed())
+			Expect(atomic.LoadInt32(&creates)).To(BeZero())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

The operator hard-depends on the Kubernetes **ImageVolume** feature
(`corev1.ImageVolumeSource`) to mount the DocumentDB extension into PostgreSQL
pods. Previously, on a cluster lacking that feature the pods would simply hang
with no clear signal, and a coarse "k8s ≥ 1.35" startup gate blocked otherwise-
capable 1.33/1.34 clusters.

This PR makes the operator **fail fast with an actionable error** at
`DocumentDB` creation, and replaces the version gate with a **capability probe**
so any cluster that actually has ImageVolume — including 1.33/1.34 with the beta
gate enabled — is admitted.

Closes #431.

## How it works

Detection is **capability-based, not version-based**: the validating webhook
runs a differential server-side dry-run — an `emptyDir` baseline Pod plus an
identical `ImageVolumeSource` Pod:

| baseline | image volume | verdict |
|---|---|---|
| accepted | accepted | **supported → admit** |
| accepted | rejected | **unsupported → block (403 Forbidden, actionable message)** |
| rejected | — | **inconclusive** (PSA/quota/other webhook) → admit (fail-open) |

Only positive results are cached (`atomic.Bool`), so steady-state create latency
is ~0, and enabling the gate later works without restarting the operator. No new
RBAC — the operator ClusterRole already grants `create` on pods.

## Changes

- **`internal/webhook/imagevolume.go`** — capability probe
  (`ensureImageVolumeSupported` + `probeImageVolume`) with an actionable error
  message.
- **`internal/webhook/documentdb_webhook.go`** — `ValidateCreate` runs the
  preflight first (create-only; it's a cluster capability, not a per-spec
  property), returning `apierrors.NewForbidden` on failure. Kept separate from
  spec validation (`v.validate`), which stays pure and returns 422 Invalid.
- **Replaced the coarse k8s ≥ 1.35 gate** with the probe as the single source of
  truth: removed `validateK8sVersion()` + its `SetupWithManager` call and the
  `util.MinK8sMinorVersion` constant; relaxed `Chart.yaml` `kubeVersion` from
  `>= 1.35.0-0` to `>= 1.33.0-0`.
- **Unit tests** (`imagevolume_test.go`) covering supported / unsupported /
  inconclusive / cache-short-circuit + admission-handler coverage.
- **CI** — `setup-test-environment` gains an opt-in `enable-image-volume-gate`
  input (writes a kind config with `featureGates: {ImageVolume: true}`), and a
  standalone `imagevolume-preflight` job (k8s **1.33.7** and **1.34.3**, gate on)
  proves the operator admits a DocumentDB **and reaches Healthy** — i.e. the
  extension image mounts at runtime. The gate-off/blocked path is covered by the
  unit tests.
- **Docs** — `before-you-start.md` + `faq.md` now describe the capability-based
  requirement: 1.35+ recommended (GA, on by default); 1.33/1.34 supported with
  the gate enabled (containerd ≥ 2.1 / CRI-O ≥ 1.33); managed offerings generally
  can't toggle the gate.

## Behavior matrix

| K8s | ImageVolume | Result |
|---|---|---|
| ≥ 1.35 | on (default) | admitted ✅ |
| 1.33–1.34 | gate enabled | admitted ✅ (CI-verified) |
| any | unavailable | blocked with actionable error ❌ |
| any | probe inconclusive (PSA/quota) | admitted (fail-open) |

## Testing

- `go build ./...`, `go vet ./...` — clean
- `go test ./internal/webhook/...` — pass
- `helm lint` — pass
- New `imagevolume-preflight` CI job exercises k8s 1.33/1.34 with the gate on.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
