### PR TITLE
fix: pin CNPG postgres to 18.4 (PG 18.6 segfaults the 0.113.0 DocumentDB extension; unblock E2E) + govulncheck

### DIFF
--- a/.github/workflows/test-unit-coverage.yml
+++ b/.github/workflows/test-unit-coverage.yml
@@ -41,12 +41,13 @@ jobs:
 
       - name: Run unit tests with coverage
         run: |
+          mapfile -t pkgs < <(go list ./... | grep -v /test/e2e)
           go test -coverprofile=coverage.out -covermode=atomic \
             -coverpkg=./... \
-            $(go list ./... | grep -v /test/e2e)
-          
-          echo "## Coverage Summary" >> $GITHUB_STEP_SUMMARY
-          go tool cover -func=coverage.out | tail -1 >> $GITHUB_STEP_SUMMARY
+            "${pkgs[@]}"
+
+          echo "## Coverage Summary" >> "$GITHUB_STEP_SUMMARY"
+          go tool cover -func=coverage.out | tail -1 >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check diff coverage (newly added lines must have >= 90% coverage)
         run: |
@@ -60,14 +61,14 @@ jobs:
           git diff -U0 --no-color --relative origin/${{ github.base_ref }} -- '*.go' ':!**/zz_generated.*.go' > patch.diff
 
           # Run patch coverage analysis with JSON output
-          RESULT=$($(go env GOPATH)/bin/go-patch-cover -o json coverage.out patch.diff)
+          RESULT=$("$(go env GOPATH)"/bin/go-patch-cover -o json coverage.out patch.diff)
           echo "$RESULT" | jq .
 
           # Extract patch coverage percentage
           PATCH_COV=$(echo "$RESULT" | jq -r '.patch_coverage')
           PATCH_STMTS=$(echo "$RESULT" | jq -r '.patch_num_stmt')
           echo "Patch coverage: ${PATCH_COV}% (${PATCH_STMTS} changed statements)"
-          echo "## Diff Coverage: ${PATCH_COV}%" >> $GITHUB_STEP_SUMMARY
+          echo "## Diff Coverage: ${PATCH_COV}%" >> "$GITHUB_STEP_SUMMARY"
 
           # Enforce threshold (skip if no changed statements)
           THRESHOLD=90

--- a/.github/workflows/test-unit-coverage.yml
+++ b/.github/workflows/test-unit-coverage.yml
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
 
 jobs:
   coverage:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
 
 jobs:
   unit-test:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -48,14 +48,14 @@ jobs:
 
       - name: Run unit tests
         run: |
-          go test -v -race -timeout 10m \
-            $(go list ./... | grep -v /test/e2e)
+          mapfile -t pkgs < <(go list ./... | grep -v /test/e2e)
+          go test -v -race -timeout 10m "${pkgs[@]}"
 
       - name: Test Summary
         if: always()
         run: |
-          echo "## Unit Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Unit tests completed" >> $GITHUB_STEP_SUMMARY
+          echo "## Unit Test Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "✅ Unit tests completed" >> "$GITHUB_STEP_SUMMARY"
 
   helm-chart-tests:
     name: Helm Chart Unit Tests
@@ -81,5 +81,5 @@ jobs:
       - name: Test Summary
         if: always()
         run: |
-          echo "## Helm Chart Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Helm chart unit tests completed" >> $GITHUB_STEP_SUMMARY
+          echo "## Helm Chart Test Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "✅ Helm chart unit tests completed" >> "$GITHUB_STEP_SUMMARY"

--- a/documentdb-kubectl-plugin/go.mod
+++ b/documentdb-kubectl-plugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/documentdb/documentdb-operator/documentdb-kubectl-plugin
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/documentdb/documentdb-operator v0.0.0

--- a/operator/cnpg-plugins/sidecar-injector/go.mod
+++ b/operator/cnpg-plugins/sidecar-injector/go.mod
@@ -1,6 +1,6 @@
 module github.com/documentdb/cnpg-i-sidecar-injector
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cloudnative-pg/api v1.25.1

--- a/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
+++ b/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
@@ -1217,7 +1217,7 @@ spec:
                       Gateway sidecar.
                     type: string
                   postgres:
-                    default: ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-minimal-trixie@sha256:229ab83c0639d294042ca747745fb214db690ade64d5d59131a135825b994391
+                    default: ghcr.io/cloudnative-pg/postgresql:18.4-minimal-trixie
                     description: |-
                       Postgres is the container image for the PostgreSQL server.
                       Must be an upstream CNPG-compatible PostgreSQL image (the operator
@@ -1225,10 +1225,12 @@ spec:
                       use trixie (Debian 13) base to match the extension's GLIBC
                       requirements.
 
-                      Pinned to an immutable digest instead of the floating
+                      Pinned to the 18.4 minor tag instead of the floating
                       "18-minimal-trixie" tag, which rolled 18.4 -> 18.6 on 2026-08-13 and
-                      crashed the DocumentDB 0.113.0 extension on insert. Holds PG at 18.4
-                      until a DocumentDB release carrying the PG 18.6 fix ships; revert then.
+                      crashed the DocumentDB 0.113.0 extension on insert. Staying on 18.4
+                      avoids that regression while still receiving CNPG's Debian/PGDG
+                      security rebuilds; revert to the floating "18-minimal-trixie" tag once
+                      a DocumentDB release carrying the PG 18.6 fix ships.
                     type: string
                 type: object
               imagePullSecrets:

--- a/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
+++ b/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
@@ -1217,13 +1217,20 @@ spec:
                       Gateway sidecar.
                     type: string
                   postgres:
-                    default: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+                    default: ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-minimal-trixie@sha256:229ab83c0639d294042ca747745fb214db690ade64d5d59131a135825b994391
                     description: |-
                       Postgres is the container image for the PostgreSQL server.
                       Must be an upstream CNPG-compatible PostgreSQL image (the operator
                       adds the DocumentDB extension via an ImageVolume mount), and must
                       use trixie (Debian 13) base to match the extension's GLIBC
                       requirements.
+
+                      Pinned to an immutable, digest-addressed PostgreSQL 18.4 build rather
+                      than the floating "18-minimal-trixie" tag. On 2026-08-13 that floating
+                      tag rolled from 18.4 to 18.6, and the 18.6 build broke the gateway's
+                      SCRAM-SHA-256 handshake (surfaced to clients as a generic InternalError),
+                      turning the E2E suite deterministically red. Pinning by digest keeps CI
+                      reproducible; bump this deliberately once a newer build is validated.
                     type: string
                 type: object
               imagePullSecrets:

--- a/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
+++ b/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
@@ -1225,18 +1225,12 @@ spec:
                       use trixie (Debian 13) base to match the extension's GLIBC
                       requirements.
 
-                      Pinned to an immutable, digest-addressed PostgreSQL 18.4 build rather
-                      than the floating "18-minimal-trixie" tag. On 2026-08-13 that floating
-                      tag rolled from 18.4 to 18.6, and the shipped DocumentDB 0.113.0
-                      extension segfaults on 18.6: the PostgreSQL backend crashes with
-                      signal 11 inside documentdb_api.insert and, with restart_after_crash
-                      off, the whole instance goes down. Clients see only the downstream
-                      symptom (usually a generic Mongo InternalError). This is an
-                      extension-vs-PG-18.6 ABI incompatibility, reproduced on both CNPG and
-                      vanilla-Debian 18.6, so it is neither a CNPG image nor a gateway/SCRAM
-                      issue. Pinning by digest keeps CI reproducible and holds PostgreSQL at
-                      18.4 until a DocumentDB release built ABI-clean for PG 18 ships; revert
-                      to the floating tag then.
+                      Pinned to an immutable digest instead of the floating
+                      "18-minimal-trixie" tag, which rolled 18.4 -> 18.6 on 2026-08-13 and
+                      crashed the DocumentDB 0.113.0 extension (segfault in
+                      documentdb_api.insert on PG 18.6 — an extension/PG-18.6 ABI
+                      mismatch, not a CNPG or gateway issue). Holds PG at 18.4 until a
+                      DocumentDB release built ABI-clean for PG 18 ships; revert then.
                     type: string
                 type: object
               imagePullSecrets:

--- a/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
+++ b/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
@@ -1227,10 +1227,8 @@ spec:
 
                       Pinned to an immutable digest instead of the floating
                       "18-minimal-trixie" tag, which rolled 18.4 -> 18.6 on 2026-08-13 and
-                      crashed the DocumentDB 0.113.0 extension (segfault in
-                      documentdb_api.insert on PG 18.6 — an extension/PG-18.6 ABI
-                      mismatch, not a CNPG or gateway issue). Holds PG at 18.4 until a
-                      DocumentDB release built ABI-clean for PG 18 ships; revert then.
+                      crashed the DocumentDB 0.113.0 extension on insert. Holds PG at 18.4
+                      until a DocumentDB release carrying the PG 18.6 fix ships; revert then.
                     type: string
                 type: object
               imagePullSecrets:

--- a/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
+++ b/operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml
@@ -1227,10 +1227,16 @@ spec:
 
                       Pinned to an immutable, digest-addressed PostgreSQL 18.4 build rather
                       than the floating "18-minimal-trixie" tag. On 2026-08-13 that floating
-                      tag rolled from 18.4 to 18.6, and the 18.6 build broke the gateway's
-                      SCRAM-SHA-256 handshake (surfaced to clients as a generic InternalError),
-                      turning the E2E suite deterministically red. Pinning by digest keeps CI
-                      reproducible; bump this deliberately once a newer build is validated.
+                      tag rolled from 18.4 to 18.6, and the shipped DocumentDB 0.113.0
+                      extension segfaults on 18.6: the PostgreSQL backend crashes with
+                      signal 11 inside documentdb_api.insert and, with restart_after_crash
+                      off, the whole instance goes down. Clients see only the downstream
+                      symptom (usually a generic Mongo InternalError). This is an
+                      extension-vs-PG-18.6 ABI incompatibility, reproduced on both CNPG and
+                      vanilla-Debian 18.6, so it is neither a CNPG image nor a gateway/SCRAM
+                      issue. Pinning by digest keeps CI reproducible and holds PostgreSQL at
+                      18.4 until a DocumentDB release built ABI-clean for PG 18 ships; revert
+                      to the floating tag then.
                     type: string
                 type: object
               imagePullSecrets:

--- a/operator/src/api/preview/documentdb_types.go
+++ b/operator/src/api/preview/documentdb_types.go
@@ -168,18 +168,12 @@ type ImageSpec struct {
 	// use trixie (Debian 13) base to match the extension's GLIBC
 	// requirements.
 	//
-	// Pinned to an immutable, digest-addressed PostgreSQL 18.4 build rather
-	// than the floating "18-minimal-trixie" tag. On 2026-08-13 that floating
-	// tag rolled from 18.4 to 18.6, and the shipped DocumentDB 0.113.0
-	// extension segfaults on 18.6: the PostgreSQL backend crashes with
-	// signal 11 inside documentdb_api.insert and, with restart_after_crash
-	// off, the whole instance goes down. Clients see only the downstream
-	// symptom (usually a generic Mongo InternalError). This is an
-	// extension-vs-PG-18.6 ABI incompatibility, reproduced on both CNPG and
-	// vanilla-Debian 18.6, so it is neither a CNPG image nor a gateway/SCRAM
-	// issue. Pinning by digest keeps CI reproducible and holds PostgreSQL at
-	// 18.4 until a DocumentDB release built ABI-clean for PG 18 ships; revert
-	// to the floating tag then.
+	// Pinned to an immutable digest instead of the floating
+	// "18-minimal-trixie" tag, which rolled 18.4 -> 18.6 on 2026-08-13 and
+	// crashed the DocumentDB 0.113.0 extension (segfault in
+	// documentdb_api.insert on PG 18.6 — an extension/PG-18.6 ABI
+	// mismatch, not a CNPG or gateway issue). Holds PG at 18.4 until a
+	// DocumentDB release built ABI-clean for PG 18 ships; revert then.
 	// +kubebuilder:default="ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-minimal-trixie@sha256:229ab83c0639d294042ca747745fb214db690ade64d5d59131a135825b994391"
 	// +optional
 	Postgres string `json:"postgres,omitempty"`

--- a/operator/src/api/preview/documentdb_types.go
+++ b/operator/src/api/preview/documentdb_types.go
@@ -167,7 +167,14 @@ type ImageSpec struct {
 	// adds the DocumentDB extension via an ImageVolume mount), and must
 	// use trixie (Debian 13) base to match the extension's GLIBC
 	// requirements.
-	// +kubebuilder:default="ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie"
+	//
+	// Pinned to an immutable, digest-addressed PostgreSQL 18.4 build rather
+	// than the floating "18-minimal-trixie" tag. On 2026-08-13 that floating
+	// tag rolled from 18.4 to 18.6, and the 18.6 build broke the gateway's
+	// SCRAM-SHA-256 handshake (surfaced to clients as a generic InternalError),
+	// turning the E2E suite deterministically red. Pinning by digest keeps CI
+	// reproducible; bump this deliberately once a newer build is validated.
+	// +kubebuilder:default="ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-minimal-trixie@sha256:229ab83c0639d294042ca747745fb214db690ade64d5d59131a135825b994391"
 	// +optional
 	Postgres string `json:"postgres,omitempty"`
 }

--- a/operator/src/api/preview/documentdb_types.go
+++ b/operator/src/api/preview/documentdb_types.go
@@ -168,11 +168,13 @@ type ImageSpec struct {
 	// use trixie (Debian 13) base to match the extension's GLIBC
 	// requirements.
 	//
-	// Pinned to an immutable digest instead of the floating
+	// Pinned to the 18.4 minor tag instead of the floating
 	// "18-minimal-trixie" tag, which rolled 18.4 -> 18.6 on 2026-08-13 and
-	// crashed the DocumentDB 0.113.0 extension on insert. Holds PG at 18.4
-	// until a DocumentDB release carrying the PG 18.6 fix ships; revert then.
-	// +kubebuilder:default="ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-minimal-trixie@sha256:229ab83c0639d294042ca747745fb214db690ade64d5d59131a135825b994391"
+	// crashed the DocumentDB 0.113.0 extension on insert. Staying on 18.4
+	// avoids that regression while still receiving CNPG's Debian/PGDG
+	// security rebuilds; revert to the floating "18-minimal-trixie" tag once
+	// a DocumentDB release carrying the PG 18.6 fix ships.
+	// +kubebuilder:default="ghcr.io/cloudnative-pg/postgresql:18.4-minimal-trixie"
 	// +optional
 	Postgres string `json:"postgres,omitempty"`
 }

--- a/operator/src/api/preview/documentdb_types.go
+++ b/operator/src/api/preview/documentdb_types.go
@@ -170,10 +170,16 @@ type ImageSpec struct {
 	//
 	// Pinned to an immutable, digest-addressed PostgreSQL 18.4 build rather
 	// than the floating "18-minimal-trixie" tag. On 2026-08-13 that floating
-	// tag rolled from 18.4 to 18.6, and the 18.6 build broke the gateway's
-	// SCRAM-SHA-256 handshake (surfaced to clients as a generic InternalError),
-	// turning the E2E suite deterministically red. Pinning by digest keeps CI
-	// reproducible; bump this deliberately once a newer build is validated.
+	// tag rolled from 18.4 to 18.6, and the shipped DocumentDB 0.113.0
+	// extension segfaults on 18.6: the PostgreSQL backend crashes with
+	// signal 11 inside documentdb_api.insert and, with restart_after_crash
+	// off, the whole instance goes down. Clients see only the downstream
+	// symptom (usually a generic Mongo InternalError). This is an
+	// extension-vs-PG-18.6 ABI incompatibility, reproduced on both CNPG and
+	// vanilla-Debian 18.6, so it is neither a CNPG image nor a gateway/SCRAM
+	// issue. Pinning by digest keeps CI reproducible and holds PostgreSQL at
+	// 18.4 until a DocumentDB release built ABI-clean for PG 18 ships; revert
+	// to the floating tag then.
 	// +kubebuilder:default="ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-minimal-trixie@sha256:229ab83c0639d294042ca747745fb214db690ade64d5d59131a135825b994391"
 	// +optional
 	Postgres string `json:"postgres,omitempty"`

--- a/operator/src/api/preview/documentdb_types.go
+++ b/operator/src/api/preview/documentdb_types.go
@@ -170,10 +170,8 @@ type ImageSpec struct {
 	//
 	// Pinned to an immutable digest instead of the floating
 	// "18-minimal-trixie" tag, which rolled 18.4 -> 18.6 on 2026-08-13 and
-	// crashed the DocumentDB 0.113.0 extension (segfault in
-	// documentdb_api.insert on PG 18.6 — an extension/PG-18.6 ABI
-	// mismatch, not a CNPG or gateway issue). Holds PG at 18.4 until a
-	// DocumentDB release built ABI-clean for PG 18 ships; revert then.
+	// crashed the DocumentDB 0.113.0 extension on insert. Holds PG at 18.4
+	// until a DocumentDB release carrying the PG 18.6 fix ships; revert then.
 	// +kubebuilder:default="ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-minimal-trixie@sha256:229ab83c0639d294042ca747745fb214db690ade64d5d59131a135825b994391"
 	// +optional
 	Postgres string `json:"postgres,omitempty"`

--- a/operator/src/config/crd/bases/documentdb.io_dbs.yaml
+++ b/operator/src/config/crd/bases/documentdb.io_dbs.yaml
@@ -1217,7 +1217,7 @@ spec:
                       Gateway sidecar.
                     type: string
                   postgres:
-                    default: ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-minimal-trixie@sha256:229ab83c0639d294042ca747745fb214db690ade64d5d59131a135825b994391
+                    default: ghcr.io/cloudnative-pg/postgresql:18.4-minimal-trixie
                     description: |-
                       Postgres is the container image for the PostgreSQL server.
                       Must be an upstream CNPG-compatible PostgreSQL image (the operator
@@ -1225,10 +1225,12 @@ spec:
                       use trixie (Debian 13) base to match the extension's GLIBC
                       requirements.
 
-                      Pinned to an immutable digest instead of the floating
+                      Pinned to the 18.4 minor tag instead of the floating
                       "18-minimal-trixie" tag, which rolled 18.4 -> 18.6 on 2026-08-13 and
-                      crashed the DocumentDB 0.113.0 extension on insert. Holds PG at 18.4
-                      until a DocumentDB release carrying the PG 18.6 fix ships; revert then.
+                      crashed the DocumentDB 0.113.0 extension on insert. Staying on 18.4
+                      avoids that regression while still receiving CNPG's Debian/PGDG
+                      security rebuilds; revert to the floating "18-minimal-trixie" tag once
+                      a DocumentDB release carrying the PG 18.6 fix ships.
                     type: string
                 type: object
               imagePullSecrets:

--- a/operator/src/config/crd/bases/documentdb.io_dbs.yaml
+++ b/operator/src/config/crd/bases/documentdb.io_dbs.yaml
@@ -1217,13 +1217,20 @@ spec:
                       Gateway sidecar.
                     type: string
                   postgres:
-                    default: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+                    default: ghcr.io/cloudnative-pg/postgresql:18.4-202608030910-minimal-trixie@sha256:229ab83c0639d294042ca747745fb214db690ade64d5d59131a135825b994391
                     description: |-
                       Postgres is the container image for the PostgreSQL server.
                       Must be an upstream CNPG-compatible PostgreSQL image (the operator
                       adds the DocumentDB extension via an ImageVolume mount), and must
                       use trixie (Debian 13) base to match the extension's GLIBC
                       requirements.
+
+                      Pinned to an immutable, digest-addressed PostgreSQL 18.4 build rather
+                      than the floating "18-minimal-trixie" tag. On 2026-08-13 that floating
+                      tag rolled from 18.4 to 18.6, and the 18.6 build broke the gateway's
+                      SCRAM-SHA-256 handshake (surfaced to clients as a generic InternalError),
+                      turning the E2E suite deterministically red. Pinning by digest keeps CI
+                      reproducible; bump this deliberately once a newer build is validated.
                     type: string
                 type: object
               imagePullSecrets:

--- a/operator/src/config/crd/bases/documentdb.io_dbs.yaml
+++ b/operator/src/config/crd/bases/documentdb.io_dbs.yaml
@@ -1225,18 +1225,12 @@ spec:
                       use trixie (Debian 13) base to match the extension's GLIBC
                       requirements.
 
-                      Pinned to an immutable, digest-addressed PostgreSQL 18.4 build rather
-                      than the floating "18-minimal-trixie" tag. On 2026-08-13 that floating
-                      tag rolled from 18.4 to 18.6, and the shipped DocumentDB 0.113.0
-                      extension segfaults on 18.6: the PostgreSQL backend crashes with
-                      signal 11 inside documentdb_api.insert and, with restart_after_crash
-                      off, the whole instance goes down. Clients see only the downstream
-                      symptom (usually a generic Mongo InternalError). This is an
-                      extension-vs-PG-18.6 ABI incompatibility, reproduced on both CNPG and
-                      vanilla-Debian 18.6, so it is neither a CNPG image nor a gateway/SCRAM
-                      issue. Pinning by digest keeps CI reproducible and holds PostgreSQL at
-                      18.4 until a DocumentDB release built ABI-clean for PG 18 ships; revert
-                      to the floating tag then.
+                      Pinned to an immutable digest instead of the floating
+                      "18-minimal-trixie" tag, which rolled 18.4 -> 18.6 on 2026-08-13 and
+                      crashed the DocumentDB 0.113.0 extension (segfault in
+                      documentdb_api.insert on PG 18.6 — an extension/PG-18.6 ABI
+                      mismatch, not a CNPG or gateway issue). Holds PG at 18.4 until a
+                      DocumentDB release built ABI-clean for PG 18 ships; revert then.
                     type: string
                 type: object
               imagePullSecrets:

--- a/operator/src/config/crd/bases/documentdb.io_dbs.yaml
+++ b/operator/src/config/crd/bases/documentdb.io_dbs.yaml
@@ -1227,10 +1227,8 @@ spec:
 
                       Pinned to an immutable digest instead of the floating
                       "18-minimal-trixie" tag, which rolled 18.4 -> 18.6 on 2026-08-13 and
-                      crashed the DocumentDB 0.113.0 extension (segfault in
-                      documentdb_api.insert on PG 18.6 — an extension/PG-18.6 ABI
-                      mismatch, not a CNPG or gateway issue). Holds PG at 18.4 until a
-                      DocumentDB release built ABI-clean for PG 18 ships; revert then.
+                      crashed the DocumentDB 0.113.0 extension on insert. Holds PG at 18.4
+                      until a DocumentDB release carrying the PG 18.6 fix ships; revert then.
                     type: string
                 type: object
               imagePullSecrets:

--- a/operator/src/config/crd/bases/documentdb.io_dbs.yaml
+++ b/operator/src/config/crd/bases/documentdb.io_dbs.yaml
@@ -1227,10 +1227,16 @@ spec:
 
                       Pinned to an immutable, digest-addressed PostgreSQL 18.4 build rather
                       than the floating "18-minimal-trixie" tag. On 2026-08-13 that floating
-                      tag rolled from 18.4 to 18.6, and the 18.6 build broke the gateway's
-                      SCRAM-SHA-256 handshake (surfaced to clients as a generic InternalError),
-                      turning the E2E suite deterministically red. Pinning by digest keeps CI
-                      reproducible; bump this deliberately once a newer build is validated.
+                      tag rolled from 18.4 to 18.6, and the shipped DocumentDB 0.113.0
+                      extension segfaults on 18.6: the PostgreSQL backend crashes with
+                      signal 11 inside documentdb_api.insert and, with restart_after_crash
+                      off, the whole instance goes down. Clients see only the downstream
+                      symptom (usually a generic Mongo InternalError). This is an
+                      extension-vs-PG-18.6 ABI incompatibility, reproduced on both CNPG and
+                      vanilla-Debian 18.6, so it is neither a CNPG image nor a gateway/SCRAM
+                      issue. Pinning by digest keeps CI reproducible and holds PostgreSQL at
+                      18.4 until a DocumentDB release built ABI-clean for PG 18 ships; revert
+                      to the floating tag then.
                     type: string
                 type: object
               imagePullSecrets:

--- a/operator/src/go.mod
+++ b/operator/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/documentdb/documentdb-operator
 
-go 1.26.5
+go 1.26.6
 
 godebug default=go1.23
 

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/documentdb/documentdb-operator/test/e2e
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cloudnative-pg/cloudnative-pg v1.29.2

--- a/test/longhaul/go.mod
+++ b/test/longhaul/go.mod
@@ -1,6 +1,6 @@
 module github.com/documentdb/documentdb-operator/test/longhaul
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/documentdb/documentdb-operator v0.0.0-00010101000000-000000000000

--- a/test/shared/go.mod
+++ b/test/shared/go.mod
@@ -1,6 +1,6 @@
 module github.com/documentdb/documentdb-operator/test/shared
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/cloudnative-pg/cloudnative-pg v1.29.2


### PR DESCRIPTION
## Problem

The **TEST - E2E** workflow started failing **deterministically on 2026-08-13** and stayed red on `main` afterwards. The `E2E data` job failed specs (`$inc`, `deleteMany`, `$or`) with a generic Mongo `(InternalError)`, while every baked DocumentDB / gateway / operator artifact was byte-identical across the last green (Aug 11) and first red (Aug 13) runs.

## Root cause

The DocumentDB CRD defaults `spec.image.postgres` to the **floating** tag `ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie`. Each E2E job spins up a fresh kind cluster and pulls whatever that tag currently points to. CloudNative-PG rolled the tag on 2026-08-13:

| Build (immutable dated tag) | PG version | Timestamp (UTC) | Note |
|---|---|---|---|
| `18.4-202608030910-minimal-trixie` | **18.4** | Aug 3 | what the last green run (Aug 11) used |
| `18.4-202608130737-minimal-trixie` | 18.4 | Aug 13 07:37 | last 18.4 |
| `18.6-202608131513-minimal-trixie` | **18.6** | Aug 13 15:13 | **first-known-bad** (first red run was Aug 13 16:20) |

**The 18.4 → 18.6 jump is the regression.** The **PostgreSQL backend segfaults inside the DocumentDB extension** on 18.6. The postgres logs show the crashing query is a DocumentDB `insert` and, because `restart_after_crash` is off, the crash takes the whole instance down:

```
client backend (PID 208) was terminated by signal 11: Segmentation fault
    detail: Failed process was running: SELECT * FROM documentdb_api.insert($1, $2, $3, NULL)
terminating any other active server processes
shutting down because "restart_after_crash" is off
```

That crash is the real, common failure across all red runs. Clients only see the downstream symptom — usually a generic Mongo `(InternalError)` when their backend dies mid-request, and in **one** run a `SCRAM-SHA-256` "sasl conversation error" from a connection whose backend was gone. The earlier SCRAM hypothesis was wrong: SCRAM was an occasional symptom, **not** the cause.

### Isolating the culprit (repro matrix)

The `0.113.0` extension `.deb` was held constant while the PostgreSQL image was swapped:

| Extension | PostgreSQL | Image / userland | Result |
|---|---|---|---|
| `0.113.0` deb | 18.4 | CNPG trixie | ✅ works |
| `0.113.0` deb | 18.6 | CNPG trixie | 💥 segfault |
| `0.113.0` deb | 18.6 | **non-CNPG Debian + PGDG** | 💥 segfault |

The **only** variable that flips pass → fail is the **PostgreSQL minor (18.4 → 18.6)**; image vendor and userland drop out. This **rules out** a bad CNPG image build and the operator's own extension-image packaging (`Dockerfile_extension` / ImageVolume lib-bundling) — the raw deb crashes on 18.6 regardless of vendor.

The fault is a **product bug in the extension** exposed by a PG 18.6 planner change (fixed upstream in [`3555c7d`](https://github.com/documentdb/documentdb/commit/3555c7d0d4997058b9d28609fd0296bda285846e)): PG 18.6's executor-pruning rework added an **unguarded `list_nth` on `fdwPrivLists`** in `ExecInitModifyTable` (18.4 only read it behind an `ri_FdwRoutine != NULL` guard). The extension's hand-built local-shard insert plan (`CreateLocalShardInsertPlan`) left that list `NIL`, so the **second** insert into a collection dereferences NULL and segfaults. It's a source logic bug — **not** an ABI/recompile issue.

> **Upstream status:** the fix has been **merged into `documentdb/documentdb` `main`**, but is **not yet in any released deb** (latest release is `v0.114-0`, which predates the fix). Until a release carrying the fix ships, PostgreSQL must stay pinned to 18.4 — see follow-ups.

## Fix

Pin the CRD default to the **version-constrained 18.4 tag**:

```
ghcr.io/cloudnative-pg/postgresql:18.4-minimal-trixie
```

Staying on the 18.4 minor avoids the 18.6 insert segfault, while the rolling tag still receives CNPG's Debian/PGDG security rebuilds — so the user-facing default isn't frozen on a single dated image (see [review discussion](https://github.com/documentdb/documentdb-kubernetes-operator/pull/445)). **This is a stopgap, not the destination** — it holds PostgreSQL at 18.4 until a DocumentDB release carrying the 18.6 fix ships, at which point the default reverts to the floating `18-minimal-trixie` tag.

### Changes
- `operator/src/api/preview/documentdb_types.go` — updated `+kubebuilder:default` marker (source of truth) + explanatory comment.
- Regenerated CRDs (`make manifests generate`): `operator/src/config/crd/bases/documentdb.io_dbs.yaml` and `operator/documentdb-helm-chart/crds/documentdb.io_dbs.yaml`.

### Validation
- Full E2E suite (data, upgrade, smoke, lifecycle, scale, tls, feature, backup, cluster-replication, ImageVolume) is green on this PR.
- `go test ./internal/cnpg/...` passes.

## Follow-ups (out of scope)
- **Un-pin, gated on an upstream release.** When `documentdb/documentdb` cuts a release (`v0.115-0`+) containing the fix now on `main`: bump `documentDbVersion`, verify the new deb on the latest PG 18.6 (canary/local repro across the 18.x range), then revert this pin back to floating `18-minimal-trixie`. Tracked separately so the bridge doesn't become permanent.
- **De-float the version pairing.** The operator floats three independent references to `18-minimal-trixie` (the postgres pod, the extension-image build base, and the deb's compile-time minor); they drifted apart, which is how this reached users. Long term, bump them as a matched set (or validate the postgres major at admission via the existing webhook).
- **Add a canary CI job** that runs the smoke suite against the *latest* `18-minimal-trixie` so the next upstream minor roll is caught before it reaches production, while the 18.4 tag protects the default path.
- Consider disabling `fail-fast` on the E2E matrix so one job failure doesn't cancel the whole workflow.

---

## Also in this PR: govulncheck fix

The `govulncheck` workflow was failing on 4 **called** standard-library vulnerabilities, all fixed in **go1.26.6**:

- `GO-2026-6218` — quadratic complexity in `net/url` `resolvePath`
- `GO-2026-6090` — unbounded post-handshake messages in `crypto/tls`
- `GO-2026-5972` — recursion depth in `encoding/asn1`
- `GO-2026-5026` — punycode label handling via `golang.org/x/net/idna`

Bumped the `go` directive from `1.26.5` → `1.26.6` in every scanned module (`operator/src`, `documentdb-kubectl-plugin`, `operator/cnpg-plugins/sidecar-injector`, `test/e2e`, `test/longhaul`, `test/shared`) and the pinned `GO_VERSION` in `test-unit.yml` / `test-unit-coverage.yml`. Also made those two workflows shellcheck-clean (SC2046/SC2086) since the actionlint gate lints any workflow a PR touches. Verified locally: `govulncheck` reports **No vulnerabilities found** for `documentdb-kubectl-plugin` and `operator/src` under go1.26.6.


