### PR TITLE
chore: bump default DocumentDB version to 0.113.0

### DIFF
--- a/.github/dockerfiles/Dockerfile_gateway_public_image
+++ b/.github/dockerfiles/Dockerfile_gateway_public_image
@@ -1,4 +1,4 @@
-ARG SOURCE_IMAGE=ghcr.io/documentdb/documentdb/documentdb-local:pg17-0.110.0
+ARG SOURCE_IMAGE=ghcr.io/documentdb/documentdb/documentdb-local:pg17-0.113.0
 FROM ${SOURCE_IMAGE} AS source
 
 FROM debian:trixie-slim

--- a/.github/workflows/build_documentdb_images.yml
+++ b/.github/workflows/build_documentdb_images.yml
@@ -68,10 +68,12 @@ jobs:
         SHORT_SHA=$(echo "$GITHUB_SHA" | cut -c1-7)
         IMAGE_TAG="${VERSION}-build-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${SHORT_SHA}"
         GATEWAY_SOURCE_IMAGE="${{ env.DOCUMENTDB_GATEWAY_IMAGE_REPO }}:pg17-${VERSION}"
-        echo "documentdb_version=$VERSION" >> $GITHUB_OUTPUT
-        echo "documentdb_version_dash=$VERSION_DASH" >> $GITHUB_OUTPUT
-        echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
-        echo "gateway_source_image=$GATEWAY_SOURCE_IMAGE" >> $GITHUB_OUTPUT
+        {
+          echo "documentdb_version=$VERSION"
+          echo "documentdb_version_dash=$VERSION_DASH"
+          echo "image_tag=$IMAGE_TAG"
+          echo "gateway_source_image=$GATEWAY_SOURCE_IMAGE"
+        } >> "$GITHUB_OUTPUT"
         echo "DocumentDB version: $VERSION"
         echo "Release tag: v$VERSION_DASH"
         echo "Candidate image tag: $IMAGE_TAG"
@@ -214,14 +216,16 @@ jobs:
     steps:
     - name: Summary
       run: |
-        echo "## DocumentDB Image Build Summary" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "- **DocumentDB Version**: \`${{ needs.resolve-public-artifacts.outputs.documentdb_version }}\`" >> $GITHUB_STEP_SUMMARY
-        echo "- **Candidate Image Tag**: \`${{ needs.resolve-public-artifacts.outputs.image_tag }}\`" >> $GITHUB_STEP_SUMMARY
-        echo "- **Extension Package Source**: \`https://github.com/${{ env.DOCUMENTDB_EXTENSION_GITHUB_REPO }}/releases/download/v${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}/deb13-postgresql-18-documentdb_${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}_{amd64,arm64}.deb\`" >> $GITHUB_STEP_SUMMARY
-        echo "- **Gateway Source Image**: \`${{ needs.resolve-public-artifacts.outputs.gateway_source_image }}\`" >> $GITHUB_STEP_SUMMARY
-        echo "- **Images**: documentdb, gateway" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "To release these images, run \`release_documentdb_images.yml\` with:" >> $GITHUB_STEP_SUMMARY
-        echo "- candidate_version: \`${{ needs.resolve-public-artifacts.outputs.image_tag }}\`" >> $GITHUB_STEP_SUMMARY
-        echo "- version: \`${{ needs.resolve-public-artifacts.outputs.documentdb_version }}\`" >> $GITHUB_STEP_SUMMARY
+        {
+          echo "## DocumentDB Image Build Summary"
+          echo ""
+          echo "- **DocumentDB Version**: \`${{ needs.resolve-public-artifacts.outputs.documentdb_version }}\`"
+          echo "- **Candidate Image Tag**: \`${{ needs.resolve-public-artifacts.outputs.image_tag }}\`"
+          echo "- **Extension Package Source**: \`https://github.com/${{ env.DOCUMENTDB_EXTENSION_GITHUB_REPO }}/releases/download/v${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}/deb13-postgresql-18-documentdb_${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}_{amd64,arm64}.deb\`"
+          echo "- **Gateway Source Image**: \`${{ needs.resolve-public-artifacts.outputs.gateway_source_image }}\`"
+          echo "- **Images**: documentdb, gateway"
+          echo ""
+          echo "To release these images, run \`release_documentdb_images.yml\` with:"
+          echo "- candidate_version: \`${{ needs.resolve-public-artifacts.outputs.image_tag }}\`"
+          echo "- version: \`${{ needs.resolve-public-artifacts.outputs.documentdb_version }}\`"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build_documentdb_images.yml
+++ b/.github/workflows/build_documentdb_images.yml
@@ -10,9 +10,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Released DocumentDB version to package (for example 0.110.0)'
+        description: 'Released DocumentDB version to package (for example 0.113.0)'
         required: false
-        default: '0.110.0'
+        default: '0.113.0'
       documentdb_extension_github_repo:
         description: 'GitHub owner/repo for DocumentDB extension releases'
         required: false
@@ -32,7 +32,7 @@ permissions:
 
 env:
 
-  DEFAULT_DOCUMENTDB_VERSION: '0.110.0'
+  DEFAULT_DOCUMENTDB_VERSION: '0.113.0'
   DOCUMENTDB_EXTENSION_GITHUB_REPO: ${{ github.event.inputs.documentdb_extension_github_repo || 'documentdb/documentdb' }}
   DOCUMENTDB_GATEWAY_IMAGE_REPO: ${{ github.event.inputs.documentdb_gateway_image_repo || 'ghcr.io/documentdb/documentdb/documentdb-local' }}
 
@@ -61,7 +61,7 @@ jobs:
           VERSION="$RAW_VERSION"
         fi
         if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "Version must use dotted semver format (for example 0.110.0), got: $RAW_VERSION" >&2
+          echo "Version must use dotted semver format (for example 0.113.0), got: $RAW_VERSION" >&2
           exit 1
         fi
         VERSION_DASH=$(echo "$VERSION" | sed -E 's/^([0-9]+\.[0-9]+)\.([0-9]+)$/\1-\2/')

--- a/.github/workflows/release_documentdb_images.yml
+++ b/.github/workflows/release_documentdb_images.yml
@@ -14,7 +14,7 @@ on:
       version:
         description: 'Database image release version (e.g., 0.111.0)'
         required: true
-        default: '0.110.0'
+        default: '0.113.0'
       update_defaults:
         description: 'Create PR to update default image versions in code'
         required: false

--- a/.github/workflows/release_documentdb_images.yml
+++ b/.github/workflows/release_documentdb_images.yml
@@ -184,14 +184,16 @@ jobs:
 
       - name: Release summary
         run: |
-          echo "## DocumentDB Image Release Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Database Version**: \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Images Promoted**: documentdb, gateway" >> $GITHUB_STEP_SUMMARY
-          echo "- **Source Tag**: \`${{ inputs.candidate_version }}\` → \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## DocumentDB Image Release Summary"
+            echo ""
+            echo "- **Database Version**: \`${{ inputs.version }}\`"
+            echo "- **Images Promoted**: documentdb, gateway"
+            echo "- **Source Tag**: \`${{ inputs.candidate_version }}\` → \`${{ inputs.version }}\`"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
           if [[ "${{ steps.current.outputs.current_version }}" != "${{ inputs.version }}" ]]; then
-            echo "- **PR Created**: Updates default versions from \`${{ steps.current.outputs.current_version }}\` to \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- **PR Created**: Updates default versions from \`${{ steps.current.outputs.current_version }}\` to \`${{ inputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- **No PR needed**: Version \`${{ inputs.version }}\` is already the default" >> $GITHUB_STEP_SUMMARY
+            echo "- **No PR needed**: Version \`${{ inputs.version }}\` is already the default" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ The project uses **two independent version tracks** for container images:
 | Track | Images | Version Source | Tag Example |
 |-------|--------|---------------|-------------|
 | **Operator** | operator, sidecar, wal-replica | `Chart.appVersion` | `0.2.0` |
-| **Database** | documentdb (extension), gateway | `values.yaml` → `documentDbVersion` | `0.110.0` |
+| **Database** | documentdb (extension), gateway | `values.yaml` → `documentDbVersion` | `0.113.0` |
 
 - Operator images are built from this repo's Go source
 - Database images are built from public `documentdb/documentdb` release artifacts (extension `.deb` + gateway payload from `documentdb-local`)

--- a/docs/designs/image-management.md
+++ b/docs/designs/image-management.md
@@ -64,10 +64,10 @@ The two version tracks are **independent** — they follow different release cad
 | **Images** | operator, sidecar, wal-replica | documentdb, gateway |
 | **Source repo** | This repo (Go) | `documentdb/documentdb` (C + Rust) |
 | **Version source** | `Chart.appVersion` in `Chart.yaml` | `documentDbVersion` in `values.yaml` |
-| **Current version** | `0.2.0` | `0.110.0` |
+| **Current version** | `0.2.0` | `0.113.0` |
 | **Build workflow** | `build_operator_images.yml` | `build_documentdb_images.yml` |
 | **Release workflow** | `release_operator.yml` | `release_documentdb_images.yml` |
-| **Tag example** | `ghcr.io/.../operator:0.2.0` | `ghcr.io/.../documentdb:0.110.0` |
+| **Tag example** | `ghcr.io/.../operator:0.2.0` | `ghcr.io/.../documentdb:0.113.0` |
 
 ### Why Two Tracks?
 
@@ -148,7 +148,7 @@ appVersion: "0.1.3"       # Default tag for operator/sidecar/wal-replica images
 
 ```yaml
 # Database image version (extension + gateway) — independent of Chart.appVersion
-documentDbVersion: "0.110.0"
+documentDbVersion: "0.113.0"
 
 image:
   documentdbk8soperator:
@@ -210,7 +210,7 @@ Builds documentdb extension and gateway images from public DocumentDB release ar
 | **Build time** | ~5 minutes (public artifact download + image build) |
 | **Multi-arch** | amd64 + arm64 → multi-arch manifest |
 | **Signing** | cosign keyless (OIDC) |
-| **Version detection** | Workflow input / repository dispatch payload (defaults to released `0.110.0`) |
+| **Version detection** | Workflow input / repository dispatch payload (defaults to released `0.113.0`) |
 
 The build process:
 1. Resolves the released DocumentDB version to package
@@ -368,16 +368,16 @@ When bumping database image versions, the following locations must be updated (a
 
 | File | Field | Example |
 |------|-------|---------|
-| `operator/src/internal/utils/constants.go` | `DEFAULT_DOCUMENTDB_IMAGE` | `...documentdb:0.110.0` |
-| `operator/src/internal/utils/constants.go` | `DEFAULT_GATEWAY_IMAGE` | `...gateway:0.110.0` |
-| `operator/cnpg-plugins/sidecar-injector/internal/config/config.go` | Default gateway image | `...gateway:0.110.0` |
-| `operator/cnpg-plugins/sidecar-injector/internal/config/config_test.go` | Expected gateway image | `...gateway:0.110.0` |
-| `operator/documentdb-helm-chart/values.yaml` | `documentDbVersion` | `"0.110.0"` |
-| `.github/workflows/test-backup-and-restore.yml` | `DOCUMENTDB_IMAGE`, `GATEWAY_IMAGE` env | `...documentdb:0.110.0` |
-| `.github/workflows/test-upgrade-and-rollback.yml` | `RELEASED_DATABASE_VERSION` | `0.110.0` |
-| `.github/workflows/build_documentdb_images.yml` | `DEFAULT_DOCUMENTDB_VERSION`, input default | `0.110.0` |
-| `.github/workflows/release_documentdb_images.yml` | Input default | `0.110.0` |
-| `.github/dockerfiles/Dockerfile_gateway_public_image` | `SOURCE_IMAGE` ARG default | `...pg17-0.110.0` |
+| `operator/src/internal/utils/constants.go` | `DEFAULT_DOCUMENTDB_IMAGE` | `...documentdb:0.113.0` |
+| `operator/src/internal/utils/constants.go` | `DEFAULT_GATEWAY_IMAGE` | `...gateway:0.113.0` |
+| `operator/cnpg-plugins/sidecar-injector/internal/config/config.go` | Default gateway image | `...gateway:0.113.0` |
+| `operator/cnpg-plugins/sidecar-injector/internal/config/config_test.go` | Expected gateway image | `...gateway:0.113.0` |
+| `operator/documentdb-helm-chart/values.yaml` | `documentDbVersion` | `"0.113.0"` |
+| `.github/workflows/test-backup-and-restore.yml` | `DOCUMENTDB_IMAGE`, `GATEWAY_IMAGE` env | `...documentdb:0.113.0` |
+| `.github/workflows/test-upgrade-and-rollback.yml` | `RELEASED_DATABASE_VERSION` | `0.113.0` |
+| `.github/workflows/build_documentdb_images.yml` | `DEFAULT_DOCUMENTDB_VERSION`, input default | `0.113.0` |
+| `.github/workflows/release_documentdb_images.yml` | Input default | `0.113.0` |
+| `.github/dockerfiles/Dockerfile_gateway_public_image` | `SOURCE_IMAGE` ARG default | `...pg17-0.113.0` |
 
 When bumping operator versions, update:
 

--- a/documentdb-playground/aks-setup/scripts/create-cluster.sh
+++ b/documentdb-playground/aks-setup/scripts/create-cluster.sh
@@ -18,7 +18,7 @@ KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.35.0}"
 OPERATOR_GITHUB_ORG="documentdb"
 # Optional: Pin specific versions (by default, installs latest)
 # OPERATOR_CHART_VERSION="0.2.0"    # Operator and sidecar image versions (matches Chart.appVersion)
-# DOCUMENTDB_VERSION="0.110.0"      # Database image version (matches values.yaml documentDbVersion)
+# DOCUMENTDB_VERSION="0.113.0"      # Database image version (matches values.yaml documentDbVersion)
 
 # Feature flags - set to "true" to enable, "false" to skip
 INSTALL_OPERATOR="${INSTALL_OPERATOR:-false}"
@@ -395,7 +395,7 @@ install_documentdb_operator() {
         --timeout 10m
     # To pin specific versions, add these options:
     #   --version ${OPERATOR_CHART_VERSION}                    # Pin operator chart version (e.g., 0.2.0)
-    #   --set documentDbVersion=${DOCUMENTDB_VERSION}          # Pin database image version (e.g., 0.110.0)
+    #   --set documentDbVersion=${DOCUMENTDB_VERSION}          # Pin database image version (e.g., 0.113.0)
     # To use custom image repositories (e.g., for forks), add:
     #   --set image.documentdbk8soperator.repository=ghcr.io/${OPERATOR_GITHUB_ORG}/documentdb-kubernetes-operator/operator
     #   --set image.sidecarinjector.repository=ghcr.io/${OPERATOR_GITHUB_ORG}/documentdb-kubernetes-operator/sidecar

--- a/operator/cnpg-plugins/sidecar-injector/internal/config/config.go
+++ b/operator/cnpg-plugins/sidecar-injector/internal/config/config.go
@@ -184,7 +184,7 @@ func (config *Configuration) applyDefaults() {
 	// Set defaults
 	if config.GatewayImage == "" {
 		// NOTE: Keep in sync with operator/src/internal/utils/constants.go:DEFAULT_GATEWAY_IMAGE
-		config.GatewayImage = "ghcr.io/documentdb/documentdb-kubernetes-operator/gateway:0.110.0"
+		config.GatewayImage = "ghcr.io/documentdb/documentdb-kubernetes-operator/gateway:0.113.0"
 	}
 	if config.GatewayImagePullPolicy == "" {
 		config.GatewayImagePullPolicy = corev1.PullIfNotPresent

--- a/operator/cnpg-plugins/sidecar-injector/internal/config/config_test.go
+++ b/operator/cnpg-plugins/sidecar-injector/internal/config/config_test.go
@@ -36,7 +36,7 @@ func TestApplyDefaults(t *testing.T) {
 	t.Run("sets default gateway image when empty", func(t *testing.T) {
 		config := &Configuration{}
 		config.applyDefaults()
-		expected := "ghcr.io/documentdb/documentdb-kubernetes-operator/gateway:0.110.0"
+		expected := "ghcr.io/documentdb/documentdb-kubernetes-operator/gateway:0.113.0"
 		if config.GatewayImage != expected {
 			t.Errorf("expected %q, got %q", expected, config.GatewayImage)
 		}

--- a/operator/documentdb-helm-chart/tests/02_sidecar_injector_test.yaml
+++ b/operator/documentdb-helm-chart/tests/02_sidecar_injector_test.yaml
@@ -82,7 +82,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: DOCUMENTDB_VERSION
-            value: "0.110.0"
+            value: "0.113.0"
 
   - it: should have empty env when documentDbVersion is empty
     set:

--- a/operator/documentdb-helm-chart/tests/09_operator_deployment_test.yaml
+++ b/operator/documentdb-helm-chart/tests/09_operator_deployment_test.yaml
@@ -71,7 +71,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: DOCUMENTDB_VERSION
-            value: "0.110.0"
+            value: "0.113.0"
 
   - it: should omit DOCUMENTDB_VERSION env when documentDbVersion is empty
     set:

--- a/operator/documentdb-helm-chart/values.yaml
+++ b/operator/documentdb-helm-chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 # which determines the default documentdb extension and gateway image tags at runtime.
 # This version is INDEPENDENT of Chart.appVersion (which controls operator/sidecar image tags).
 # When empty, the operator falls back to its compiled-in defaults (see constants.go).
-documentDbVersion: "0.110.0"
+documentDbVersion: "0.113.0"
 
 # Gateway image pull policy for the gateway sidecar container.
 # Valid values: Always, IfNotPresent, Never. Defaults to IfNotPresent if not set.

--- a/operator/src/internal/cnpg/cnpg_sync_test.go
+++ b/operator/src/internal/cnpg/cnpg_sync_test.go
@@ -50,7 +50,7 @@ func baseCluster(name, namespace string) *cnpgv1.Cluster {
 					{
 						Name: "documentdb",
 						ImageVolumeSource: corev1.ImageVolumeSource{
-							Reference: "ghcr.io/documentdb/documentdb:0.110.0",
+							Reference: "ghcr.io/documentdb/documentdb:0.113.0",
 						},
 					},
 				},
@@ -65,7 +65,7 @@ func baseCluster(name, namespace string) *cnpgv1.Cluster {
 					Name:    util.DEFAULT_SIDECAR_INJECTOR_PLUGIN,
 					Enabled: pointer.Bool(true),
 					Parameters: map[string]string{
-						"gatewayImage":               "ghcr.io/documentdb/gateway:0.110.0",
+						"gatewayImage":               "ghcr.io/documentdb/gateway:0.113.0",
 						"documentDbCredentialSecret": "documentdb-credentials",
 					},
 				},
@@ -90,7 +90,7 @@ var _ = Describe("SyncCnpgCluster", func() {
 	It("detects extension image changes", func() {
 		current := baseCluster("test-cluster", namespace)
 		desired := current.DeepCopy()
-		desired.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference = "ghcr.io/documentdb/documentdb:0.110.0"
+		desired.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference = "ghcr.io/documentdb/documentdb:0.113.0"
 
 		c := buildFakeClient(current).Build()
 		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
@@ -99,13 +99,13 @@ var _ = Describe("SyncCnpgCluster", func() {
 
 		updated := &cnpgv1.Cluster{}
 		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
-		Expect(updated.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference).To(Equal("ghcr.io/documentdb/documentdb:0.110.0"))
+		Expect(updated.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference).To(Equal("ghcr.io/documentdb/documentdb:0.113.0"))
 	})
 
 	It("detects gateway image changes", func() {
 		current := baseCluster("test-cluster", namespace)
 		desired := current.DeepCopy()
-		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.110.0"
+		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.113.0"
 
 		c := buildFakeClient(current).Build()
 		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
@@ -114,7 +114,7 @@ var _ = Describe("SyncCnpgCluster", func() {
 
 		updated := &cnpgv1.Cluster{}
 		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
-		Expect(updated.Spec.Plugins[0].Parameters["gatewayImage"]).To(Equal("ghcr.io/documentdb/gateway:0.110.0"))
+		Expect(updated.Spec.Plugins[0].Parameters["gatewayImage"]).To(Equal("ghcr.io/documentdb/gateway:0.113.0"))
 	})
 
 	It("patches plugin parameters (TLS secret sync)", func() {
@@ -171,8 +171,8 @@ var _ = Describe("SyncCnpgCluster", func() {
 	It("does not add restart annotation when extension image changes", func() {
 		current := baseCluster("test-cluster", namespace)
 		desired := current.DeepCopy()
-		desired.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference = "ghcr.io/documentdb/documentdb:0.110.0"
-		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.110.0"
+		desired.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference = "ghcr.io/documentdb/documentdb:0.113.0"
+		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.113.0"
 
 		c := buildFakeClient(current).Build()
 		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
@@ -181,8 +181,8 @@ var _ = Describe("SyncCnpgCluster", func() {
 
 		updated := &cnpgv1.Cluster{}
 		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
-		Expect(updated.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference).To(Equal("ghcr.io/documentdb/documentdb:0.110.0"))
-		Expect(updated.Spec.Plugins[0].Parameters["gatewayImage"]).To(Equal("ghcr.io/documentdb/gateway:0.110.0"))
+		Expect(updated.Spec.PostgresConfiguration.Extensions[0].ImageVolumeSource.Reference).To(Equal("ghcr.io/documentdb/documentdb:0.113.0"))
+		Expect(updated.Spec.Plugins[0].Parameters["gatewayImage"]).To(Equal("ghcr.io/documentdb/gateway:0.113.0"))
 		// No restart annotation — CNPG handles restart for extension changes
 		Expect(updated.Annotations).ToNot(HaveKey("kubectl.kubernetes.io/restartedAt"))
 	})
@@ -218,7 +218,7 @@ var _ = Describe("SyncCnpgCluster", func() {
 			{
 				Name: "documentdb",
 				ImageVolumeSource: corev1.ImageVolumeSource{
-					Reference: "ghcr.io/documentdb/documentdb:0.110.0",
+					Reference: "ghcr.io/documentdb/documentdb:0.113.0",
 				},
 			},
 		}
@@ -244,7 +244,7 @@ var _ = Describe("SyncCnpgCluster", func() {
 		current.Spec.Plugins = nil // no plugins in current
 
 		desired := baseCluster("test-cluster", namespace)
-		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.110.0"
+		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.113.0"
 
 		c := buildFakeClient(current).Build()
 		err := SyncCnpgCluster(context.Background(), c, current, desired, nil)
@@ -254,7 +254,7 @@ var _ = Describe("SyncCnpgCluster", func() {
 	It("handles gateway and TLS changes together", func() {
 		current := baseCluster("test-cluster", namespace)
 		desired := current.DeepCopy()
-		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.110.0"
+		desired.Spec.Plugins[0].Parameters["gatewayImage"] = "ghcr.io/documentdb/gateway:0.113.0"
 		desired.Spec.Plugins[0].Parameters["gatewayTLSSecret"] = "new-tls-secret"
 
 		c := buildFakeClient(current).Build()
@@ -263,7 +263,7 @@ var _ = Describe("SyncCnpgCluster", func() {
 
 		updated := &cnpgv1.Cluster{}
 		Expect(c.Get(context.Background(), types.NamespacedName{Name: "test-cluster", Namespace: namespace}, updated)).To(Succeed())
-		Expect(updated.Spec.Plugins[0].Parameters["gatewayImage"]).To(Equal("ghcr.io/documentdb/gateway:0.110.0"))
+		Expect(updated.Spec.Plugins[0].Parameters["gatewayImage"]).To(Equal("ghcr.io/documentdb/gateway:0.113.0"))
 		Expect(updated.Spec.Plugins[0].Parameters["gatewayTLSSecret"]).To(Equal("new-tls-secret"))
 		// Restart annotation because gateway updated (no extension change)
 		Expect(updated.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))

--- a/operator/src/internal/utils/constants.go
+++ b/operator/src/internal/utils/constants.go
@@ -33,9 +33,9 @@ const (
 	GATEWAY_IMAGE_REPO              = "ghcr.io/documentdb/documentdb-kubernetes-operator/gateway"
 
 	// DEFAULT_DOCUMENTDB_IMAGE is the extension image used in ImageVolume mode.
-	DEFAULT_DOCUMENTDB_IMAGE = DOCUMENTDB_EXTENSION_IMAGE_REPO + ":0.110.0"
+	DEFAULT_DOCUMENTDB_IMAGE = DOCUMENTDB_EXTENSION_IMAGE_REPO + ":0.113.0"
 	// NOTE: Keep in sync with operator/cnpg-plugins/sidecar-injector/internal/config/config.go:applyDefaults()
-	DEFAULT_GATEWAY_IMAGE                 = GATEWAY_IMAGE_REPO + ":0.110.0"
+	DEFAULT_GATEWAY_IMAGE                 = GATEWAY_IMAGE_REPO + ":0.113.0"
 	DEFAULT_DOCUMENTDB_CREDENTIALS_SECRET = "documentdb-credentials"
 	DEFAULT_OTEL_COLLECTOR_IMAGE          = "otel/opentelemetry-collector-contrib:0.149.0"
 


### PR DESCRIPTION
## What

Bumps the default **database version track** (`documentDbVersion`) from `0.110.0` to `0.113.0`, following the same pattern as #364.

## Why

Ship the newer released DocumentDB extension/gateway images (`documentdb/documentdb` v0.113-0) as the operator's out-of-the-box default. This is independent of `Chart.appVersion` (operator/sidecar track).

## Changes

- `operator/documentdb-helm-chart/values.yaml` — `documentDbVersion`
- `operator/src/internal/utils/constants.go` — `DEFAULT_DOCUMENTDB_IMAGE`, `DEFAULT_GATEWAY_IMAGE`
- `operator/cnpg-plugins/sidecar-injector/internal/config/config.go` (+ test) — default gateway image
- `operator/src/internal/cnpg/cnpg_sync_test.go` — expected default image references
- Helm unit tests: `tests/02_sidecar_injector_test.yaml`, `tests/09_operator_deployment_test.yaml`
- Workflows: `build_documentdb_images.yml`, `release_documentdb_images.yml` defaults
- `.github/dockerfiles/Dockerfile_gateway_public_image` — `SOURCE_IMAGE` ARG
- Docs: `AGENTS.md`, `docs/designs/image-management.md`, `documentdb-playground/aks-setup/scripts/create-cluster.sh`

## Testing

- `go test ./internal/cnpg/... ./internal/utils/...` ✅
- sidecar-injector `go test ./internal/config/...` ✅
- `helm unittest` (02, 09) ✅ 39 tests passing