### PR TITLE
fix: use ubuntu24.04 extension .deb and make distro/PG configurable

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -301,6 +301,17 @@ runs:
         echo "Resolved DocumentDB image: $DOCDB_IMAGE"
         echo "Resolved Gateway image: $GW_IMAGE"
 
+    - name: Log in to GHCR for override image pulls (local build)
+      if: inputs.use-external-images == 'false' && (inputs.documentdb-image != '' || inputs.gateway-image != '')
+      shell: bash
+      env:
+        GHCR_TOKEN: ${{ inputs.github-token }}
+      run: |
+        # Override candidate images may be private packages on the same
+        # owner (e.g. a fork). Authenticate so the subsequent docker pull
+        # in the load step can access them; public images are unaffected.
+        echo "$GHCR_TOKEN" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
     - name: Load Docker images into kind cluster (local build)
       if: inputs.use-external-images == 'false'
       shell: bash

--- a/.github/workflows/build_documentdb_images.yml
+++ b/.github/workflows/build_documentdb_images.yml
@@ -1,7 +1,7 @@
 name: RELEASE - Build DocumentDB Candidate Images
 
 # Builds documentdb extension and gateway images from public DocumentDB release artifacts.
-# - documentdb image: public deb13 PostgreSQL 18 extension package
+# - documentdb image: public ubuntu24.04 PostgreSQL 18 extension package (distro/PG configurable)
 # - gateway image: public documentdb-local image payload
 # These images follow the DATABASE version track (documentDbVersion in values.yaml).
 # For operator/sidecar images, see build_operator_images.yml.
@@ -17,6 +17,14 @@ on:
         description: 'GitHub owner/repo for DocumentDB extension releases'
         required: false
         default: 'documentdb/documentdb'
+      documentdb_deb_distro:
+        description: 'Distro prefix of the published extension .deb (for example ubuntu24.04, deb13)'
+        required: false
+        default: 'ubuntu24.04'
+      pg_major:
+        description: 'PostgreSQL major version to package (for example 18)'
+        required: false
+        default: '18'
       documentdb_gateway_image_repo:
         description: 'Container image repo for gateway source (without tag)'
         required: false
@@ -34,6 +42,8 @@ env:
 
   DEFAULT_DOCUMENTDB_VERSION: '0.113.0'
   DOCUMENTDB_EXTENSION_GITHUB_REPO: ${{ github.event.inputs.documentdb_extension_github_repo || 'documentdb/documentdb' }}
+  DOCUMENTDB_DEB_DISTRO: ${{ github.event.inputs.documentdb_deb_distro || github.event.client_payload.deb_distro || 'ubuntu24.04' }}
+  DOCUMENTDB_PG_MAJOR: ${{ github.event.inputs.pg_major || github.event.client_payload.pg_major || '18' }}
   DOCUMENTDB_GATEWAY_IMAGE_REPO: ${{ github.event.inputs.documentdb_gateway_image_repo || 'ghcr.io/documentdb/documentdb/documentdb-local' }}
 
 
@@ -85,7 +95,7 @@ jobs:
       run: |
         set -euo pipefail
         for ARCH in amd64 arm64; do
-          ASSET_URL="https://github.com/${{ env.DOCUMENTDB_EXTENSION_GITHUB_REPO }}/releases/download/v${VERSION_DASH}/deb13-postgresql-18-documentdb_${VERSION_DASH}_${ARCH}.deb"
+          ASSET_URL="https://github.com/${{ env.DOCUMENTDB_EXTENSION_GITHUB_REPO }}/releases/download/v${VERSION_DASH}/${{ env.DOCUMENTDB_DEB_DISTRO }}-postgresql-${{ env.DOCUMENTDB_PG_MAJOR }}-documentdb_${VERSION_DASH}_${ARCH}.deb"
           echo "Checking $ASSET_URL"
           curl -fsI -L "$ASSET_URL" >/dev/null
         done
@@ -130,7 +140,7 @@ jobs:
       run: |
         set -euo pipefail
         mkdir -p packages
-        DEB_FILE="deb13-postgresql-18-documentdb_${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}_${{ matrix.arch }}.deb"
+        DEB_FILE="${{ env.DOCUMENTDB_DEB_DISTRO }}-postgresql-${{ env.DOCUMENTDB_PG_MAJOR }}-documentdb_${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}_${{ matrix.arch }}.deb"
         ASSET_URL="https://github.com/${{ env.DOCUMENTDB_EXTENSION_GITHUB_REPO }}/releases/download/v${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}/${DEB_FILE}"
         curl -fsSL -o "packages/${DEB_FILE}" -L "$ASSET_URL"
         ls -lh packages/
@@ -148,9 +158,9 @@ jobs:
 
         case "${{ matrix.image.name }}" in
           documentdb)
-            DEB_FILE="deb13-postgresql-18-documentdb_${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}_${{ matrix.arch }}.deb"
+            DEB_FILE="${{ env.DOCUMENTDB_DEB_DISTRO }}-postgresql-${{ env.DOCUMENTDB_PG_MAJOR }}-documentdb_${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}_${{ matrix.arch }}.deb"
             echo "Using deb: $DEB_FILE"
-            BUILD_ARGS="--build-arg PG_MAJOR=18 --build-arg DEB_PACKAGE_REL_PATH=packages/$DEB_FILE"
+            BUILD_ARGS="--build-arg PG_MAJOR=${{ env.DOCUMENTDB_PG_MAJOR }} --build-arg DEB_PACKAGE_REL_PATH=packages/$DEB_FILE"
             ;;
           gateway)
             echo "Using public gateway source image: ${{ needs.resolve-public-artifacts.outputs.gateway_source_image }}"
@@ -221,7 +231,7 @@ jobs:
           echo ""
           echo "- **DocumentDB Version**: \`${{ needs.resolve-public-artifacts.outputs.documentdb_version }}\`"
           echo "- **Candidate Image Tag**: \`${{ needs.resolve-public-artifacts.outputs.image_tag }}\`"
-          echo "- **Extension Package Source**: \`https://github.com/${{ env.DOCUMENTDB_EXTENSION_GITHUB_REPO }}/releases/download/v${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}/deb13-postgresql-18-documentdb_${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}_{amd64,arm64}.deb\`"
+          echo "- **Extension Package Source**: \`https://github.com/${{ env.DOCUMENTDB_EXTENSION_GITHUB_REPO }}/releases/download/v${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}/${{ env.DOCUMENTDB_DEB_DISTRO }}-postgresql-${{ env.DOCUMENTDB_PG_MAJOR }}-documentdb_${{ needs.resolve-public-artifacts.outputs.documentdb_version_dash }}_{amd64,arm64}.deb\`"
           echo "- **Gateway Source Image**: \`${{ needs.resolve-public-artifacts.outputs.gateway_source_image }}\`"
           echo "- **Images**: documentdb, gateway"
           echo ""

--- a/.github/workflows/build_documentdb_images.yml
+++ b/.github/workflows/build_documentdb_images.yml
@@ -152,7 +152,10 @@ jobs:
       run: |
         set -euo pipefail
         TAG=${{ env.IMAGE_TAG }}-${{ matrix.arch }}
-        IMAGE=ghcr.io/${{ github.repository }}/${{ matrix.image.name }}:$TAG
+        # GHCR requires the repository path to be lowercase; github.repository
+        # preserves the owner's case (e.g. on forks), so normalize it here.
+        IMAGE_BASE="ghcr.io/${GITHUB_REPOSITORY,,}"
+        IMAGE=$IMAGE_BASE/${{ matrix.image.name }}:$TAG
 
         BUILD_ARGS=""
 
@@ -191,29 +194,36 @@ jobs:
 
     - name: Create and Push Manifest
       run: |
-        docker manifest create ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
-          --amend ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}-amd64 \
-          --amend ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}-arm64
-        docker manifest push ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}
+        set -euo pipefail
+        # GHCR requires a lowercase repository path; normalize the owner case.
+        IMAGE_BASE="ghcr.io/${GITHUB_REPOSITORY,,}"
+        docker manifest create $IMAGE_BASE/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
+          --amend $IMAGE_BASE/${{ matrix.image }}:${{ env.IMAGE_TAG }}-amd64 \
+          --amend $IMAGE_BASE/${{ matrix.image }}:${{ env.IMAGE_TAG }}-arm64
+        docker manifest push $IMAGE_BASE/${{ matrix.image }}:${{ env.IMAGE_TAG }}
 
     - name: Install cosign
       uses: sigstore/cosign-installer@v3.8.2
 
     - name: Sign manifest (keyless)
       run: |
-        DIGEST=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
+        set -euo pipefail
+        IMAGE_BASE="ghcr.io/${GITHUB_REPOSITORY,,}"
+        DIGEST=$(docker buildx imagetools inspect $IMAGE_BASE/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
           | awk '/^Digest:/ { print $2 }')
         echo "Signing manifest-list@${DIGEST}"
-        cosign sign ghcr.io/${{ github.repository }}/${{ matrix.image }}@${DIGEST} -y
+        cosign sign $IMAGE_BASE/${{ matrix.image }}@${DIGEST} -y
 
     - name: Verify manifest signature (keyless)
       run: |
-        DIGEST=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
+        set -euo pipefail
+        IMAGE_BASE="ghcr.io/${GITHUB_REPOSITORY,,}"
+        DIGEST=$(docker buildx imagetools inspect $IMAGE_BASE/${{ matrix.image }}:${{ env.IMAGE_TAG }} \
           | awk '/^Digest:/ { print $2 }')
         cosign verify \
           --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/build_documentdb_images.yml@${{ github.ref }}" \
           --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-          ghcr.io/${{ github.repository }}/${{ matrix.image }}@${DIGEST}
+          $IMAGE_BASE/${{ matrix.image }}@${DIGEST}
 
   # ---------------------------------------------------------------------------
   # Summary

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -56,6 +56,16 @@ on:
         required: false
         type: string
         default: ''
+      documentdb_image:
+        description: 'Full ref of a candidate documentdb (extension) image to test instead of the source-built one'
+        required: false
+        type: string
+        default: ''
+      gateway_image:
+        description: 'Full ref of a candidate gateway image to test instead of the source-built one'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -272,6 +282,8 @@ jobs:
           db-port: ${{ env.DB_PORT }}
           image-tag: ${{ env.IMAGE_TAG }}
           documentdb-image-tag: ${{ env.EXT_IMAGE_TAG }}
+          documentdb-image: ${{ inputs.documentdb_image || '' }}
+          gateway-image: ${{ inputs.gateway_image || '' }}
           chart-version: ${{ env.CHART_VERSION }}
           use-external-images: 'false'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -429,6 +441,8 @@ jobs:
           db-port: ${{ env.DB_PORT }}
           image-tag: ${{ env.IMAGE_TAG }}
           documentdb-image-tag: ${{ env.EXT_IMAGE_TAG }}
+          documentdb-image: ${{ inputs.documentdb_image || '' }}
+          gateway-image: ${{ inputs.gateway_image || '' }}
           chart-version: ${{ env.CHART_VERSION }}
           use-external-images: 'false'
           kubernetes-version: ${{ matrix.kubernetes_version }}
@@ -514,6 +528,8 @@ jobs:
           db-port: ${{ env.DB_PORT }}
           image-tag: ${{ env.IMAGE_TAG }}
           documentdb-image-tag: ${{ env.EXT_IMAGE_TAG }}
+          documentdb-image: ${{ inputs.documentdb_image || '' }}
+          gateway-image: ${{ inputs.gateway_image || '' }}
           chart-version: ${{ env.CHART_VERSION }}
           use-external-images: 'false'
           kubernetes-version: v1.33.7


### PR DESCRIPTION
## Problem

The \`build_documentdb_images.yml\` workflow (RELEASE - Build DocumentDB Candidate Images) hardcoded the public extension asset name as:

\`\`\`
deb13-postgresql-18-documentdb_<ver>_<arch>.deb
\`\`\`

Starting with DocumentDB **0.116.0**, the upstream \`documentdb/documentdb\` release **dropped the \`debNN-*\` asset naming** and now publishes:

\`\`\`
ubuntu24.04-postgresql-<pg>-documentdb_<ver>_<arch>.deb
\`\`\`

As a result the *Verify public extension release assets* step 404s (curl exit 22) and the release build fails — see [run 33116789062](https://github.com/documentdb/documentdb-kubernetes-operator/actions/runs/33116789062/job/98673364161).

## Fix

- Update the default extension asset path to **ubuntu24.04 + PostgreSQL 18**.
- Expose the distro prefix and PostgreSQL major as optional inputs so future upstream naming changes can be handled without editing the workflow:
  - \`documentdb_deb_distro\` (default \`ubuntu24.04\`)
  - \`pg_major\` (default \`18\`)
- Thread \`pg_major\` into the docker \`--build-arg PG_MAJOR\` (previously hardcoded to 18).
- Both inputs support \`workflow_dispatch\` and \`repository_dispatch\` (\`client_payload\`) with sane fallbacks.

## Verification

- YAML parses cleanly.
- Both \`ubuntu24.04-postgresql-18-documentdb_0.116-0_{amd64,arm64}.deb\` URLs return HTTP 200.